### PR TITLE
Feature/21 services métier gestion transactions

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/exception/BusinessException.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/exception/BusinessException.java
@@ -1,0 +1,7 @@
+package be.ephec.padel.backend.exception;
+
+public class BusinessException extends RuntimeException {
+    public BusinessException(String message) {
+        super(message);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/exception/NotFoundException.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package be.ephec.padel.backend.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Joueur.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Joueur.java
@@ -3,6 +3,7 @@ package be.ephec.padel.backend.model.entities;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import jakarta.persistence.*;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,10 +22,12 @@ public class Joueur {
     @Column(nullable = false)
     private TypeJoueur type;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "joueur_matricule", nullable = false)
-    private Joueur joueur;
+    @Column(nullable = false, precision = 12, scale = 2)
+    private BigDecimal solde = BigDecimal.ZERO;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "site_id")
+    private Site site;
 
     @OneToMany(mappedBy = "joueur")
     private List<Participation> participations = new ArrayList<>();
@@ -39,6 +42,15 @@ public class Joueur {
         this.matricule = matricule;
         this.nom = nom;
         this.type = type;
+        this.solde = BigDecimal.ZERO;
+    }
+
+    public Joueur(String matricule, String nom, TypeJoueur type, Site site) {
+        this.matricule = matricule;
+        this.nom = nom;
+        this.type = type;
+        this.site = site;
+        this.solde = BigDecimal.ZERO;
     }
 
     public String getMatricule() {
@@ -51,6 +63,14 @@ public class Joueur {
 
     public TypeJoueur getType() {
         return type;
+    }
+
+    public BigDecimal getSolde() {
+        return solde;
+    }
+
+    public Site getSite() {
+        return site;
     }
 
     public List<Participation> getParticipations() {
@@ -67,5 +87,13 @@ public class Joueur {
 
     public void setType(TypeJoueur type) {
         this.type = type;
+    }
+
+    public void setSolde(BigDecimal solde) {
+        this.solde = (solde == null) ? BigDecimal.ZERO : solde;
+    }
+
+    public void setSite(Site site) {
+        this.site = site;
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/JoueurRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/JoueurRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface JoueurRepository extends JpaRepository<Joueur, String> {
-    Optional<Joueur> findByMatricule(String matricule);
-    boolean existsByMatricule(String matricule);
+    Optional<Joueur> findById(String matricule); // déjà fourni par JpaRepository
+    boolean existsById(String matricule);
 }
+

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MouvementSoldeRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MouvementSoldeRepository.java
@@ -1,10 +1,12 @@
 package be.ephec.padel.backend.repository;
 
+
 import be.ephec.padel.backend.model.entities.MouvementSolde;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
+
 public interface MouvementSoldeRepository extends JpaRepository<MouvementSolde, Long> {
-    List<MouvementSolde> findByJoueurMatriculeOrderByDateMouvementDesc(String matricule);
+    List<MouvementSolde> findByJoueur_MatriculeOrderByDateMouvementDesc(String matricule);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
@@ -2,7 +2,10 @@ package be.ephec.padel.backend.repository;
 
 import be.ephec.padel.backend.model.entities.Paiement;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public interface PaiementRepository extends JpaRepository<Paiement, Long> {
@@ -12,4 +15,8 @@ public interface PaiementRepository extends JpaRepository<Paiement, Long> {
     List<Paiement> findByParticipation_Joueur_Matricule(String matricule);
 
     List<Paiement> findByParticipation_Match_Id(Long matchId);
+
+    @Query("select coalesce(sum(p.montant), 0) from Paiement p where p.participation.id = :participationId")
+    BigDecimal sumMontantByParticipationId(@Param("participationId") Long participationId);
+
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
@@ -1,4 +1,5 @@
 package be.ephec.padel.backend.repository;
+import java.util.Optional;
 
 import be.ephec.padel.backend.model.entities.Participation;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -6,7 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
-    List<Participation> findByMatchId(Long matchId);
+    List<Participation> findByMatch_Id(Long matchId);
     List<Participation> findByJoueurMatricule(String matricule);
-    boolean existsByMatchIdAndJoueurMatricule(Long matchId, String matricule);
+
+    boolean existsByMatch_IdAndJoueur_Matricule(Long matchId, String joueurMatricule);
+
+    Optional<Participation> findByMatch_IdAndJoueur_Matricule(Long matchId, String matricule);
+
+    int countByMatch_Id(Long matchId);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
@@ -1,0 +1,90 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+@Transactional
+public class JoueurService {
+
+    private final JoueurRepository joueurRepository;
+    private final SiteRepository siteRepository;
+
+    public JoueurService(JoueurRepository joueurRepository, SiteRepository siteRepository) {
+        this.joueurRepository = joueurRepository;
+        this.siteRepository = siteRepository;
+    }
+
+    public Joueur creerJoueur(String matricule, String nom, TypeJoueur type, Long siteId) {
+        if (matricule == null || matricule.isBlank()) throw new BusinessException("Matricule obligatoire");
+        if (nom == null || nom.isBlank()) throw new BusinessException("Nom obligatoire");
+        if (type == null) throw new BusinessException("Type joueur obligatoire");
+
+        verifierMatricule(type, matricule);
+
+        if (joueurRepository.existsById(matricule)) {
+            throw new BusinessException("Matricule déjà utilisé");
+        }
+
+        Site site = null;
+
+        if (type == TypeJoueur.SITE) {
+            if (siteId == null) throw new BusinessException("Un joueur SITE doit être lié à un site");
+            site = siteRepository.findById(siteId)
+                    .orElseThrow(() -> new NotFoundException("Site introuvable"));
+        } else {
+            // Correction : éviter GLOBAL/LIBRE rattachés par erreur à un site
+            if (siteId != null) {
+                throw new BusinessException("Seul un joueur SITE peut avoir un site.");
+            }
+        }
+
+        Joueur joueur = new Joueur(matricule, nom, type, site);
+        joueur.setSolde(BigDecimal.ZERO);
+        return joueurRepository.save(joueur);
+    }
+
+    public Joueur getJoueur(String matricule) {
+        return joueurRepository.findById(matricule)
+                .orElseThrow(() -> new NotFoundException("Joueur introuvable"));
+    }
+
+    public List<Joueur> lister() {
+        return joueurRepository.findAll();
+    }
+
+    public boolean aDette(String matricule) {
+        Joueur joueur = getJoueur(matricule);
+        return joueur.getSolde() != null && joueur.getSolde().compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    public void verifierPasDeDette(String matricule) {
+        if (aDette(matricule)) {
+            throw new BusinessException("Action impossible : solde dû (dette) non réglé.");
+        }
+    }
+
+    private void verifierMatricule(TypeJoueur type, String matricule) {
+        String pattern;
+        switch (type) {
+            case GLOBAL -> pattern = "^G\\d{4}$";
+            case SITE -> pattern = "^S\\d{4}$";
+            case LIBRE -> pattern = "^L\\d{4}$";
+            default -> throw new BusinessException("Type joueur inconnu");
+        }
+
+        if (!matricule.matches(pattern)) {
+            throw new BusinessException("Matricule invalide pour le type " + type + " : " + matricule);
+        }
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -1,0 +1,107 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+public class MatchPadelService {
+
+    private final MatchPadelRepository matchPadelRepository;
+    private final TerrainRepository terrainRepository;
+    private final JoueurRepository joueurRepository;
+
+    public MatchPadelService(MatchPadelRepository matchPadelRepository,
+                             TerrainRepository terrainRepository,
+                             JoueurRepository joueurRepository) {
+        this.matchPadelRepository = matchPadelRepository;
+        this.terrainRepository = terrainRepository;
+        this.joueurRepository = joueurRepository;
+    }
+
+    public MatchPadel creerMatch(Long terrainId,
+                                 String organisateurMatricule,
+                                 LocalDateTime dateDebut,
+                                 MatchVisibilite visibilite) {
+
+        if (terrainId == null) throw new BusinessException("Terrain obligatoire");
+        if (organisateurMatricule == null || organisateurMatricule.isBlank()) {
+            throw new BusinessException("Organisateur obligatoire");
+        }
+        if (dateDebut == null) throw new BusinessException("Date début obligatoire");
+        if (visibilite == null) throw new BusinessException("Visibilité obligatoire");
+
+        // ✅ un seul "now" pour toute la méthode
+        LocalDateTime now = LocalDateTime.now();
+
+        if (!dateDebut.isAfter(now)) {
+            throw new BusinessException("La date du match doit être dans le futur.");
+        }
+
+        Terrain terrain = terrainRepository.findById(terrainId)
+                .orElseThrow(() -> new NotFoundException("Terrain introuvable"));
+
+        Joueur organisateur = joueurRepository.findById(organisateurMatricule)
+                .orElseThrow(() -> new NotFoundException("Joueur introuvable"));
+
+        // Règle: pas de réservation si dette > 0
+        if (organisateur.getSolde() != null && organisateur.getSolde().signum() > 0) {
+            throw new BusinessException("Réservation impossible : dette en cours (" + organisateur.getSolde() + ").");
+        }
+
+        verifierDroitReservation(organisateur, terrain, dateDebut, now);
+
+        MatchPadel match = new MatchPadel(terrain, organisateur, dateDebut, visibilite);
+        return matchPadelRepository.save(match);
+    }
+
+    private void verifierDroitReservation(Joueur orga,
+                                          Terrain terrain,
+                                          LocalDateTime dateDebut,
+                                          LocalDateTime now) {
+        TypeJoueur type = orga.getType();
+        if (type == null) throw new BusinessException("Type joueur manquant.");
+
+        switch (type) {
+            case GLOBAL -> {
+                if (dateDebut.isAfter(now.plusWeeks(3))) {
+                    throw new BusinessException("Un membre GLOBAL peut réserver au maximum 3 semaines à l'avance.");
+                }
+            }
+            case SITE -> {
+                if (dateDebut.isAfter(now.plusWeeks(2))) {
+                    throw new BusinessException("Un membre SITE peut réserver au maximum 2 semaines à l'avance.");
+                }
+                if (orga.getSite() == null) {
+                    throw new BusinessException("Joueur SITE sans site associé.");
+                }
+                Long siteJoueur = orga.getSite().getId();
+                Long siteTerrain = terrain.getSite().getId();
+
+                if (!siteJoueur.equals(siteTerrain)) {
+                    throw new BusinessException("Un membre SITE ne peut réserver que sur son site.");
+                }
+            }
+            case LIBRE -> {
+                if (dateDebut.isAfter(now.plusDays(5))) {
+                    throw new BusinessException("Un membre LIBRE peut réserver au maximum 5 jours à l'avance.");
+                }
+            }
+            default -> throw new BusinessException("Type joueur inconnu.");
+        }
+    }
+
+}
+

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/PaiementService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/PaiementService.java
@@ -1,0 +1,85 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Paiement;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+public class PaiementService {
+
+    private static final BigDecimal PRIX_MATCH = new BigDecimal("60.00");
+    private static final BigDecimal PART_JOUEUR = PRIX_MATCH.divide(new BigDecimal("4"), 2, RoundingMode.HALF_UP); // 15.00
+
+    private final PaiementRepository paiementRepository;
+    private final ParticipationRepository participationRepository;
+    private final SoldeService soldeService;
+
+    public PaiementService(PaiementRepository paiementRepository,
+                           ParticipationRepository participationRepository,
+                           SoldeService soldeService) {
+        this.paiementRepository = paiementRepository;
+        this.participationRepository = participationRepository;
+        this.soldeService = soldeService;
+    }
+
+    public Paiement payerParticipation(Long participationId, BigDecimal montant) {
+        Participation participation = participationRepository.findById(participationId)
+                .orElseThrow(() -> new NotFoundException("Participation introuvable"));
+
+        BigDecimal m = validerMontant(montant);
+
+        // Total déjà payé pour cette participation (0 si aucun paiement)
+        BigDecimal dejaPaye = paiementRepository.sumMontantByParticipationId(participationId);
+        if (dejaPaye == null) dejaPaye = BigDecimal.ZERO;
+        dejaPaye = dejaPaye.setScale(2, RoundingMode.HALF_UP);
+
+        BigDecimal reste = PART_JOUEUR.subtract(dejaPaye).setScale(2, RoundingMode.HALF_UP);
+
+        if (reste.signum() <= 0) {
+            throw new BusinessException("Participation déjà payée en totalité.");
+        }
+        if (m.compareTo(reste) > 0) {
+            throw new BusinessException("Paiement trop élevé. Reste à payer = " + reste);
+        }
+
+        // 1) Enregistrer le paiement (trace)
+        Paiement saved = paiementRepository.save(new Paiement(participation, m, LocalDateTime.now()));
+
+        // 2) Réduire la dette du joueur
+        String matricule = participation.getJoueur().getMatricule();
+        soldeService.crediter(matricule, m);
+
+        return saved;
+    }
+
+    /**
+     * Paiement en donnant matchId + matricule.
+     */
+    public Paiement payerPourMatch(Long matchId, String joueurMatricule, BigDecimal montant) {
+        Participation participation = participationRepository
+                .findByMatch_IdAndJoueur_Matricule(matchId, joueurMatricule)
+                .orElseThrow(() -> new NotFoundException("Participation introuvable pour ce match/joueur"));
+
+        return payerParticipation(participation.getId(), montant);
+    }
+
+    private BigDecimal validerMontant(BigDecimal montant) {
+        if (montant == null) {
+            throw new BusinessException("Montant obligatoire");
+        }
+        if (montant.signum() <= 0) {
+            throw new BusinessException("Montant invalide");
+        }
+        return montant.setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java
@@ -1,0 +1,111 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@Transactional
+public class ParticipationService {
+
+    private static final BigDecimal PART_JOUEUR = new BigDecimal("15.00");
+
+    private final ParticipationRepository participationRepository;
+    private final MatchPadelRepository matchPadelRepository;
+    private final JoueurRepository joueurRepository;
+    private final SoldeService soldeService;
+    private final PaiementService paiementService;
+
+    public ParticipationService(ParticipationRepository participationRepository,
+                                MatchPadelRepository matchPadelRepository,
+                                JoueurRepository joueurRepository,
+                                SoldeService soldeService,
+                                PaiementService paiementService) {
+        this.participationRepository = participationRepository;
+        this.matchPadelRepository = matchPadelRepository;
+        this.joueurRepository = joueurRepository;
+        this.soldeService = soldeService;
+        this.paiementService = paiementService;
+    }
+
+
+
+    public Participation rejoindreEtPayerMatchPublic(Long matchId, String joueurMatricule, BigDecimal montant) {
+        MatchPadel match = getMatchOrThrow(matchId);
+
+        if (match.getVisibilite() != MatchVisibilite.PUBLIC) {
+            throw new BusinessException("Match privé : seule l'organisation peut ajouter des joueurs.");
+        }
+
+        Joueur joueur = getJoueurOrThrow(joueurMatricule);
+
+        verifierNonDejaInscrit(matchId, joueurMatricule);
+        verifierPlaceDisponible(matchId);
+
+        Participation saved = participationRepository.save(new Participation(match, joueur));
+
+        soldeService.debiter(joueurMatricule, PART_JOUEUR);
+        paiementService.payerParticipation(saved.getId(), montant);
+
+        return saved;
+    }
+
+    public Participation ajouterJoueurParOrganisateur(Long matchId,
+                                                      String organisateurMatricule,
+                                                      String joueurMatriculeAAjouter) {
+        MatchPadel match = getMatchOrThrow(matchId);
+
+        if (match.getVisibilite() == MatchVisibilite.PUBLIC) {
+            throw new BusinessException("Match public : l'organisateur ne peut pas ajouter des joueurs.");
+        }
+
+        String orga = match.getOrganisateur().getMatricule();
+        if (!orga.equals(organisateurMatricule)) {
+            throw new BusinessException("Seul l'organisateur peut ajouter des joueurs à ce match.");
+        }
+
+        Joueur joueurAAjouter = getJoueurOrThrow(joueurMatriculeAAjouter);
+
+        verifierNonDejaInscrit(matchId, joueurMatriculeAAjouter);
+        verifierPlaceDisponible(matchId);
+
+        Participation saved = participationRepository.save(new Participation(match, joueurAAjouter));
+
+        soldeService.debiter(joueurMatriculeAAjouter, PART_JOUEUR);
+
+        return saved;
+    }
+
+    private MatchPadel getMatchOrThrow(Long matchId) {
+        return matchPadelRepository.findById(matchId)
+                .orElseThrow(() -> new NotFoundException("Match introuvable"));
+    }
+
+    private Joueur getJoueurOrThrow(String matricule) {
+        return joueurRepository.findById(matricule)
+                .orElseThrow(() -> new NotFoundException("Joueur introuvable"));
+    }
+
+    private void verifierNonDejaInscrit(Long matchId, String joueurMatricule) {
+        if (participationRepository.existsByMatch_IdAndJoueur_Matricule(matchId, joueurMatricule)) {
+            throw new BusinessException("Joueur déjà inscrit à ce match");
+        }
+    }
+
+    private void verifierPlaceDisponible(Long matchId) {
+        int nb = participationRepository.countByMatch_Id(matchId);
+        if (nb >= 4) {
+            throw new BusinessException("Match déjà complet");
+        }
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/SoldeService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/SoldeService.java
@@ -1,0 +1,83 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MouvementSolde;
+import be.ephec.padel.backend.model.enums.TypeMouvement;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MouvementSoldeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+public class SoldeService {
+
+    private final JoueurRepository joueurRepository;
+    private final MouvementSoldeRepository mouvementSoldeRepository;
+
+    public SoldeService(JoueurRepository joueurRepository,
+                        MouvementSoldeRepository mouvementSoldeRepository) {
+        this.joueurRepository = joueurRepository;
+        this.mouvementSoldeRepository = mouvementSoldeRepository;
+    }
+
+    public void crediter(String matricule, BigDecimal montant) {
+        BigDecimal m = validateMontant(montant);
+
+        Joueur joueur = joueurRepository.findById(matricule)
+                .orElseThrow(() -> new NotFoundException("Joueur introuvable"));
+
+        BigDecimal detteAvant = nullSafe(joueur.getSolde());
+
+        if (m.compareTo(detteAvant) > 0) {
+            throw new BusinessException("Paiement trop élevé. Dette actuelle = " + detteAvant);
+        }
+
+        joueur.setSolde(detteAvant.subtract(m));
+        joueurRepository.save(joueur);
+
+        mouvementSoldeRepository.save(new MouvementSolde(
+                LocalDateTime.now(),
+                m,
+                TypeMouvement.CREDIT,
+                joueur
+        ));
+    }
+
+    // DEBIT = dette : augmente la dette
+    public void debiter(String matricule, BigDecimal montant) {
+        BigDecimal m = validateMontant(montant);
+
+        Joueur joueur = joueurRepository.findById(matricule)
+                .orElseThrow(() -> new NotFoundException("Joueur introuvable"));
+
+        BigDecimal detteAvant = nullSafe(joueur.getSolde());
+
+        joueur.setSolde(detteAvant.add(m));
+        joueurRepository.save(joueur);
+
+        mouvementSoldeRepository.save(new MouvementSolde(
+                LocalDateTime.now(),
+                m,
+                TypeMouvement.DEBIT,
+                joueur
+        ));
+    }
+
+    private BigDecimal validateMontant(BigDecimal montant) {
+        if (montant == null || montant.signum() <= 0) {
+            throw new BusinessException("Montant invalide");
+        }
+        return montant.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal nullSafe(BigDecimal value) {
+        return (value == null ? BigDecimal.ZERO : value).setScale(2, RoundingMode.HALF_UP);
+    }
+}


### PR DESCRIPTION
Implémentation des services métier et de la gestion transactionnelle pour l’issue #21.

Principaux changements :

Règles de réservation appliquées selon le type de joueur (GLOBAL/SITE/LIBRE) avec fenêtres de réservation correctes.

Blocage de la création de match si le joueur a une dette > 0.

Match PUBLIC : inscription uniquement via join + paiement immédiat (premier payé = premier servi au niveau métier).

Match PUBLIC : l’organisateur ne peut pas ajouter manuellement des joueurs.

Gestion de la dette et traçabilité des mouvements/paiements via SoldeService / PaiementService (transactionnel).