### PR TITLE
issue 14 : empêcher overlap terrain (1h30 + 15 min)

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -10,18 +10,37 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
-    List<MatchPadel> findByTerrainId(Long terrainId);
+
+    @Query("select m from MatchPadel m where m.terrain.id = :terrainId")
+    List<MatchPadel> findByTerrainId(@Param("terrainId") Long terrainId);
     List<MatchPadel> findByDateDebutBetween(LocalDateTime start, LocalDateTime end);
+    @Query("""
+        select m
+        from MatchPadel m
+        where m.terrain.id = :terrainId
+          and m.dateDebut between :start and :end
+        """)
+    List<MatchPadel> findByTerrainIdAndDateDebutBetween(@Param("terrainId") Long terrainId,
+                                                        @Param("start") LocalDateTime start,
+                                                        @Param("end") LocalDateTime end);
+    @Query("""
+        select (count(m) > 0)
+        from MatchPadel m
+        where m.terrain.id = :terrainId
+          and m.dateDebut between :start and :end
+        """)
+    boolean existsByTerrainIdAndDateDebutBetween(@Param("terrainId") Long terrainId,
+                                                 @Param("start") LocalDateTime start,
+                                                 @Param("end") LocalDateTime end);
 
     @Query("""
-select distinct m
-from MatchPadel m
-join fetch m.terrain t
-join fetch t.site
-join fetch m.organisateur o
-left join fetch m.participations p
-where m.id = :id
-""")
+        select distinct m
+        from MatchPadel m
+        join fetch m.terrain t
+        join fetch t.site
+        join fetch m.organisateur o
+        left join fetch m.participations p
+        where m.id = :id
+        """)
     Optional<MatchPadel> findByIdWithDetails(@Param("id") Long id);
 }
-

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -20,10 +20,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional
 public class MatchPadelService {
+
+    private static final long DUREE_MATCH_MIN = 90;
+    private static final long BUFFER_MIN = 15;
+    private static final long SLOT_MIN = DUREE_MATCH_MIN + BUFFER_MIN; // 105
 
     private final MatchPadelRepository matchPadelRepository;
     private final TerrainRepository terrainRepository;
@@ -114,12 +119,18 @@ public class MatchPadelService {
         Joueur organisateur = joueurRepository.findById(organisateurMatricule)
                 .orElseThrow(() -> new NotFoundException("Joueur introuvable"));
 
+        // Règle dette : dette si solde > 0
         if (organisateur.getSolde() != null && organisateur.getSolde().signum() > 0) {
             throw new BusinessException("Réservation impossible : dette en cours (" + organisateur.getSolde() + ").");
         }
 
+        // Fenêtres GLOBAL/SITE/LIBRE + règles site
         verifierDroitReservation(organisateur, terrain, dateDebut, now);
 
+        // Issue 14 : overlap terrain (durée match + buffer)
+        verifierTerrainDisponible(terrainId, dateDebut);
+
+        // Création match
         MatchPadel match = new MatchPadel(terrain, organisateur, dateDebut, visibilite);
         MatchPadel saved = matchPadelRepository.save(match);
 
@@ -134,6 +145,32 @@ public class MatchPadelService {
         return saved;
     }
 
+    private void verifierTerrainDisponible(Long terrainId, LocalDateTime newStart) {
+        if (terrainId == null) throw new BusinessException("Terrain obligatoire");
+        if (newStart == null) throw new BusinessException("Date début obligatoire");
+
+        LocalDateTime from = newStart.minusMinutes(SLOT_MIN);
+        LocalDateTime to = newStart.plusMinutes(SLOT_MIN);
+
+        List<MatchPadel> candidats =
+                matchPadelRepository.findByTerrainIdAndDateDebutBetween(terrainId, from, to);
+
+        LocalDateTime newEndBuffer = newStart.plusMinutes(SLOT_MIN);
+
+        for (MatchPadel existing : candidats) {
+            LocalDateTime existingStart = existing.getDateDebut();
+            if (existingStart == null) continue;
+
+            LocalDateTime existingEndBuffer = existingStart.plusMinutes(SLOT_MIN);
+
+            boolean overlap = existingStart.isBefore(newEndBuffer) && newStart.isBefore(existingEndBuffer);
+            if (overlap) {
+                throw new BusinessException(
+                        "Terrain indisponible : un match est déjà prévu sur ce terrain (1h30 + 15 minutes de battement)."
+                );
+            }
+        }
+    }
     private void verifierDroitReservation(Joueur orga,
                                           Terrain terrain,
                                           LocalDateTime dateDebut,
@@ -154,6 +191,10 @@ public class MatchPadelService {
                 if (orga.getSite() == null) {
                     throw new BusinessException("Joueur SITE sans site associé.");
                 }
+                if (terrain.getSite() == null) {
+                    throw new BusinessException("Terrain sans site associé.");
+                }
+
                 Long siteJoueur = orga.getSite().getId();
                 Long siteTerrain = terrain.getSite().getId();
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/service/MatchPadelServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/service/MatchPadelServiceTest.java
@@ -99,6 +99,7 @@ class MatchPadelServiceTest {
         assertEquals(new BigDecimal("20.00"), dto.getMontantPaye());
         assertEquals(Tarifs.PRIX_MATCH.subtract(new BigDecimal("20.00")), dto.getResteAPayer());
     }
+
     @Test
     void getMatchDto_montantPayeNull_considererZero() {
         MatchPadel m = mock(MatchPadel.class);
@@ -322,6 +323,67 @@ class MatchPadelServiceTest {
                 service.creerMatch(1L, "S0001", date, MatchVisibilite.PUBLIC));
     }
 
+    @Test
+    void creerMatch_refuse_si_terrain_occupe_overlap() {
+        Terrain t = mock(Terrain.class);
+        when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+
+        Joueur orga = mock(Joueur.class);
+        when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
+        when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
+
+        LocalDateTime date = LocalDateTime.now().plusDays(2);
+
+        MatchPadel existing = mock(MatchPadel.class);
+        when(existing.getDateDebut()).thenReturn(date.minusMinutes(30));
+
+        when(matchRepo.findByTerrainIdAndDateDebutBetween(eq(1L), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(List.of(existing));
+
+        assertThrows(BusinessException.class, () ->
+                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+
+        verify(matchRepo, never()).save(any());
+        verify(participationRepo, never()).save(any());
+        verify(soldeService, never()).debiter(anyString(), any());
+        verify(paiementService, never()).payerParticipation(anyLong(), any());
+    }
+
+    @Test
+    void creerMatch_ok_si_match_existant_finit_juste_a_la_limite_105min() {
+        Terrain t = mock(Terrain.class);
+        when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+
+        Joueur orga = mock(Joueur.class);
+        when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
+        when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
+
+        LocalDateTime date = LocalDateTime.now().plusDays(2);
+
+        MatchPadel existing = mock(MatchPadel.class);
+        when(existing.getDateDebut()).thenReturn(date.minusMinutes(105)); // pile à la limite
+
+        when(matchRepo.findByTerrainIdAndDateDebutBetween(eq(1L), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(List.of(existing));
+
+        MatchPadel savedMatch = mock(MatchPadel.class);
+        when(matchRepo.save(any(MatchPadel.class))).thenReturn(savedMatch);
+
+        Participation p = mock(Participation.class);
+        when(p.getId()).thenReturn(123L);
+        when(participationRepo.save(any(Participation.class))).thenReturn(p);
+
+        MatchPadel res = service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC);
+        assertSame(savedMatch, res);
+
+        verify(matchRepo).save(any(MatchPadel.class));
+        verify(participationRepo).save(any(Participation.class));
+        verify(soldeService).debiter(eq("G0001"), eq(Tarifs.PART_PAR_JOUEUR));
+        verify(paiementService).payerParticipation(eq(123L), eq(Tarifs.PART_PAR_JOUEUR));
+    }
+
     // ----------------
     // creerMatch happy paths
     // ----------------
@@ -337,6 +399,9 @@ class MatchPadelServiceTest {
         when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
         when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
         when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
+
+        when(matchRepo.findByTerrainIdAndDateDebutBetween(eq(1L), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(List.of());
 
         // save match
         MatchPadel savedMatch = mock(MatchPadel.class);


### PR DESCRIPTION
Ajout d’une règle métier lors de la création d’un match : un terrain ne peut pas être réservé si un autre match chevauche le créneau.

Un match bloque le terrain pendant 1h30 + 15 min de battement (soit 105 minutes).

Implémentation dans MatchPadelService avec récupération des matchs candidats via MatchPadelRepository.

Ajout de tests unitaires couvrant :

refus en cas de chevauchement,

acceptation à la limite exacte (+105 min).

Validation manuelle effectuée via Swagger (création OK, overlap refusé, limite OK).