### PR TITLE
Closes #18 #22 #24 - REST controllers + DTO mapping + Swagger

### DIFF
--- a/backend/backend/.mvn/jvm.config
+++ b/backend/backend/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Djava.home=C:\Users\fanoa\.jdks\ms-21.0.10

--- a/backend/backend/docker-compose.yml
+++ b/backend/backend/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD}"
     ports:
-      - "1433:1433"
+      - "14333:1433"
     volumes:
       - mssql_data:/var/opt/mssql
     healthcheck:

--- a/backend/backend/pom.xml
+++ b/backend/backend/pom.xml
@@ -40,6 +40,16 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.15</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,9 +61,13 @@
             <artifactId>mssql-jdbc</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
-
-
     <build>
         <plugins>
             <plugin>

--- a/backend/backend/src/main/java/be/ephec/padel/backend/common/Tarifs.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/common/Tarifs.java
@@ -1,0 +1,11 @@
+package be.ephec.padel.backend.common;
+
+import java.math.BigDecimal;
+
+public final class Tarifs {
+
+    public static final BigDecimal PRIX_MATCH = new BigDecimal("60.00");
+    public static final BigDecimal PART_PAR_JOUEUR = new BigDecimal("15.00");
+
+    private Tarifs() {}
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/JoueurController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/JoueurController.java
@@ -1,0 +1,58 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.request.JoueurCreateRequest;
+import be.ephec.padel.backend.dto.response.DetteDto;
+import be.ephec.padel.backend.dto.response.JoueurDto;
+import be.ephec.padel.backend.mapper.JoueurMapper;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.service.JoueurService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/joueurs")
+public class JoueurController {
+
+    private final JoueurService joueurService;
+
+    public JoueurController(JoueurService joueurService) {
+        this.joueurService = joueurService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<JoueurDto>> list() {
+        List<JoueurDto> dtos = joueurService.lister().stream()
+                .map(JoueurMapper::toDto)
+                .toList();
+        return ResponseEntity.ok(dtos);
+    }
+
+    @GetMapping("/{matricule}")
+    public ResponseEntity<JoueurDto> getOne(@PathVariable String matricule) {
+        Joueur joueur = joueurService.getJoueur(matricule);
+        return ResponseEntity.ok(JoueurMapper.toDto(joueur));
+    }
+
+    @GetMapping("/{matricule}/dette")
+    public ResponseEntity<DetteDto> hasDette(@PathVariable String matricule) {
+        boolean dette = joueurService.aDette(matricule);
+        return ResponseEntity.ok(new DetteDto(dette));
+    }
+
+    @PostMapping
+    public ResponseEntity<JoueurDto> create(@Valid @RequestBody JoueurCreateRequest req) {
+        Joueur created = joueurService.creerJoueur(
+                req.getMatricule(),
+                req.getNom(),
+                req.getType(),
+                req.getSiteId()
+        );
+
+        URI location = URI.create("/api/v1/joueurs/" + created.getMatricule());
+        return ResponseEntity.created(location).body(JoueurMapper.toDto(created));
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
@@ -1,0 +1,41 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.request.CreateMatchRequest;
+import be.ephec.padel.backend.dto.response.MatchDto;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.service.MatchPadelService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/matchs")
+public class MatchController {
+
+    private final MatchPadelService matchPadelService;
+
+    public MatchController(MatchPadelService matchPadelService) {
+        this.matchPadelService = matchPadelService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MatchDto> getOne(@PathVariable Long id) {
+        return ResponseEntity.ok(matchPadelService.getMatchDto(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<MatchDto> create(@Valid @RequestBody CreateMatchRequest req) {
+        MatchPadel created = matchPadelService.creerMatch(
+                req.getTerrainId(),
+                req.getOrganisateurMatricule(),
+                req.getDateDebut(),
+                req.getVisibilite()
+        );
+
+        MatchDto dto = matchPadelService.getMatchDto(created.getId());
+        URI location = URI.create("/api/v1/matchs/" + created.getId());
+        return ResponseEntity.created(location).body(dto);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/PaiementController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/PaiementController.java
@@ -1,0 +1,34 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.request.PayRequest;
+import be.ephec.padel.backend.dto.response.PaiementDto;
+import be.ephec.padel.backend.mapper.PaiementMapper;
+import be.ephec.padel.backend.model.entities.Paiement;
+import be.ephec.padel.backend.service.PaiementService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/participations")
+public class PaiementController {
+
+    private final PaiementService paiementService;
+
+    public PaiementController(PaiementService paiementService) {
+        this.paiementService = paiementService;
+    }
+
+    @PostMapping("/{participationId}/paiements")
+    public ResponseEntity<PaiementDto> pay(
+            @PathVariable Long participationId,
+            @Valid @RequestBody PayRequest req
+    ) {
+        Paiement saved = paiementService.payerParticipation(participationId, req.getMontant());
+
+        URI location = URI.create("/api/v1/participations/" + participationId + "/paiements/" + saved.getId());
+        return ResponseEntity.created(location).body(PaiementMapper.toDto(saved));
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/ParticipationController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/ParticipationController.java
@@ -1,0 +1,50 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.request.AddPlayerToPrivateMatchRequest;
+import be.ephec.padel.backend.dto.request.JoinPublicMatchRequest;
+import be.ephec.padel.backend.dto.response.ParticipationDto;
+import be.ephec.padel.backend.mapper.ParticipationMapper;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.service.ParticipationService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/matchs")
+public class ParticipationController {
+
+    private final ParticipationService participationService;
+
+    public ParticipationController(ParticipationService participationService) {
+        this.participationService = participationService;
+    }
+
+    @PostMapping("/{matchId}/participants/public")
+    public ResponseEntity<ParticipationDto> rejoindreMatchPublic(
+            @PathVariable Long matchId,
+            @Valid @RequestBody JoinPublicMatchRequest req) {
+
+        Participation participation = participationService.rejoindreEtPayerMatchPublic(
+                matchId,
+                req.getJoueurMatricule(),
+                req.getMontant()
+        );
+
+        return ResponseEntity.ok(ParticipationMapper.toDto(participation));
+    }
+
+    @PostMapping("/{matchId}/participants/prive")
+    public ResponseEntity<ParticipationDto> ajouterJoueurPrive(
+            @PathVariable Long matchId,
+            @Valid @RequestBody AddPlayerToPrivateMatchRequest req) {
+
+        Participation participation = participationService.ajouterJoueurParOrganisateur(
+                matchId,
+                req.getOrganisateurMatricule(),
+                req.getJoueurMatriculeAAjouter()
+        );
+
+        return ResponseEntity.ok(ParticipationMapper.toDto(participation));
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/SiteController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/SiteController.java
@@ -1,0 +1,52 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.request.CreateSiteRequest;
+import be.ephec.padel.backend.dto.response.SiteDto;
+import be.ephec.padel.backend.mapper.SiteMapper;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.service.SiteService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/sites")
+public class SiteController {
+
+    private final SiteService siteService;
+
+    public SiteController(SiteService siteService) {
+        this.siteService = siteService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SiteDto>> list() {
+        List<SiteDto> dtos = siteService.lister().stream()
+                .map(SiteMapper::toDto)
+                .toList();
+        return ResponseEntity.ok(dtos);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SiteDto> getOne(@PathVariable Long id) {
+        Site site = siteService.getSite(id);
+        return ResponseEntity.ok(SiteMapper.toDto(site));
+    }
+
+    @PostMapping
+    public ResponseEntity<SiteDto> create(@Valid @RequestBody CreateSiteRequest req) {
+        Site created = siteService.creerSite(req.getNom(), req.getVille());
+
+        URI location = URI.create("/api/v1/sites/" + created.getId());
+        return ResponseEntity.created(location)
+                .body(SiteMapper.toDto(created));
+    }
+
+    @GetMapping("/_whoami")
+    public String whoami() {
+        return "SITE_CONTROLLER_V2";
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/TerrainController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/TerrainController.java
@@ -1,0 +1,61 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.request.CreateTerrainRequest;
+import be.ephec.padel.backend.dto.response.TerrainDto;
+import be.ephec.padel.backend.mapper.TerrainMapper;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.service.TerrainService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/terrains")
+public class TerrainController {
+
+    private final TerrainService terrainService;
+
+    public TerrainController(TerrainService terrainService) {
+        this.terrainService = terrainService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TerrainDto>> list(
+            @RequestParam(required = false) Long siteId) {
+
+        List<Terrain> terrains = (siteId == null)
+                ? terrainService.lister()
+                : terrainService.listerParSite(siteId);
+
+        List<TerrainDto> dtos = terrains.stream()
+                .map(TerrainMapper::toDto)
+                .toList();
+
+        return ResponseEntity.ok(dtos);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<TerrainDto> getOne(@PathVariable Long id) {
+        Terrain terrain = terrainService.getTerrain(id);
+        return ResponseEntity.ok(TerrainMapper.toDto(terrain));
+    }
+
+    @PostMapping
+    public ResponseEntity<TerrainDto> create(
+            @Valid @RequestBody CreateTerrainRequest req) {
+
+        Terrain created = terrainService.creerTerrain(
+                req.getNom(),
+                req.getSiteId()
+        );
+
+        URI location = URI.create("/api/v1/terrains/" + created.getId());
+
+        return ResponseEntity
+                .created(location)
+                .body(TerrainMapper.toDto(created));
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/AddPlayerToPrivateMatchRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/AddPlayerToPrivateMatchRequest.java
@@ -1,0 +1,18 @@
+package be.ephec.padel.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class AddPlayerToPrivateMatchRequest {
+
+    @NotBlank
+    private String organisateurMatricule;
+
+    @NotBlank
+    private String joueurMatriculeAAjouter;
+
+    public String getOrganisateurMatricule() { return organisateurMatricule; }
+    public void setOrganisateurMatricule(String organisateurMatricule) { this.organisateurMatricule = organisateurMatricule; }
+
+    public String getJoueurMatriculeAAjouter() { return joueurMatriculeAAjouter; }
+    public void setJoueurMatriculeAAjouter(String joueurMatriculeAAjouter) { this.joueurMatriculeAAjouter = joueurMatriculeAAjouter; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateMatchRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateMatchRequest.java
@@ -1,0 +1,34 @@
+package be.ephec.padel.backend.dto.request;
+
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public class CreateMatchRequest {
+
+    @NotNull
+    private Long terrainId;
+
+    @NotBlank
+    private String organisateurMatricule;
+
+    @NotNull
+    private LocalDateTime dateDebut;
+
+    @NotNull
+    private MatchVisibilite visibilite;
+
+    public Long getTerrainId() { return terrainId; }
+    public void setTerrainId(Long terrainId) { this.terrainId = terrainId; }
+
+    public String getOrganisateurMatricule() { return organisateurMatricule; }
+    public void setOrganisateurMatricule(String organisateurMatricule) { this.organisateurMatricule = organisateurMatricule; }
+
+    public LocalDateTime getDateDebut() { return dateDebut; }
+    public void setDateDebut(LocalDateTime dateDebut) { this.dateDebut = dateDebut; }
+
+    public MatchVisibilite getVisibilite() { return visibilite; }
+    public void setVisibilite(MatchVisibilite visibilite) { this.visibilite = visibilite; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateSiteRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateSiteRequest.java
@@ -1,0 +1,18 @@
+package be.ephec.padel.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class CreateSiteRequest {
+
+    @NotBlank
+    private String nom;
+
+    @NotBlank
+    private String ville;
+
+    public String getNom() { return nom; }
+    public void setNom(String nom) { this.nom = nom; }
+
+    public String getVille() { return ville; }
+    public void setVille(String ville) { this.ville = ville; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateTerrainRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateTerrainRequest.java
@@ -1,0 +1,19 @@
+package be.ephec.padel.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class CreateTerrainRequest {
+
+    @NotBlank
+    private String nom;
+
+    @NotNull
+    private Long siteId;
+
+    public String getNom() { return nom; }
+    public void setNom(String nom) { this.nom = nom; }
+
+    public Long getSiteId() { return siteId; }
+    public void setSiteId(Long siteId) { this.siteId = siteId; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/JoinPublicMatchRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/JoinPublicMatchRequest.java
@@ -1,0 +1,23 @@
+package be.ephec.padel.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+public class JoinPublicMatchRequest {
+
+    @NotBlank(message = "Matricule du joueur obligatoire")
+    private String joueurMatricule;
+
+    @NotNull(message = "Montant obligatoire")
+    @Positive(message = "Le montant doit être > 0")
+    private BigDecimal montant;
+
+    public String getJoueurMatricule() { return joueurMatricule; }
+    public void setJoueurMatricule(String joueurMatricule) { this.joueurMatricule = joueurMatricule; }
+
+    public BigDecimal getMontant() { return montant; }
+    public void setMontant(BigDecimal montant) { this.montant = montant; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/JoueurCreateRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/JoueurCreateRequest.java
@@ -1,0 +1,31 @@
+package be.ephec.padel.backend.dto.request;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class JoueurCreateRequest {
+
+    @NotBlank
+    private String matricule;
+
+    @NotBlank
+    private String nom;
+
+    @NotNull
+    private TypeJoueur type;
+
+    // Peut être null, ton service valide selon le type
+    private Long siteId;
+
+    public String getMatricule() { return matricule; }
+    public void setMatricule(String matricule) { this.matricule = matricule; }
+
+    public String getNom() { return nom; }
+    public void setNom(String nom) { this.nom = nom; }
+
+    public TypeJoueur getType() { return type; }
+    public void setType(TypeJoueur type) { this.type = type; }
+
+    public Long getSiteId() { return siteId; }
+    public void setSiteId(Long siteId) { this.siteId = siteId; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/PayRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/PayRequest.java
@@ -1,0 +1,16 @@
+package be.ephec.padel.backend.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+public class PayRequest {
+
+    @NotNull(message = "Montant obligatoire")
+    @Positive(message = "Le montant doit être > 0")
+    private BigDecimal montant;
+
+    public BigDecimal getMontant() { return montant; }
+    public void setMontant(BigDecimal montant) { this.montant = montant; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/ApiErrorDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/ApiErrorDto.java
@@ -1,0 +1,85 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public class ApiErrorDto {
+
+    private LocalDateTime timestamp;
+    private int status;
+    private String error;
+    private String message;
+    private String path;
+
+    /**
+     * Optionnel : détails de validation (champ/param -> message).
+     * Null si pas applicable.
+     */
+    private Map<String, String> details;
+
+    public ApiErrorDto() {
+        // Constructeur vide requis (Jackson)
+    }
+
+    public ApiErrorDto(LocalDateTime timestamp,
+                       int status,
+                       String error,
+                       String message,
+                       String path,
+                       Map<String, String> details) {
+        this.timestamp = timestamp;
+        this.status = status;
+        this.error = error;
+        this.message = message;
+        this.path = path;
+        this.details = details;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/DetteDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/DetteDto.java
@@ -1,0 +1,8 @@
+package be.ephec.padel.backend.dto.response;
+
+public class DetteDto {
+    private boolean dette;
+
+    public DetteDto(boolean dette) { this.dette = dette; }
+    public boolean isDette() { return dette; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/JoueurDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/JoueurDto.java
@@ -1,0 +1,27 @@
+package be.ephec.padel.backend.dto.response;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+
+import java.math.BigDecimal;
+
+public class JoueurDto {
+
+    private String matricule;
+    private String nom;
+    private TypeJoueur type;
+    private Long siteId;
+    private BigDecimal solde;
+
+    public JoueurDto(String matricule, String nom, TypeJoueur type, Long siteId, BigDecimal solde) {
+        this.matricule = matricule;
+        this.nom = nom;
+        this.type = type;
+        this.siteId = siteId;
+        this.solde = solde;
+    }
+
+    public String getMatricule() { return matricule; }
+    public String getNom() { return nom; }
+    public TypeJoueur getType() { return type; }
+    public Long getSiteId() { return siteId; }
+    public BigDecimal getSolde() { return solde; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDto.java
@@ -1,0 +1,64 @@
+package be.ephec.padel.backend.dto.response;
+
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class MatchDto {
+
+    private Long id;
+    private Long terrainId;
+    private String terrainNom;
+    private Long siteId;
+
+    private String organisateurMatricule;
+    private LocalDateTime dateDebut;
+    private MatchVisibilite visibilite;
+
+    private int nbParticipants;
+
+    // ✅ nouveaux champs
+    private BigDecimal montantTotal;   // 60.00
+    private BigDecimal montantPaye;    // somme des paiements
+    private BigDecimal resteAPayer;    // montantTotal - montantPaye (min 0)
+
+    public MatchDto(Long id,
+                    Long terrainId,
+                    String terrainNom,
+                    Long siteId,
+                    String organisateurMatricule,
+                    LocalDateTime dateDebut,
+                    MatchVisibilite visibilite,
+                    int nbParticipants,
+                    BigDecimal montantTotal,
+                    BigDecimal montantPaye,
+                    BigDecimal resteAPayer) {
+
+        this.id = id;
+        this.terrainId = terrainId;
+        this.terrainNom = terrainNom;
+        this.siteId = siteId;
+        this.organisateurMatricule = organisateurMatricule;
+        this.dateDebut = dateDebut;
+        this.visibilite = visibilite;
+        this.nbParticipants = nbParticipants;
+
+        this.montantTotal = montantTotal;
+        this.montantPaye = montantPaye;
+        this.resteAPayer = resteAPayer;
+    }
+
+    public Long getId() { return id; }
+    public Long getTerrainId() { return terrainId; }
+    public String getTerrainNom() { return terrainNom; }
+    public Long getSiteId() { return siteId; }
+    public String getOrganisateurMatricule() { return organisateurMatricule; }
+    public LocalDateTime getDateDebut() { return dateDebut; }
+    public MatchVisibilite getVisibilite() { return visibilite; }
+    public int getNbParticipants() { return nbParticipants; }
+
+    public BigDecimal getMontantTotal() { return montantTotal; }
+    public BigDecimal getMontantPaye() { return montantPaye; }
+    public BigDecimal getResteAPayer() { return resteAPayer; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PaiementDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PaiementDto.java
@@ -1,0 +1,26 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class PaiementDto {
+
+    private Long id;
+    private Long participationId;
+    private BigDecimal montant;
+    private LocalDateTime datePaiement;
+
+    public PaiementDto(Long id, Long participationId,
+                       BigDecimal montant,
+                       LocalDateTime datePaiement) {
+        this.id = id;
+        this.participationId = participationId;
+        this.montant = montant;
+        this.datePaiement = datePaiement;
+    }
+
+    public Long getId() { return id; }
+    public Long getParticipationId() { return participationId; }
+    public BigDecimal getMontant() { return montant; }
+    public LocalDateTime getDatePaiement() { return datePaiement; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/ParticipationDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/ParticipationDto.java
@@ -1,0 +1,18 @@
+package be.ephec.padel.backend.dto.response;
+
+public class ParticipationDto {
+
+    private Long id;
+    private Long matchId;
+    private String joueurMatricule;
+
+    public ParticipationDto(Long id, Long matchId, String joueurMatricule) {
+        this.id = id;
+        this.matchId = matchId;
+        this.joueurMatricule = joueurMatricule;
+    }
+
+    public Long getId() { return id; }
+    public Long getMatchId() { return matchId; }
+    public String getJoueurMatricule() { return joueurMatricule; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/SiteDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/SiteDto.java
@@ -1,0 +1,17 @@
+package be.ephec.padel.backend.dto.response;
+
+public class SiteDto {
+    private Long id;
+    private String nom;
+    private String ville;
+
+    public SiteDto(Long id, String nom, String ville) {
+        this.id = id;
+        this.nom = nom;
+        this.ville = ville;
+    }
+
+    public Long getId() { return id; }
+    public String getNom() { return nom; }
+    public String getVille() { return ville; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/TerrainDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/TerrainDto.java
@@ -1,0 +1,17 @@
+package be.ephec.padel.backend.dto.response;
+
+public class TerrainDto {
+    private Long id;
+    private String nom;
+    private Long siteId;
+
+    public TerrainDto(Long id, String nom, Long siteId) {
+        this.id = id;
+        this.nom = nom;
+        this.siteId = siteId;
+    }
+
+    public Long getId() { return id; }
+    public String getNom() { return nom; }
+    public Long getSiteId() { return siteId; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/error/ApiExceptionHandler.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/error/ApiExceptionHandler.java
@@ -1,0 +1,157 @@
+package be.ephec.padel.backend.error;
+
+import be.ephec.padel.backend.dto.response.ApiErrorDto;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ApiErrorDto> handleNotFound(
+            NotFoundException ex,
+            HttpServletRequest request) {
+
+        ApiErrorDto error = buildError(
+                HttpStatus.NOT_FOUND,
+                ex.getMessage(),
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiErrorDto> handleBusiness(
+            BusinessException ex,
+            HttpServletRequest request) {
+
+        ApiErrorDto error = buildError(
+                HttpStatus.BAD_REQUEST,
+                ex.getMessage(),
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorDto> handleValidation(
+            MethodArgumentNotValidException ex,
+            HttpServletRequest request) {
+
+        Map<String, String> details = new HashMap<>();
+        ex.getBindingResult().getFieldErrors()
+                .forEach(err -> details.put(err.getField(), err.getDefaultMessage()));
+
+        ApiErrorDto error = buildError(
+                HttpStatus.BAD_REQUEST,
+                "Validation failed",
+                request.getRequestURI(),
+                details
+        );
+
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiErrorDto> handleConstraintViolation(
+            ConstraintViolationException ex,
+            HttpServletRequest request) {
+
+        Map<String, String> details = new HashMap<>();
+        ex.getConstraintViolations().forEach(v -> details.put(
+                v.getPropertyPath().toString(),
+                v.getMessage()
+        ));
+
+        ApiErrorDto error = buildError(
+                HttpStatus.BAD_REQUEST,
+                "Validation failed",
+                request.getRequestURI(),
+                details
+        );
+
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiErrorDto> handleJsonError(
+            HttpMessageNotReadableException ex,
+            HttpServletRequest request) {
+
+        ApiErrorDto error = buildError(
+                HttpStatus.BAD_REQUEST,
+                "Malformed JSON request",
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiErrorDto> handleTypeMismatch(
+            MethodArgumentTypeMismatchException ex,
+            HttpServletRequest request) {
+
+        String msg = "Invalid value for parameter '" + ex.getName() + "': " + ex.getValue();
+
+        ApiErrorDto error = buildError(
+                HttpStatus.BAD_REQUEST,
+                msg,
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiErrorDto> handleUnexpected(
+            Exception ex,
+            HttpServletRequest request) {
+
+        // Ne pas exposer les détails internes en production.
+        ApiErrorDto error = buildError(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Unexpected error",
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+
+    private ApiErrorDto buildError(
+            HttpStatus status,
+            String message,
+            String path,
+            Map<String, String> details) {
+
+        ApiErrorDto dto = new ApiErrorDto();
+        dto.setTimestamp(LocalDateTime.now());
+        dto.setStatus(status.value());
+        dto.setError(status.getReasonPhrase());
+        dto.setMessage(message);
+        dto.setPath(path);
+        dto.setDetails(details);
+
+        return dto;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/JoueurMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/JoueurMapper.java
@@ -1,0 +1,61 @@
+package be.ephec.padel.backend.mapper;
+
+import be.ephec.padel.backend.dto.request.JoueurCreateRequest;
+import be.ephec.padel.backend.dto.response.JoueurDto;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.Site;
+
+import java.math.BigDecimal;
+
+public final class JoueurMapper {
+
+    private JoueurMapper() {}
+
+    public static JoueurDto toDto(Joueur joueur) {
+        if (joueur == null) return null;
+
+        Long siteId = null;
+        if (joueur.getSite() != null) {
+            siteId = joueur.getSite().getId();
+        }
+
+        BigDecimal solde = joueur.getSolde() != null ? joueur.getSolde() : BigDecimal.ZERO;
+
+        return new JoueurDto(
+                joueur.getMatricule(),
+                joueur.getNom(),
+                joueur.getType(),
+                siteId,
+                solde
+        );
+    }
+
+    /**
+     * Mapping request -> entity.
+     * IMPORTANT : l'entity Joueur n'a pas de setMatricule(), donc on utilise le constructeur.
+     * Le Site (si nécessaire) doit être résolu par le service (lookup + règles métier).
+     */
+    public static Joueur toEntity(JoueurCreateRequest req) {
+        if (req == null) return null;
+
+        return new Joueur(
+                req.getMatricule(),
+                req.getNom(),
+                req.getType()
+        );
+    }
+
+    /**
+     * Variante utile si ton service a déjà résolu le Site à partir de siteId.
+     */
+    public static Joueur toEntity(JoueurCreateRequest req, Site site) {
+        if (req == null) return null;
+
+        return new Joueur(
+                req.getMatricule(),
+                req.getNom(),
+                req.getType(),
+                site
+        );
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchMapper.java
@@ -1,0 +1,53 @@
+package be.ephec.padel.backend.mapper;
+
+import be.ephec.padel.backend.dto.response.MatchDto;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+
+import java.math.BigDecimal;
+
+public final class MatchMapper {
+
+    private MatchMapper() {}
+
+    public static MatchDto toDtoBase(MatchPadel match) {
+        return toDtoComplet(match, null, null, null);
+    }
+
+    public static MatchDto toDtoComplet(MatchPadel match,
+                                        BigDecimal montantTotal,
+                                        BigDecimal montantPaye,
+                                        BigDecimal resteAPayer) {
+        if (match == null) return null;
+
+        Terrain terrain = match.getTerrain();
+        Long terrainId = terrain != null ? terrain.getId() : null;
+        String terrainNom = terrain != null ? terrain.getNom() : null;
+
+        Site site = (terrain != null) ? terrain.getSite() : null;
+        Long siteId = site != null ? site.getId() : null;
+
+        String organisateurMatricule = match.getOrganisateur() != null
+                ? match.getOrganisateur().getMatricule()
+                : null;
+
+        int nbParticipants = match.getParticipations() != null
+                ? match.getParticipations().size()
+                : 0;
+
+        return new MatchDto(
+                match.getId(),
+                terrainId,
+                terrainNom,
+                siteId,
+                organisateurMatricule,
+                match.getDateDebut(),
+                match.getVisibilite(),
+                nbParticipants,
+                montantTotal,
+                montantPaye,
+                resteAPayer
+        );
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/PaiementMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/PaiementMapper.java
@@ -1,0 +1,24 @@
+package be.ephec.padel.backend.mapper;
+
+import be.ephec.padel.backend.dto.response.PaiementDto;
+import be.ephec.padel.backend.model.entities.Paiement;
+
+public final class PaiementMapper {
+
+    private PaiementMapper() {}
+
+    public static PaiementDto toDto(Paiement paiement) {
+        if (paiement == null) return null;
+
+        Long participationId = paiement.getParticipation() != null
+                ? paiement.getParticipation().getId()
+                : null;
+
+        return new PaiementDto(
+                paiement.getId(),
+                participationId,
+                paiement.getMontant(),
+                paiement.getDatePaiement()
+        );
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/ParticipationMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/ParticipationMapper.java
@@ -1,0 +1,27 @@
+package be.ephec.padel.backend.mapper;
+
+import be.ephec.padel.backend.dto.response.ParticipationDto;
+import be.ephec.padel.backend.model.entities.Participation;
+
+public final class ParticipationMapper {
+
+    private ParticipationMapper() {}
+
+    public static ParticipationDto toDto(Participation participation) {
+        if (participation == null) return null;
+
+        Long matchId = participation.getMatch() != null
+                ? participation.getMatch().getId()
+                : null;
+
+        String joueurMatricule = participation.getJoueur() != null
+                ? participation.getJoueur().getMatricule()
+                : null;
+
+        return new ParticipationDto(
+                participation.getId(),
+                matchId,
+                joueurMatricule
+        );
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/SiteMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/SiteMapper.java
@@ -1,0 +1,29 @@
+package be.ephec.padel.backend.mapper;
+
+import be.ephec.padel.backend.dto.request.CreateSiteRequest;
+import be.ephec.padel.backend.dto.response.SiteDto;
+import be.ephec.padel.backend.model.entities.Site;
+
+public final class SiteMapper {
+
+    private SiteMapper() {}
+
+    public static SiteDto toDto(Site site) {
+        if (site == null) return null;
+
+        return new SiteDto(
+                site.getId(),
+                site.getNom(),
+                site.getVille()
+        );
+    }
+
+    public static Site toEntity(CreateSiteRequest req) {
+        if (req == null) return null;
+
+        return new Site(
+                req.getNom(),
+                req.getVille()
+        );
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/TerrainMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/TerrainMapper.java
@@ -1,0 +1,38 @@
+package be.ephec.padel.backend.mapper;
+
+import be.ephec.padel.backend.dto.request.CreateTerrainRequest;
+import be.ephec.padel.backend.dto.response.TerrainDto;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+
+public final class TerrainMapper {
+
+    private TerrainMapper() {}
+
+    public static TerrainDto toDto(Terrain terrain) {
+        if (terrain == null) return null;
+
+        Long siteId = terrain.getSite() != null
+                ? terrain.getSite().getId()
+                : null;
+
+        return new TerrainDto(
+                terrain.getId(),
+                terrain.getNom(),
+                siteId
+        );
+    }
+
+    /**
+     * Ici on suppose que le service a déjà récupéré le Site
+     * à partir du siteId (lookup + validation).
+     */
+    public static Terrain toEntity(CreateTerrainRequest req, Site site) {
+        if (req == null) return null;
+
+        return new Terrain(
+                req.getNom(),
+                site
+        );
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Participation.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Participation.java
@@ -21,8 +21,7 @@ public class Participation {
     @JoinColumn(name = "match_id", nullable = false)
     private MatchPadel match;
 
-
-    @ManyToOne(optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "joueur_matricule", nullable = false)
     private Joueur joueur;
 

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -2,11 +2,26 @@ package be.ephec.padel.backend.repository;
 
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
     List<MatchPadel> findByTerrainId(Long terrainId);
     List<MatchPadel> findByDateDebutBetween(LocalDateTime start, LocalDateTime end);
+
+    @Query("""
+select distinct m
+from MatchPadel m
+join fetch m.terrain t
+join fetch t.site
+join fetch m.organisateur o
+left join fetch m.participations p
+where m.id = :id
+""")
+    Optional<MatchPadel> findByIdWithDetails(@Param("id") Long id);
 }
+

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
@@ -11,12 +11,21 @@ import java.util.List;
 public interface PaiementRepository extends JpaRepository<Paiement, Long> {
 
     List<Paiement> findByParticipation_Id(Long participationId);
-
     List<Paiement> findByParticipation_Joueur_Matricule(String matricule);
-
     List<Paiement> findByParticipation_Match_Id(Long matchId);
 
-    @Query("select coalesce(sum(p.montant), 0) from Paiement p where p.participation.id = :participationId")
+    @Query("""
+        select coalesce(sum(p.montant), 0)
+        from Paiement p
+        where p.participation.id = :participationId
+    """)
     BigDecimal sumMontantByParticipationId(@Param("participationId") Long participationId);
 
+    @Query("""
+        select coalesce(sum(pa.montant), 0)
+        from Paiement pa
+        join pa.participation part
+        where part.match.id = :matchId
+    """)
+    BigDecimal sumMontantByMatchId(@Param("matchId") Long matchId);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
@@ -8,8 +8,7 @@ import java.util.List;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
     List<Participation> findByMatch_Id(Long matchId);
-    List<Participation> findByJoueurMatricule(String matricule);
-
+    List<Participation> findByJoueur_Matricule(String matricule);
     boolean existsByMatch_IdAndJoueur_Matricule(Long matchId, String joueurMatricule);
 
     Optional<Participation> findByMatch_IdAndJoueur_Matricule(Long matchId, String matricule);

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/TerrainRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/TerrainRepository.java
@@ -6,6 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface TerrainRepository extends JpaRepository<Terrain, Long> {
-    List<Terrain> findBySiteId(Long siteId);
+
     boolean existsByNomAndSiteId(String nom, Long siteId);
+
+    List<Terrain> findBySite_Id(Long siteId);
 }
+

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -1,18 +1,24 @@
 package be.ephec.padel.backend.service;
 
+import be.ephec.padel.backend.common.Tarifs;
+import be.ephec.padel.backend.dto.response.MatchDto;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.entities.Terrain;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.TerrainRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Service
@@ -22,13 +28,67 @@ public class MatchPadelService {
     private final MatchPadelRepository matchPadelRepository;
     private final TerrainRepository terrainRepository;
     private final JoueurRepository joueurRepository;
+    private final SoldeService soldeService;
+    private final ParticipationRepository participationRepository;
+    private final PaiementService paiementService;
+    private final PaiementRepository paiementRepository;
 
     public MatchPadelService(MatchPadelRepository matchPadelRepository,
                              TerrainRepository terrainRepository,
-                             JoueurRepository joueurRepository) {
+                             JoueurRepository joueurRepository,
+                             SoldeService soldeService,
+                             ParticipationRepository participationRepository,
+                             PaiementService paiementService,
+                             PaiementRepository paiementRepository) {
         this.matchPadelRepository = matchPadelRepository;
         this.terrainRepository = terrainRepository;
         this.joueurRepository = joueurRepository;
+        this.soldeService = soldeService;
+        this.participationRepository = participationRepository;
+        this.paiementService = paiementService;
+        this.paiementRepository = paiementRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public MatchPadel getMatch(Long id) {
+        return matchPadelRepository.findByIdWithDetails(id)
+                .orElseThrow(() -> new NotFoundException("Match introuvable"));
+    }
+
+    @Transactional(readOnly = true)
+    public MatchDto getMatchDto(Long id) {
+        MatchPadel m = getMatch(id);
+
+        BigDecimal montantTotal = Tarifs.PRIX_MATCH;
+
+        BigDecimal montantPaye = paiementRepository.sumMontantByMatchId(id);
+        if (montantPaye == null) montantPaye = BigDecimal.ZERO;
+
+        BigDecimal resteAPayer = montantTotal.subtract(montantPaye);
+        if (resteAPayer.signum() < 0) resteAPayer = BigDecimal.ZERO;
+
+        Terrain terrain = m.getTerrain();
+        Long terrainId = (terrain != null) ? terrain.getId() : null;
+        String terrainNom = (terrain != null) ? terrain.getNom() : null;
+        Long siteId = (terrain != null && terrain.getSite() != null) ? terrain.getSite().getId() : null;
+
+        String organisateurMatricule = (m.getOrganisateur() != null) ? m.getOrganisateur().getMatricule() : null;
+
+        int nbParticipants = (m.getParticipations() != null) ? m.getParticipations().size() : 0;
+
+        return new MatchDto(
+                m.getId(),
+                terrainId,
+                terrainNom,
+                siteId,
+                organisateurMatricule,
+                m.getDateDebut(),
+                m.getVisibilite(),
+                nbParticipants,
+                montantTotal,
+                montantPaye,
+                resteAPayer
+        );
     }
 
     public MatchPadel creerMatch(Long terrainId,
@@ -43,9 +103,7 @@ public class MatchPadelService {
         if (dateDebut == null) throw new BusinessException("Date début obligatoire");
         if (visibilite == null) throw new BusinessException("Visibilité obligatoire");
 
-        // ✅ un seul "now" pour toute la méthode
         LocalDateTime now = LocalDateTime.now();
-
         if (!dateDebut.isAfter(now)) {
             throw new BusinessException("La date du match doit être dans le futur.");
         }
@@ -56,7 +114,6 @@ public class MatchPadelService {
         Joueur organisateur = joueurRepository.findById(organisateurMatricule)
                 .orElseThrow(() -> new NotFoundException("Joueur introuvable"));
 
-        // Règle: pas de réservation si dette > 0
         if (organisateur.getSolde() != null && organisateur.getSolde().signum() > 0) {
             throw new BusinessException("Réservation impossible : dette en cours (" + organisateur.getSolde() + ").");
         }
@@ -64,7 +121,17 @@ public class MatchPadelService {
         verifierDroitReservation(organisateur, terrain, dateDebut, now);
 
         MatchPadel match = new MatchPadel(terrain, organisateur, dateDebut, visibilite);
-        return matchPadelRepository.save(match);
+        MatchPadel saved = matchPadelRepository.save(match);
+
+        // organisateur = participant
+        Participation pOrg = participationRepository.save(new Participation(saved, organisateur));
+
+        // payé à l’avance : dette puis paiement immédiat
+        BigDecimal part = Tarifs.PART_PAR_JOUEUR;
+        soldeService.debiter(organisateurMatricule, part);
+        paiementService.payerParticipation(pOrg.getId(), part);
+
+        return saved;
     }
 
     private void verifierDroitReservation(Joueur orga,
@@ -102,6 +169,4 @@ public class MatchPadelService {
             default -> throw new BusinessException("Type joueur inconnu.");
         }
     }
-
 }
-

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/PaiementService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/PaiementService.java
@@ -1,5 +1,6 @@
 package be.ephec.padel.backend.service;
 
+import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Paiement;
@@ -17,8 +18,7 @@ import java.time.LocalDateTime;
 @Transactional
 public class PaiementService {
 
-    private static final BigDecimal PRIX_MATCH = new BigDecimal("60.00");
-    private static final BigDecimal PART_JOUEUR = PRIX_MATCH.divide(new BigDecimal("4"), 2, RoundingMode.HALF_UP); // 15.00
+    private static final BigDecimal PART_JOUEUR = Tarifs.PART_PAR_JOUEUR;
 
     private final PaiementRepository paiementRepository;
     private final ParticipationRepository participationRepository;
@@ -38,7 +38,6 @@ public class PaiementService {
 
         BigDecimal m = validerMontant(montant);
 
-        // Total déjà payé pour cette participation (0 si aucun paiement)
         BigDecimal dejaPaye = paiementRepository.sumMontantByParticipationId(participationId);
         if (dejaPaye == null) dejaPaye = BigDecimal.ZERO;
         dejaPaye = dejaPaye.setScale(2, RoundingMode.HALF_UP);
@@ -52,19 +51,14 @@ public class PaiementService {
             throw new BusinessException("Paiement trop élevé. Reste à payer = " + reste);
         }
 
-        // 1) Enregistrer le paiement (trace)
         Paiement saved = paiementRepository.save(new Paiement(participation, m, LocalDateTime.now()));
 
-        // 2) Réduire la dette du joueur
         String matricule = participation.getJoueur().getMatricule();
         soldeService.crediter(matricule, m);
 
         return saved;
     }
 
-    /**
-     * Paiement en donnant matchId + matricule.
-     */
     public Paiement payerPourMatch(Long matchId, String joueurMatricule, BigDecimal montant) {
         Participation participation = participationRepository
                 .findByMatch_IdAndJoueur_Matricule(matchId, joueurMatricule)

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java
@@ -1,5 +1,6 @@
 package be.ephec.padel.backend.service;
 
+import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
@@ -18,7 +19,7 @@ import java.math.BigDecimal;
 @Transactional
 public class ParticipationService {
 
-    private static final BigDecimal PART_JOUEUR = new BigDecimal("15.00");
+    private static final BigDecimal PART_JOUEUR = Tarifs.PART_PAR_JOUEUR;
 
     private final ParticipationRepository participationRepository;
     private final MatchPadelRepository matchPadelRepository;
@@ -38,14 +39,15 @@ public class ParticipationService {
         this.paiementService = paiementService;
     }
 
-
-
     public Participation rejoindreEtPayerMatchPublic(Long matchId, String joueurMatricule, BigDecimal montant) {
         MatchPadel match = getMatchOrThrow(matchId);
 
         if (match.getVisibilite() != MatchVisibilite.PUBLIC) {
             throw new BusinessException("Match privé : seule l'organisation peut ajouter des joueurs.");
         }
+
+        // ✅ En match PUBLIC : paiement obligatoire et complet (= 15.00)
+        BigDecimal m = validerMontantPublic(montant);
 
         Joueur joueur = getJoueurOrThrow(joueurMatricule);
 
@@ -54,8 +56,9 @@ public class ParticipationService {
 
         Participation saved = participationRepository.save(new Participation(match, joueur));
 
+        // dette puis paiement immédiat (validation au paiement)
         soldeService.debiter(joueurMatricule, PART_JOUEUR);
-        paiementService.payerParticipation(saved.getId(), montant);
+        paiementService.payerParticipation(saved.getId(), m);
 
         return saved;
     }
@@ -81,9 +84,21 @@ public class ParticipationService {
 
         Participation saved = participationRepository.save(new Participation(match, joueurAAjouter));
 
+        // en privé : inscription => dette (paiement ultérieur via endpoint paiement)
         soldeService.debiter(joueurMatriculeAAjouter, PART_JOUEUR);
 
         return saved;
+    }
+
+    private BigDecimal validerMontantPublic(BigDecimal montant) {
+        if (montant == null) throw new BusinessException("Montant obligatoire");
+        if (montant.signum() <= 0) throw new BusinessException("Montant invalide");
+
+        BigDecimal m = montant.setScale(2, BigDecimal.ROUND_HALF_UP);
+        if (m.compareTo(PART_JOUEUR) != 0) {
+            throw new BusinessException("Pour un match public, le paiement doit être de " + PART_JOUEUR);
+        }
+        return m;
     }
 
     private MatchPadel getMatchOrThrow(Long matchId) {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/SiteService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/SiteService.java
@@ -1,0 +1,42 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.repository.SiteRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class SiteService {
+
+    private final SiteRepository siteRepository;
+
+    public SiteService(SiteRepository siteRepository) {
+        this.siteRepository = siteRepository;
+    }
+
+    public List<Site> lister() {
+        return siteRepository.findAll();
+    }
+
+    public Site getSite(Long id) {
+        if (id == null) throw new BusinessException("Id site obligatoire");
+        return siteRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Site introuvable"));
+    }
+
+    public Site creerSite(String nom, String ville) {
+        if (nom == null || nom.isBlank()) throw new BusinessException("Nom obligatoire");
+        if (ville == null || ville.isBlank()) throw new BusinessException("Ville obligatoire");
+
+        if (siteRepository.existsByNom(nom)) {
+            throw new BusinessException("Nom de site déjà utilisé");
+        }
+
+        return siteRepository.save(new Site(nom, ville));
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/TerrainService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/TerrainService.java
@@ -1,0 +1,56 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class TerrainService {
+
+    private final TerrainRepository terrainRepository;
+    private final SiteRepository siteRepository;
+
+    public TerrainService(TerrainRepository terrainRepository, SiteRepository siteRepository) {
+        this.terrainRepository = terrainRepository;
+        this.siteRepository = siteRepository;
+    }
+
+    public List<Terrain> lister() {
+        return terrainRepository.findAll();
+    }
+
+    public List<Terrain> listerParSite(Long siteId) {
+        if (siteId == null) throw new BusinessException("SiteId obligatoire");
+        // utilise une des deux méthodes, on choisit findBySite_Id
+        return terrainRepository.findBySite_Id(siteId);
+    }
+
+    public Terrain getTerrain(Long id) {
+        if (id == null) throw new BusinessException("Id terrain obligatoire");
+        return terrainRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Terrain introuvable"));
+    }
+
+    public Terrain creerTerrain(String nom, Long siteId) {
+        if (nom == null || nom.isBlank()) throw new BusinessException("Nom obligatoire");
+        if (siteId == null) throw new BusinessException("SiteId obligatoire");
+
+        Site site = siteRepository.findById(siteId)
+                .orElseThrow(() -> new NotFoundException("Site introuvable"));
+
+        // Bonus (utile) : éviter doublon de terrain dans le même site
+        if (terrainRepository.existsByNomAndSiteId(nom, siteId)) {
+            throw new BusinessException("Terrain déjà existant pour ce site");
+        }
+
+        return terrainRepository.save(new Terrain(nom, site));
+    }
+}

--- a/backend/backend/src/main/resources/application-docker.properties
+++ b/backend/backend/src/main/resources/application-docker.properties
@@ -3,4 +3,4 @@ spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.SQLServerDialect
+#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.SQLServerDialect

--- a/backend/backend/src/main/resources/application.properties
+++ b/backend/backend/src/main/resources/application.properties
@@ -1,10 +1,9 @@
 spring.application.name=backend
-spring.datasource.url=jdbc:sqlserver://localhost:1433;databaseName=padel;encrypt=false;trustServerCertificate=true
 
+spring.datasource.url=jdbc:sqlserver://localhost:14333;databaseName=padel;encrypt=true;trustServerCertificate=true
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.datasource.driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver
 spring.jpa.open-in-view=false


### PR DESCRIPTION
Closes #18
Closes #22
Closes #24

### Contenu
- Controllers REST pour Site, Terrain, Joueur, Match, Participation, Paiement
- DTO request/response + mapping (pas d’exposition des entités)
- Validation @Valid + contraintes sur les DTO
- Gestion centralisée des erreurs (BusinessException 400, NotFound 404, validation 400)
- Swagger/OpenAPI via springdoc (Swagger UI + /v3/api-docs)

### Règles métier couvertes
- Réservation selon type (GLOBAL/SITE/LIBRE) + blocage si dette > 0
- Match PUBLIC : organisateur inclus + paiement à l’avance, rejoindre en payant, max 4 joueurs
- Calcul match : montantTotal / montantPaye / resteAPayer

### Tests
- Scénarios testés via Swagger : création site/terrain/joueurs, match public/privé, paiement, match complet, règles SITE/LIBRE.