### PR TITLE
Issue #3 - Création des entités JPA principales

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Joueur.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Joueur.java
@@ -1,0 +1,49 @@
+package be.ephec.padel.backend.model.entities;
+
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "joueur")
+public class Joueur {
+
+    @Id
+    @Column(length = 10)
+    private String matricule;
+
+    @Column(nullable = false)
+    private String nom;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TypeJoueur type;
+
+    public Joueur() {
+    }
+
+    public Joueur(String matricule, String nom, TypeJoueur type) {
+        this.matricule = matricule;
+        this.nom = nom;
+        this.type = type;
+    }
+
+    public String getMatricule() {
+        return matricule;
+    }
+
+    public String getNom() {
+        return nom;
+    }
+
+    public TypeJoueur getType() {
+        return type;
+    }
+
+    public void setNom(String nom) {
+        this.nom = nom;
+    }
+
+    public void setType(TypeJoueur type) {
+        this.type = type;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/MatchPadel.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/MatchPadel.java
@@ -1,0 +1,76 @@
+package be.ephec.padel.backend.model.entities;
+
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "match_padel")
+public class MatchPadel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "terrain_id", nullable = false)
+    private Terrain terrain;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "organisateur_matricule", nullable = false)
+    private Joueur organisateur;
+
+    @Column(name = "date_debut", nullable = false)
+    private LocalDateTime dateDebut;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MatchVisibilite visibilite;
+
+    public MatchPadel() {
+    }
+
+    public MatchPadel(Terrain terrain, Joueur organisateur, LocalDateTime dateDebut, MatchVisibilite visibilite) {
+        this.terrain = terrain;
+        this.organisateur = organisateur;
+        this.dateDebut = dateDebut;
+        this.visibilite = visibilite;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Terrain getTerrain() {
+        return terrain;
+    }
+
+    public Joueur getOrganisateur() {
+        return organisateur;
+    }
+
+    public LocalDateTime getDateDebut() {
+        return dateDebut;
+    }
+
+    public MatchVisibilite getVisibilite() {
+        return visibilite;
+    }
+
+    public void setTerrain(Terrain terrain) {
+        this.terrain = terrain;
+    }
+
+    public void setOrganisateur(Joueur organisateur) {
+        this.organisateur = organisateur;
+    }
+
+    public void setDateDebut(LocalDateTime dateDebut) {
+        this.dateDebut = dateDebut;
+    }
+
+    public void setVisibilite(MatchVisibilite visibilite) {
+        this.visibilite = visibilite;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/MouvementSolde.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/MouvementSolde.java
@@ -1,0 +1,50 @@
+package be.ephec.padel.backend.model.entities;
+
+import be.ephec.padel.backend.model.enums.TypeMouvement;
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mouvement_solde")
+public class MouvementSolde {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "joueur_matricule", nullable = false)
+    private Joueur joueur;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TypeMouvement type;
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal montant;
+
+    @Column(name = "date_mouvement", nullable = false)
+    private LocalDateTime dateMouvement;
+
+    public MouvementSolde() {}
+
+    public MouvementSolde(Joueur joueur, TypeMouvement type, BigDecimal montant, LocalDateTime dateMouvement) {
+        this.joueur = joueur;
+        this.type = type;
+        this.montant = montant;
+        this.dateMouvement = dateMouvement;
+    }
+
+    public Long getId() { return id; }
+    public Joueur getJoueur() { return joueur; }
+    public TypeMouvement getType() { return type; }
+    public BigDecimal getMontant() { return montant; }
+    public LocalDateTime getDateMouvement() { return dateMouvement; }
+
+    public void setJoueur(Joueur joueur) { this.joueur = joueur; }
+    public void setType(TypeMouvement type) { this.type = type; }
+    public void setMontant(BigDecimal montant) { this.montant = montant; }
+    public void setDateMouvement(LocalDateTime dateMouvement) { this.dateMouvement = dateMouvement; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Paiement.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Paiement.java
@@ -1,0 +1,63 @@
+package be.ephec.padel.backend.model.entities;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "paiement")
+public class Paiement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "participation_id", nullable = false)
+    private Participation participation;
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal montant;
+
+    @Column(name = "date_paiement", nullable = false)
+    private LocalDateTime datePaiement;
+
+    public Paiement() {
+    }
+
+    public Paiement(Participation participation, BigDecimal montant, LocalDateTime datePaiement) {
+        this.participation = participation;
+        this.montant = montant;
+        this.datePaiement = datePaiement;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Participation getParticipation() {
+        return participation;
+    }
+
+    public BigDecimal getMontant() {
+        return montant;
+    }
+
+    public LocalDateTime getDatePaiement() {
+        return datePaiement;
+    }
+
+    public void setParticipation(Participation participation) {
+        this.participation = participation;
+    }
+
+    public void setMontant(BigDecimal montant) {
+        this.montant = montant;
+    }
+
+    public void setDatePaiement(LocalDateTime datePaiement) {
+        this.datePaiement = datePaiement;
+    }
+}
+

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Participation.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Participation.java
@@ -1,0 +1,51 @@
+package be.ephec.padel.backend.model.entities;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+        name = "participation",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"match_id", "joueur_matricule"})
+)
+public class Participation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "match_id", nullable = false)
+    private MatchPadel match;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "joueur_matricule", nullable = false)
+    private Joueur joueur;
+
+    public Participation() {
+    }
+
+    public Participation(MatchPadel match, Joueur joueur) {
+        this.match = match;
+        this.joueur = joueur;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public MatchPadel getMatch() {
+        return match;
+    }
+
+    public Joueur getJoueur() {
+        return joueur;
+    }
+
+    public void setMatch(MatchPadel match) {
+        this.match = match;
+    }
+
+    public void setJoueur(Joueur joueur) {
+        this.joueur = joueur;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Site.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Site.java
@@ -1,0 +1,47 @@
+package be.ephec.padel.backend.model.entities;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "site")
+public class Site {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String nom;
+
+    @Column(nullable = false)
+    private String ville;
+
+
+    public Site() {
+    }
+
+    public Site(String nom, String ville) {
+        this.nom = nom;
+        this.ville = ville;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNom() {
+        return nom;
+    }
+
+    public String getVille() {
+        return ville;
+    }
+
+    public void setNom(String nom) {
+        this.nom = nom;
+    }
+
+    public void setVille(String ville) {
+        this.ville = ville;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Terrain.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Terrain.java
@@ -1,0 +1,48 @@
+package be.ephec.padel.backend.model.entities;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "terrain")
+public class Terrain {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nom;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "site_id", nullable = false)
+    private Site site;
+
+    public Terrain() {
+    }
+
+    public Terrain(String nom, Site site) {
+        this.nom = nom;
+        this.site = site;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNom() {
+        return nom;
+    }
+
+    public Site getSite() {
+        return site;
+    }
+
+    public void setNom(String nom) {
+        this.nom = nom;
+    }
+
+    public void setSite(Site site) {
+        this.site = site;
+    }
+}
+

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/MatchVisibilite.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/MatchVisibilite.java
@@ -1,0 +1,6 @@
+package be.ephec.padel.backend.model.enums;
+
+public enum MatchVisibilite {
+    PRIVE,
+    PUBLIC
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/TypeJoueur.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/TypeJoueur.java
@@ -1,0 +1,7 @@
+package be.ephec.padel.backend.model.enums;
+
+public enum TypeJoueur {
+    GLOBAL,
+    SITE,
+    LIBRE
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/TypeMouvement.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/TypeMouvement.java
@@ -1,0 +1,6 @@
+package be.ephec.padel.backend.model.enums;
+
+public enum TypeMouvement {
+    CREDIT,
+    DEBIT
+}

--- a/backend/backend/src/main/resources/application.properties
+++ b/backend/backend/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.datasource.url=jdbc:sqlserver://localhost:1433;databaseName=padel;encrypt
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.datasource.driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver
 spring.jpa.open-in-view=false


### PR DESCRIPTION
Création des entités JPA principales :

- Site
- Terrain
- Joueur
- MatchPadel
- Participation
- Paiement
- MouvementSolde

Ajout des enums :
- TypeJoueur
- TypeMouvement
- MatchVisibilite
