### PR TITLE
Issue #12 - Repositories Spring Data JPA

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/JoueurRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/JoueurRepository.java
@@ -1,0 +1,11 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.Joueur;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JoueurRepository extends JpaRepository<Joueur, String> {
+    Optional<Joueur> findByMatricule(String matricule);
+    boolean existsByMatricule(String matricule);
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -1,0 +1,12 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
+    List<MatchPadel> findByTerrainId(Long terrainId);
+    List<MatchPadel> findByDateDebutBetween(LocalDateTime start, LocalDateTime end);
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MouvementSoldeRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MouvementSoldeRepository.java
@@ -1,0 +1,10 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.MouvementSolde;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MouvementSoldeRepository extends JpaRepository<MouvementSolde, Long> {
+    List<MouvementSolde> findByJoueurMatriculeOrderByDateMouvementDesc(String matricule);
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
@@ -1,0 +1,15 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.Paiement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PaiementRepository extends JpaRepository<Paiement, Long> {
+
+    List<Paiement> findByParticipation_Id(Long participationId);
+
+    List<Paiement> findByParticipation_Joueur_Matricule(String matricule);
+
+    List<Paiement> findByParticipation_Match_Id(Long matchId);
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
@@ -1,0 +1,12 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.Participation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ParticipationRepository extends JpaRepository<Participation, Long> {
+    List<Participation> findByMatchId(Long matchId);
+    List<Participation> findByJoueurMatricule(String matricule);
+    boolean existsByMatchIdAndJoueurMatricule(Long matchId, String matricule);
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/SiteRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/SiteRepository.java
@@ -1,0 +1,8 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.Site;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SiteRepository extends JpaRepository<Site, Long> {
+    boolean existsByNom(String nom);
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/TerrainRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/TerrainRepository.java
@@ -1,0 +1,11 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.Terrain;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TerrainRepository extends JpaRepository<Terrain, Long> {
+    List<Terrain> findBySiteId(Long siteId);
+    boolean existsByNomAndSiteId(String nom, Long siteId);
+}


### PR DESCRIPTION
Implémentation des repositories Spring Data JPA pour toutes les entités principales :

- JoueurRepository
- MatchPadelRepository
- ParticipationRepository
- PaiementRepository
- MouvementSoldeRepository
- SiteRepository
- TerrainRepository

Utilisation de JpaRepository pour générer automatiquement :
- CRUD
- Méthodes dérivées (findBy, existsBy, etc.)

Closes #12
