### PR TITLE
Issue #30: horaires/fermetures sites + fermetures globales + tests

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/FermetureGlobaleController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/FermetureGlobaleController.java
@@ -1,0 +1,44 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.request.CreateFermetureGlobaleRequest;
+import be.ephec.padel.backend.dto.response.FermetureGlobaleDto;
+import be.ephec.padel.backend.mapper.FermetureGlobaleMapper;
+import be.ephec.padel.backend.model.entities.FermetureGlobale;
+import be.ephec.padel.backend.service.FermetureGlobaleService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/fermetures-globales")
+public class FermetureGlobaleController {
+
+    private final FermetureGlobaleService service;
+
+    public FermetureGlobaleController(FermetureGlobaleService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<FermetureGlobaleDto>> list() {
+        return ResponseEntity.ok(
+                service.lister().stream().map(FermetureGlobaleMapper::toDto).toList()
+        );
+    }
+
+    @PostMapping
+    public ResponseEntity<FermetureGlobaleDto> create(@Valid @RequestBody CreateFermetureGlobaleRequest req) {
+        FermetureGlobale created = service.creer(req);
+        URI location = URI.create("/api/v1/fermetures-globales/" + created.getId());
+        return ResponseEntity.created(location).body(FermetureGlobaleMapper.toDto(created));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.supprimer(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/SiteController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/SiteController.java
@@ -1,6 +1,7 @@
 package be.ephec.padel.backend.controller;
 
 import be.ephec.padel.backend.dto.request.CreateSiteRequest;
+import be.ephec.padel.backend.dto.request.UpdateSiteHorairesRequest;
 import be.ephec.padel.backend.dto.response.SiteDto;
 import be.ephec.padel.backend.mapper.SiteMapper;
 import be.ephec.padel.backend.model.entities.Site;
@@ -44,5 +45,13 @@ public class SiteController {
         return ResponseEntity.created(location)
                 .body(SiteMapper.toDto(created));
     }
+    @PutMapping("/{id}/horaires")
+    public ResponseEntity<SiteDto> updateHoraires(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateSiteHorairesRequest request) {
 
+        Site updated = siteService.updateHoraires(id, request);
+
+        return ResponseEntity.ok(SiteMapper.toDto(updated));
+    }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateFermetureGlobaleRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateFermetureGlobaleRequest.java
@@ -1,0 +1,18 @@
+package be.ephec.padel.backend.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public class CreateFermetureGlobaleRequest {
+
+    @NotNull
+    private LocalDate date;
+
+    private String motif;
+
+    public LocalDate getDate() { return date; }
+    public void setDate(LocalDate date) { this.date = date; }
+
+    public String getMotif() { return motif; }
+    public void setMotif(String motif) { this.motif = motif; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/UpdateSiteHorairesRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/UpdateSiteHorairesRequest.java
@@ -1,0 +1,42 @@
+package be.ephec.padel.backend.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
+
+public class UpdateSiteHorairesRequest {
+
+    @NotNull
+    private LocalTime heureOuverture;
+
+    @NotNull
+    private LocalTime heureFermeture;
+
+    private Set<DayOfWeek> joursFermeture;
+
+    public LocalTime getHeureOuverture() {
+        return heureOuverture;
+    }
+
+    public void setHeureOuverture(LocalTime heureOuverture) {
+        this.heureOuverture = heureOuverture;
+    }
+
+    public LocalTime getHeureFermeture() {
+        return heureFermeture;
+    }
+
+    public void setHeureFermeture(LocalTime heureFermeture) {
+        this.heureFermeture = heureFermeture;
+    }
+
+    public Set<DayOfWeek> getJoursFermeture() {
+        return joursFermeture;
+    }
+
+    public void setJoursFermeture(Set<DayOfWeek> joursFermeture) {
+        this.joursFermeture = joursFermeture;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/FermetureGlobaleDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/FermetureGlobaleDto.java
@@ -1,0 +1,20 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.time.LocalDate;
+
+public class FermetureGlobaleDto {
+
+    private Long id;
+    private LocalDate date;
+    private String motif;
+
+    public FermetureGlobaleDto(Long id, LocalDate date, String motif) {
+        this.id = id;
+        this.date = date;
+        this.motif = motif;
+    }
+
+    public Long getId() { return id; }
+    public LocalDate getDate() { return date; }
+    public String getMotif() { return motif; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/SiteDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/SiteDto.java
@@ -1,17 +1,37 @@
 package be.ephec.padel.backend.dto.response;
 
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
+
 public class SiteDto {
     private Long id;
     private String nom;
     private String ville;
 
-    public SiteDto(Long id, String nom, String ville) {
+    private LocalTime heureOuverture;
+    private LocalTime heureFermeture;
+    private Set<DayOfWeek> joursFermeture;
+
+    public SiteDto(Long id,
+                   String nom,
+                   String ville,
+                   LocalTime heureOuverture,
+                   LocalTime heureFermeture,
+                   Set<DayOfWeek> joursFermeture) {
         this.id = id;
         this.nom = nom;
         this.ville = ville;
+        this.heureOuverture = heureOuverture;
+        this.heureFermeture = heureFermeture;
+        this.joursFermeture = joursFermeture;
     }
 
     public Long getId() { return id; }
     public String getNom() { return nom; }
     public String getVille() { return ville; }
+
+    public LocalTime getHeureOuverture() { return heureOuverture; }
+    public LocalTime getHeureFermeture() { return heureFermeture; }
+    public Set<DayOfWeek> getJoursFermeture() { return joursFermeture; }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/FermetureGlobaleMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/FermetureGlobaleMapper.java
@@ -1,0 +1,14 @@
+package be.ephec.padel.backend.mapper;
+
+import be.ephec.padel.backend.dto.response.FermetureGlobaleDto;
+import be.ephec.padel.backend.model.entities.FermetureGlobale;
+
+public final class FermetureGlobaleMapper {
+
+    private FermetureGlobaleMapper() {}
+
+    public static FermetureGlobaleDto toDto(FermetureGlobale f) {
+        if (f == null) return null;
+        return new FermetureGlobaleDto(f.getId(), f.getDate(), f.getMotif());
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/SiteMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/SiteMapper.java
@@ -14,7 +14,10 @@ public final class SiteMapper {
         return new SiteDto(
                 site.getId(),
                 site.getNom(),
-                site.getVille()
+                site.getVille(),
+                site.getHeureOuverture(),
+                site.getHeureFermeture(),
+                site.getJoursFermeture()
         );
     }
 

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/FermetureGlobale.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/FermetureGlobale.java
@@ -1,0 +1,37 @@
+package be.ephec.padel.backend.model.entities;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "fermeture_globale",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"date_fermeture"})
+)
+public class FermetureGlobale {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "date_fermeture", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "motif")
+    private String motif;
+
+    public FermetureGlobale() {}
+
+    public FermetureGlobale(LocalDate date, String motif) {
+        this.date = date;
+        this.motif = motif;
+    }
+
+    public Long getId() { return id; }
+    public LocalDate getDate() { return date; }
+    public String getMotif() { return motif; }
+
+    public void setDate(LocalDate date) { this.date = date; }
+    public void setMotif(String motif) { this.motif = motif; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Site.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Site.java
@@ -2,8 +2,9 @@ package be.ephec.padel.backend.model.entities;
 
 import jakarta.persistence.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.*;
 
 @Entity
 @Table(name = "site")
@@ -19,6 +20,33 @@ public class Site {
     @Column(nullable = false)
     private String ville;
 
+    // ----------------------------
+    // Issue #30 : horaires + fermetures site
+    // ----------------------------
+
+    // TEMP (dev) : nullable=true pour éviter l’échec Hibernate sur SQL Server quand la table `site` contient déjà des lignes.
+// SQL Server n’autorise pas l’ajout d’une colonne NOT NULL sans DEFAULT sur une table non vide.
+// À remplacer par une vraie migration (Flyway/Liquibase) :
+// 1) ajouter colonne nullable, 2) backfill des valeurs, 3) passer NOT NULL (+ éventuellement DEFAULT).
+    @Column(name = "heure_ouverture", nullable = true)
+    private LocalTime heureOuverture;
+
+    @Column(name = "heure_fermeture", nullable = true)
+    private LocalTime heureFermeture;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+            name = "site_jour_fermeture",
+            joinColumns = @JoinColumn(name = "site_id")
+    )
+    @Column(name = "jour", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Set<DayOfWeek> joursFermeture = new HashSet<>();
+
+    // ----------------------------
+    // Relation terrains
+    // ----------------------------
+
     @OneToMany(mappedBy = "site",
             cascade = CascadeType.ALL,
             orphanRemoval = true)
@@ -31,6 +59,14 @@ public class Site {
         this.nom = nom;
         this.ville = ville;
     }
+    public Site(String nom, String ville, LocalTime heureOuverture, LocalTime heureFermeture) {
+        this.nom = nom;
+        this.ville = ville;
+        this.heureOuverture = heureOuverture;
+        this.heureFermeture = heureFermeture;
+    }
+
+    // ---- Getters ----
 
     public Long getId() {
         return id;
@@ -48,6 +84,20 @@ public class Site {
         return terrains;
     }
 
+    public LocalTime getHeureOuverture() {
+        return heureOuverture;
+    }
+
+    public LocalTime getHeureFermeture() {
+        return heureFermeture;
+    }
+
+    public Set<DayOfWeek> getJoursFermeture() {
+        return joursFermeture;
+    }
+
+    // ---- Setters ----
+
     public void setNom(String nom) {
         this.nom = nom;
     }
@@ -55,6 +105,23 @@ public class Site {
     public void setVille(String ville) {
         this.ville = ville;
     }
+
+    public void setHeureOuverture(LocalTime heureOuverture) {
+        this.heureOuverture = heureOuverture;
+    }
+
+    public void setHeureFermeture(LocalTime heureFermeture) {
+        this.heureFermeture = heureFermeture;
+    }
+
+    public void setJoursFermeture(Set<DayOfWeek> joursFermeture) {
+        this.joursFermeture.clear();
+        if (joursFermeture != null) {
+            this.joursFermeture.addAll(joursFermeture);
+        }
+    }
+
+    // ---- Helpers ----
 
     public void addTerrain(Terrain terrain) {
         terrains.add(terrain);

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/FermetureGlobaleRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/FermetureGlobaleRepository.java
@@ -1,0 +1,10 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.FermetureGlobale;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface FermetureGlobaleRepository extends JpaRepository<FermetureGlobale, Long> {
+    boolean existsByDate(LocalDate date);
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/FermetureGlobaleService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/FermetureGlobaleService.java
@@ -1,0 +1,46 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.dto.request.CreateFermetureGlobaleRequest;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.FermetureGlobale;
+import be.ephec.padel.backend.repository.FermetureGlobaleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+public class FermetureGlobaleService {
+
+    private final FermetureGlobaleRepository repo;
+
+    public FermetureGlobaleService(FermetureGlobaleRepository repo) {
+        this.repo = repo;
+    }
+
+    @Transactional(readOnly = true)
+    public List<FermetureGlobale> lister() {
+        return repo.findAll();
+    }
+
+    public FermetureGlobale creer(CreateFermetureGlobaleRequest req) {
+        LocalDate date = req.getDate(); // @NotNull déjà, mais on reste safe
+        if (date == null) throw new BusinessException("Date de fermeture obligatoire");
+
+        if (repo.existsByDate(date)) {
+            throw new BusinessException("Une fermeture globale existe déjà pour cette date");
+        }
+
+        return repo.save(new FermetureGlobale(date, req.getMotif()));
+    }
+
+    public void supprimer(Long id) {
+        FermetureGlobale f = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Fermeture globale introuvable"));
+
+        repo.delete(f);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -4,19 +4,14 @@ import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.dto.response.MatchDto;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
-import be.ephec.padel.backend.model.entities.Joueur;
-import be.ephec.padel.backend.model.entities.MatchPadel;
-import be.ephec.padel.backend.model.entities.Participation;
-import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.entities.*;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
-import be.ephec.padel.backend.repository.JoueurRepository;
-import be.ephec.padel.backend.repository.MatchPadelRepository;
-import be.ephec.padel.backend.repository.PaiementRepository;
-import be.ephec.padel.backend.repository.ParticipationRepository;
-import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.repository.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -37,14 +32,14 @@ public class MatchPadelService {
     private final ParticipationRepository participationRepository;
     private final PaiementService paiementService;
     private final PaiementRepository paiementRepository;
-
+    private final FermetureGlobaleRepository fermetureGlobaleRepository;
     public MatchPadelService(MatchPadelRepository matchPadelRepository,
                              TerrainRepository terrainRepository,
                              JoueurRepository joueurRepository,
                              SoldeService soldeService,
                              ParticipationRepository participationRepository,
                              PaiementService paiementService,
-                             PaiementRepository paiementRepository) {
+                             PaiementRepository paiementRepository, FermetureGlobaleRepository fermetureGlobaleRepository) {
         this.matchPadelRepository = matchPadelRepository;
         this.terrainRepository = terrainRepository;
         this.joueurRepository = joueurRepository;
@@ -52,6 +47,7 @@ public class MatchPadelService {
         this.participationRepository = participationRepository;
         this.paiementService = paiementService;
         this.paiementRepository = paiementRepository;
+        this.fermetureGlobaleRepository = fermetureGlobaleRepository;
     }
 
     @Transactional(readOnly = true)
@@ -96,6 +92,49 @@ public class MatchPadelService {
         );
     }
 
+    private void verifierFermetureGlobale(LocalDateTime dateDebut) {
+        if (dateDebut == null) throw new BusinessException("Date début obligatoire");
+        if (fermetureGlobaleRepository.existsByDate(dateDebut.toLocalDate())) {
+            throw new BusinessException("Réservation impossible : fermeture globale (jour férié).");
+        }
+    }
+    private void verifierOuvertureSite(Terrain terrain, LocalDateTime dateDebut) {
+        if (terrain == null || terrain.getSite() == null) {
+            throw new BusinessException("Terrain sans site associé.");
+        }
+
+        Site site = terrain.getSite();
+
+        // Jour fermé ?
+        DayOfWeek jour = dateDebut.getDayOfWeek();
+        if (site.getJoursFermeture().contains(jour)) {
+            throw new BusinessException("Réservation impossible : site fermé ce jour-là.");
+        }
+
+        LocalTime ouverture = site.getHeureOuverture();
+        LocalTime fermeture = site.getHeureFermeture();
+        if (ouverture == null || fermeture == null) {
+            throw new BusinessException("Horaires d'ouverture non configurés pour ce site.");
+        }
+
+        // Horaires invalides
+        if (!ouverture.isBefore(fermeture)) {
+            throw new BusinessException("Horaires du site invalides (ouverture >= fermeture).");
+        }
+
+        LocalTime start = dateDebut.toLocalTime();
+        LocalTime end = dateDebut.plusMinutes(SLOT_MIN).toLocalTime(); // 105 min (match + battement)
+
+        // Si le créneau dépasse minuit, on refuse (hors scope)
+        if (end.isBefore(start)) {
+            throw new BusinessException("Réservation impossible : le créneau dépasse minuit.");
+        }
+
+        if (start.isBefore(ouverture) || end.isAfter(fermeture)) {
+            throw new BusinessException("Réservation impossible : en dehors des horaires d'ouverture.");
+        }
+    }
+
     public MatchPadel creerMatch(Long terrainId,
                                  String organisateurMatricule,
                                  LocalDateTime dateDebut,
@@ -124,10 +163,10 @@ public class MatchPadelService {
             throw new BusinessException("Réservation impossible : dette en cours (" + organisateur.getSolde() + ").");
         }
 
-        // Fenêtres GLOBAL/SITE/LIBRE + règles site
         verifierDroitReservation(organisateur, terrain, dateDebut, now);
 
-        // Issue 14 : overlap terrain (durée match + buffer)
+        verifierFermetureGlobale(dateDebut);
+        verifierOuvertureSite(terrain, dateDebut);
         verifierTerrainDisponible(terrainId, dateDebut);
 
         // Création match

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/SiteService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/SiteService.java
@@ -1,5 +1,6 @@
 package be.ephec.padel.backend.service;
 
+import be.ephec.padel.backend.dto.request.UpdateSiteHorairesRequest;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Site;
@@ -38,5 +39,25 @@ public class SiteService {
         }
 
         return siteRepository.save(new Site(nom, ville));
+    }
+    @Transactional
+    public Site updateHoraires(Long siteId, UpdateSiteHorairesRequest req) {
+
+        Site site = siteRepository.findById(siteId)
+                .orElseThrow(() -> new NotFoundException("Site introuvable"));
+
+        if (!req.getHeureOuverture().isBefore(req.getHeureFermeture())) {
+            throw new BusinessException("L'heure d'ouverture doit être avant l'heure de fermeture.");
+        }
+
+        site.setHeureOuverture(req.getHeureOuverture());
+        site.setHeureFermeture(req.getHeureFermeture());
+
+        site.getJoursFermeture().clear();
+        if (req.getJoursFermeture() != null) {
+            site.getJoursFermeture().addAll(req.getJoursFermeture());
+        }
+
+        return site;
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/controller/web/FermetureGlobaleControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/controller/web/FermetureGlobaleControllerTest.java
@@ -1,0 +1,86 @@
+package be.ephec.padel.backend.controller.web;
+
+import be.ephec.padel.backend.repository.FermetureGlobaleRepository;
+import be.ephec.padel.backend.repository.SqlServerTestContainerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FermetureGlobaleControllerTest extends SqlServerTestContainerConfig {
+
+    @Autowired MockMvc mvc;
+    @Autowired FermetureGlobaleRepository fermetureGlobaleRepository;
+
+    @BeforeEach
+    void clean() {
+        fermetureGlobaleRepository.deleteAll();
+    }
+
+    @Test
+    void post_cree_fermeture_globale_et_get_list_la_retourne() throws Exception {
+        mvc.perform(post("/api/v1/fermetures-globales")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "date": "2026-03-15", "motif": "Maintenance" }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", containsString("/api/v1/fermetures-globales/")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").isNumber())
+                .andExpect(jsonPath("$.date").value("2026-03-15"))
+                .andExpect(jsonPath("$.motif").value("Maintenance"));
+
+        mvc.perform(get("/api/v1/fermetures-globales"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].date").value("2026-03-15"));
+    }
+
+    @Test
+    void post_refuse_doublon_date() throws Exception {
+        mvc.perform(post("/api/v1/fermetures-globales")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"date\": \"2026-03-15\", \"motif\": \"A\" }"))
+                .andExpect(status().isCreated());
+
+        mvc.perform(post("/api/v1/fermetures-globales")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"date\": \"2026-03-15\", \"motif\": \"B\" }"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("existe déjà")));
+    }
+
+    @Test
+    void delete_supprime_et_retourne_204() throws Exception {
+        String body = "{ \"date\": \"2026-03-15\", \"motif\": \"Maintenance\" }";
+
+        String location = mvc.perform(post("/api/v1/fermetures-globales")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getHeader("Location");
+
+        // Location = /api/v1/fermetures-globales/{id}
+        String id = location.substring(location.lastIndexOf('/') + 1);
+
+        mvc.perform(delete("/api/v1/fermetures-globales/" + id))
+                .andExpect(status().isNoContent());
+
+        mvc.perform(get("/api/v1/fermetures-globales"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/controller/web/MatchCreationIntegrationTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/controller/web/MatchCreationIntegrationTest.java
@@ -1,0 +1,141 @@
+package be.ephec.padel.backend.controller.web;
+
+import be.ephec.padel.backend.model.entities.FermetureGlobale;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.*;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MatchCreationIntegrationTest extends SqlServerTestContainerConfig {
+
+    @Autowired MockMvc mvc;
+
+    @Autowired SiteRepository siteRepository;
+    @Autowired TerrainRepository terrainRepository;
+    @Autowired JoueurRepository joueurRepository;
+    @Autowired FermetureGlobaleRepository fermetureGlobaleRepository;
+
+    @Autowired MatchPadelRepository matchPadelRepository;
+    @Autowired ParticipationRepository participationRepository;
+    @Autowired PaiementRepository paiementRepository;
+    @Autowired MouvementSoldeRepository mouvementSoldeRepository;
+
+    private Site site;
+    private Terrain terrain;
+    private Joueur orga;
+
+    @BeforeEach
+    void cleanAndSeed() {
+        // Nettoyage (ordre important à cause des FK)
+        paiementRepository.deleteAll();
+        participationRepository.deleteAll();
+        matchPadelRepository.deleteAll();
+        mouvementSoldeRepository.deleteAll();
+        fermetureGlobaleRepository.deleteAll();
+        terrainRepository.deleteAll();
+        joueurRepository.deleteAll();
+        siteRepository.deleteAll();
+
+        // Seed minimal
+        site = new Site("Site IT", "Bruxelles", LocalTime.of(8, 0), LocalTime.of(22, 0));
+        site.setJoursFermeture(Set.of()); // ouvert tous les jours par défaut
+        site = siteRepository.save(site);
+
+        terrain = new Terrain("Terrain IT", site);
+        terrain = terrainRepository.save(terrain);
+
+        orga = new Joueur("G0001", "Orga Test", TypeJoueur.GLOBAL);
+        orga.setSolde(BigDecimal.ZERO); // sécurité si jamais
+        orga = joueurRepository.save(orga);
+    }
+
+    private String jsonCreateMatch(LocalDateTime dateDebut) {
+        // LocalDateTime -> format ISO "yyyy-MM-ddTHH:mm:ss" accepté par Jackson
+        return """
+                {
+                  "terrainId": %d,
+                  "organisateurMatricule": "%s",
+                  "dateDebut": "%s",
+                  "visibilite": "PUBLIC"
+                }
+                """.formatted(terrain.getId(), orga.getMatricule(), dateDebut.toString());
+    }
+
+    private static LocalDateTime nextDay(DayOfWeek day, int hour, int minute) {
+        LocalDate d = LocalDate.now().with(TemporalAdjusters.next(day));
+        return d.atTime(hour, minute);
+    }
+
+    @Test
+    void postMatch_refuse_si_fermeture_globale() throws Exception {
+        LocalDateTime date = nextDay(DayOfWeek.TUESDAY, 10, 0);
+        fermetureGlobaleRepository.save(new FermetureGlobale(date.toLocalDate(), "Férié"));
+
+        mvc.perform(post("/api/v1/matchs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonCreateMatch(date)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("fermeture globale")));
+    }
+
+    @Test
+    void postMatch_refuse_si_site_ferme_ce_jour() throws Exception {
+        LocalDateTime date = nextDay(DayOfWeek.SUNDAY, 10, 0);
+
+        site.setJoursFermeture(Set.of(DayOfWeek.SUNDAY));
+        siteRepository.save(site);
+
+        mvc.perform(post("/api/v1/matchs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonCreateMatch(date)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("site fermé")));
+    }
+
+    @Test
+    void postMatch_refuse_si_hors_horaires_fin_depasse_fermeture() throws Exception {
+        // 21:30 + 105 minutes => dépasse 22:00 => refus
+        LocalDateTime date = nextDay(DayOfWeek.WEDNESDAY, 21, 30);
+
+        mvc.perform(post("/api/v1/matchs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonCreateMatch(date)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("en dehors des horaires")));
+    }
+
+    @Test
+    void postMatch_ok_si_site_ouvert_et_dans_horaires_et_pas_de_fermeture_globale() throws Exception {
+        LocalDateTime date = nextDay(DayOfWeek.THURSDAY, 10, 0);
+
+        mvc.perform(post("/api/v1/matchs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonCreateMatch(date)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", containsString("/api/v1/matchs/")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").isNumber());
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/service/MatchPadelServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/service/MatchPadelServiceTest.java
@@ -13,8 +13,10 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -29,6 +31,7 @@ class MatchPadelServiceTest {
     private ParticipationRepository participationRepo;
     private PaiementService paiementService;
     private PaiementRepository paiementRepo;
+    private FermetureGlobaleRepository fermetureGlobaleRepo;
 
     private MatchPadelService service;
 
@@ -41,12 +44,41 @@ class MatchPadelServiceTest {
         participationRepo = mock(ParticipationRepository.class);
         paiementService = mock(PaiementService.class);
         paiementRepo = mock(PaiementRepository.class);
+        fermetureGlobaleRepo = mock(FermetureGlobaleRepository.class);
 
         service = new MatchPadelService(
                 matchRepo, terrainRepo, joueurRepo,
                 soldeService, participationRepo,
-                paiementService, paiementRepo
+                paiementService, paiementRepo,
+                fermetureGlobaleRepo
         );
+    }
+
+    // ----------------
+    // Helpers
+    // ----------------
+
+    private LocalDateTime dateValide() {
+        return LocalDateTime.now()
+                .plusDays(2)
+                .withHour(10).withMinute(0).withSecond(0).withNano(0);
+    }
+
+    private void stubSiteOuvert(Terrain t) {
+        Site site = mock(Site.class);
+        when(t.getSite()).thenReturn(site);
+
+        when(site.getHeureOuverture()).thenReturn(LocalTime.of(8, 0));
+        when(site.getHeureFermeture()).thenReturn(LocalTime.of(22, 0));
+        when(site.getJoursFermeture()).thenReturn(Set.of());
+    }
+
+    private Joueur stubOrgaGlobalSansDette(String matricule) {
+        Joueur orga = mock(Joueur.class);
+        when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
+        when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
+        when(joueurRepo.findById(matricule)).thenReturn(Optional.of(orga));
+        return orga;
     }
 
     // ----------------
@@ -61,10 +93,9 @@ class MatchPadelServiceTest {
 
     @Test
     void getMatchDto_calcule_montants_et_nbParticipants() {
-        // Match mocké
         MatchPadel m = mock(MatchPadel.class);
         when(m.getId()).thenReturn(1L);
-        when(m.getDateDebut()).thenReturn(LocalDateTime.now().plusDays(1));
+        when(m.getDateDebut()).thenReturn(dateValide());
         when(m.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
 
         Terrain t = mock(Terrain.class);
@@ -80,10 +111,8 @@ class MatchPadelServiceTest {
         when(m.getOrganisateur()).thenReturn(orga);
 
         when(m.getParticipations()).thenReturn(List.of(mock(Participation.class), mock(Participation.class)));
-
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(m));
 
-        // payé 20 sur un prix match (Tarifs.PRIX_MATCH)
         when(paiementRepo.sumMontantByMatchId(1L)).thenReturn(new BigDecimal("20.00"));
 
         MatchDto dto = service.getMatchDto(1L);
@@ -104,7 +133,7 @@ class MatchPadelServiceTest {
     void getMatchDto_montantPayeNull_considererZero() {
         MatchPadel m = mock(MatchPadel.class);
         when(m.getId()).thenReturn(1L);
-        when(m.getDateDebut()).thenReturn(LocalDateTime.now().plusDays(1));
+        when(m.getDateDebut()).thenReturn(dateValide());
         when(m.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
         when(m.getParticipations()).thenReturn(List.of());
 
@@ -121,7 +150,7 @@ class MatchPadelServiceTest {
     void getMatchDto_resteJamaisNegatif() {
         MatchPadel m = mock(MatchPadel.class);
         when(m.getId()).thenReturn(1L);
-        when(m.getDateDebut()).thenReturn(LocalDateTime.now().plusDays(1));
+        when(m.getDateDebut()).thenReturn(dateValide());
         when(m.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
         when(m.getParticipations()).thenReturn(List.of());
 
@@ -140,14 +169,14 @@ class MatchPadelServiceTest {
     @Test
     void creerMatch_terrainIdNull_refuse() {
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(null, "G0001", LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC));
+                service.creerMatch(null, "G0001", dateValide(), MatchVisibilite.PUBLIC));
         verifyNoInteractions(matchRepo, terrainRepo, joueurRepo, participationRepo, soldeService, paiementService);
     }
 
     @Test
     void creerMatch_organisateurBlank_refuse() {
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "   ", LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, "   ", dateValide(), MatchVisibilite.PUBLIC));
         verifyNoInteractions(matchRepo, terrainRepo, joueurRepo, participationRepo, soldeService, paiementService);
     }
 
@@ -161,7 +190,7 @@ class MatchPadelServiceTest {
     @Test
     void creerMatch_visibiliteNull_refuse() {
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", LocalDateTime.now().plusDays(1), null));
+                service.creerMatch(1L, "G0001", dateValide(), null));
         verifyNoInteractions(matchRepo, terrainRepo, joueurRepo, participationRepo, soldeService, paiementService);
     }
 
@@ -178,7 +207,7 @@ class MatchPadelServiceTest {
         when(terrainRepo.findById(1L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class, () ->
-                service.creerMatch(1L, "G0001", LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, "G0001", dateValide(), MatchVisibilite.PUBLIC));
 
         verifyNoInteractions(joueurRepo, matchRepo, participationRepo, soldeService, paiementService);
     }
@@ -190,7 +219,7 @@ class MatchPadelServiceTest {
         when(joueurRepo.findById("G0001")).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class, () ->
-                service.creerMatch(1L, "G0001", LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, "G0001", dateValide(), MatchVisibilite.PUBLIC));
 
         verifyNoInteractions(matchRepo, participationRepo, soldeService, paiementService);
     }
@@ -199,13 +228,14 @@ class MatchPadelServiceTest {
     void creerMatch_refuse_si_dette_orga_positive() {
         Terrain t = mock(Terrain.class);
         when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+        stubSiteOuvert(t);
 
         Joueur orga = mock(Joueur.class);
         when(orga.getSolde()).thenReturn(new BigDecimal("0.01"));
         when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, "G0001", dateValide(), MatchVisibilite.PUBLIC));
 
         verifyNoInteractions(matchRepo, participationRepo, soldeService, paiementService);
     }
@@ -218,38 +248,34 @@ class MatchPadelServiceTest {
     void creerMatch_global_tropLoin_refuse() {
         Terrain t = mock(Terrain.class);
         when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+        stubSiteOuvert(t);
 
         Joueur orga = mock(Joueur.class);
         when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
         when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
         when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
 
-        // > 3 semaines
         LocalDateTime date = LocalDateTime.now().plusWeeks(3).plusMinutes(1);
 
         assertThrows(BusinessException.class, () ->
                 service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
-
-        verifyNoInteractions(matchRepo, participationRepo, soldeService, paiementService);
     }
 
     @Test
     void creerMatch_libre_tropLoin_refuse() {
         Terrain t = mock(Terrain.class);
         when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+        stubSiteOuvert(t);
 
         Joueur orga = mock(Joueur.class);
         when(orga.getType()).thenReturn(TypeJoueur.LIBRE);
         when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
         when(joueurRepo.findById("L0001")).thenReturn(Optional.of(orga));
 
-        // > 5 jours
         LocalDateTime date = LocalDateTime.now().plusDays(5).plusMinutes(1);
 
         assertThrows(BusinessException.class, () ->
                 service.creerMatch(1L, "L0001", date, MatchVisibilite.PUBLIC));
-
-        verifyNoInteractions(matchRepo, participationRepo, soldeService, paiementService);
     }
 
     @Test
@@ -268,7 +294,7 @@ class MatchPadelServiceTest {
 
         when(joueurRepo.findById("S0001")).thenReturn(Optional.of(orga));
 
-        LocalDateTime date = LocalDateTime.now().plusDays(1);
+        LocalDateTime date = dateValide();
 
         assertThrows(BusinessException.class, () ->
                 service.creerMatch(1L, "S0001", date, MatchVisibilite.PUBLIC));
@@ -293,7 +319,7 @@ class MatchPadelServiceTest {
 
         when(joueurRepo.findById("S0001")).thenReturn(Optional.of(orga));
 
-        LocalDateTime date = LocalDateTime.now().plusDays(1);
+        LocalDateTime date = dateValide();
 
         assertThrows(BusinessException.class, () ->
                 service.creerMatch(1L, "S0001", date, MatchVisibilite.PUBLIC));
@@ -316,24 +342,26 @@ class MatchPadelServiceTest {
         when(siteJoueur.getId()).thenReturn(1L);
         when(orga.getSite()).thenReturn(siteJoueur);
 
-        // > 2 semaines
         LocalDateTime date = LocalDateTime.now().plusWeeks(2).plusMinutes(1);
 
         assertThrows(BusinessException.class, () ->
                 service.creerMatch(1L, "S0001", date, MatchVisibilite.PUBLIC));
     }
 
+    // ----------------
+    // Issue 14 - overlap terrain
+    // ----------------
+
     @Test
     void creerMatch_refuse_si_terrain_occupe_overlap() {
         Terrain t = mock(Terrain.class);
         when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+        stubSiteOuvert(t);
+        when(fermetureGlobaleRepo.existsByDate(any())).thenReturn(false);
 
-        Joueur orga = mock(Joueur.class);
-        when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
-        when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
-        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
+        stubOrgaGlobalSansDette("G0001");
 
-        LocalDateTime date = LocalDateTime.now().plusDays(2);
+        LocalDateTime date = dateValide();
 
         MatchPadel existing = mock(MatchPadel.class);
         when(existing.getDateDebut()).thenReturn(date.minusMinutes(30));
@@ -343,27 +371,21 @@ class MatchPadelServiceTest {
 
         assertThrows(BusinessException.class, () ->
                 service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
-
-        verify(matchRepo, never()).save(any());
-        verify(participationRepo, never()).save(any());
-        verify(soldeService, never()).debiter(anyString(), any());
-        verify(paiementService, never()).payerParticipation(anyLong(), any());
     }
 
     @Test
     void creerMatch_ok_si_match_existant_finit_juste_a_la_limite_105min() {
         Terrain t = mock(Terrain.class);
         when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+        stubSiteOuvert(t);
+        when(fermetureGlobaleRepo.existsByDate(any())).thenReturn(false);
 
-        Joueur orga = mock(Joueur.class);
-        when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
-        when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
-        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
+        stubOrgaGlobalSansDette("G0001");
 
-        LocalDateTime date = LocalDateTime.now().plusDays(2);
+        LocalDateTime date = dateValide();
 
         MatchPadel existing = mock(MatchPadel.class);
-        when(existing.getDateDebut()).thenReturn(date.minusMinutes(105)); // pile à la limite
+        when(existing.getDateDebut()).thenReturn(date.minusMinutes(105));
 
         when(matchRepo.findByTerrainIdAndDateDebutBetween(eq(1L), any(LocalDateTime.class), any(LocalDateTime.class)))
                 .thenReturn(List.of(existing));
@@ -377,50 +399,121 @@ class MatchPadelServiceTest {
 
         MatchPadel res = service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC);
         assertSame(savedMatch, res);
-
-        verify(matchRepo).save(any(MatchPadel.class));
-        verify(participationRepo).save(any(Participation.class));
-        verify(soldeService).debiter(eq("G0001"), eq(Tarifs.PART_PAR_JOUEUR));
-        verify(paiementService).payerParticipation(eq(123L), eq(Tarifs.PART_PAR_JOUEUR));
     }
 
     // ----------------
-    // creerMatch happy paths
+    // Issue 30 - fermeture globale
     // ----------------
 
     @Test
-    void creerMatch_ok_global_cree_match_participation_debite_et_paye() {
-        // terrain
+    void creerMatch_refuse_si_fermeture_globale() {
         Terrain t = mock(Terrain.class);
         when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+        stubSiteOuvert(t);
 
-        // orga
-        Joueur orga = mock(Joueur.class);
-        when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
-        when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
-        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
+        stubOrgaGlobalSansDette("G0001");
+
+        LocalDateTime date = LocalDateTime.of(2026, 12, 25, 10, 0);
+        when(fermetureGlobaleRepo.existsByDate(date.toLocalDate())).thenReturn(true);
+
+        assertThrows(BusinessException.class, () ->
+                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+    }
+
+    @Test
+    void creerMatch_ok_si_pas_fermeture_globale() {
+        Terrain t = mock(Terrain.class);
+        when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+        stubSiteOuvert(t);
+
+        stubOrgaGlobalSansDette("G0001");
+
+        LocalDateTime date = dateValide();
+        when(fermetureGlobaleRepo.existsByDate(date.toLocalDate())).thenReturn(false);
 
         when(matchRepo.findByTerrainIdAndDateDebutBetween(eq(1L), any(LocalDateTime.class), any(LocalDateTime.class)))
                 .thenReturn(List.of());
 
-        // save match
         MatchPadel savedMatch = mock(MatchPadel.class);
         when(matchRepo.save(any(MatchPadel.class))).thenReturn(savedMatch);
 
-        // save participation orga -> doit avoir un id pour payerParticipation
         Participation p = mock(Participation.class);
         when(p.getId()).thenReturn(123L);
         when(participationRepo.save(any(Participation.class))).thenReturn(p);
 
-        LocalDateTime date = LocalDateTime.now().plusDays(2);
+        MatchPadel res = service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC);
+        assertSame(savedMatch, res);
+    }
+
+    // ----------------
+    // Issue 30 - horaires + jours fermeture site
+    // ----------------
+
+    @Test
+    void creerMatch_refuse_si_site_ferme_ce_jour() {
+        Terrain t = mock(Terrain.class);
+        when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+
+        Site site = mock(Site.class);
+        when(t.getSite()).thenReturn(site);
+
+        LocalDateTime date = dateValide();
+        when(site.getHeureOuverture()).thenReturn(LocalTime.of(8, 0));
+        when(site.getHeureFermeture()).thenReturn(LocalTime.of(22, 0));
+        when(site.getJoursFermeture()).thenReturn(Set.of(date.getDayOfWeek()));
+
+        stubOrgaGlobalSansDette("G0001");
+        when(fermetureGlobaleRepo.existsByDate(date.toLocalDate())).thenReturn(false);
+
+        assertThrows(BusinessException.class, () ->
+                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+    }
+
+    @Test
+    void creerMatch_refuse_si_hors_horaires_fin_depasse_fermeture() {
+        Terrain t = mock(Terrain.class);
+        when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+
+        Site site = mock(Site.class);
+        when(t.getSite()).thenReturn(site);
+
+        LocalDateTime date = LocalDateTime.now()
+                .plusDays(2)
+                .withHour(21).withMinute(30).withSecond(0).withNano(0);
+
+        when(site.getHeureOuverture()).thenReturn(LocalTime.of(8, 0));
+        when(site.getHeureFermeture()).thenReturn(LocalTime.of(22, 0));
+        when(site.getJoursFermeture()).thenReturn(Set.of());
+
+        stubOrgaGlobalSansDette("G0001");
+        when(fermetureGlobaleRepo.existsByDate(date.toLocalDate())).thenReturn(false);
+
+        assertThrows(BusinessException.class, () ->
+                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+    }
+
+    @Test
+    void creerMatch_ok_si_dans_horaires_et_site_ouvert() {
+        Terrain t = mock(Terrain.class);
+        when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+        stubSiteOuvert(t);
+
+        stubOrgaGlobalSansDette("G0001");
+
+        LocalDateTime date = dateValide();
+        when(fermetureGlobaleRepo.existsByDate(date.toLocalDate())).thenReturn(false);
+
+        when(matchRepo.findByTerrainIdAndDateDebutBetween(eq(1L), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(List.of());
+
+        MatchPadel savedMatch = mock(MatchPadel.class);
+        when(matchRepo.save(any(MatchPadel.class))).thenReturn(savedMatch);
+
+        Participation p = mock(Participation.class);
+        when(p.getId()).thenReturn(123L);
+        when(participationRepo.save(any(Participation.class))).thenReturn(p);
 
         MatchPadel res = service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC);
-
         assertSame(savedMatch, res);
-
-        verify(matchRepo).save(any(MatchPadel.class));
-        verify(participationRepo).save(any(Participation.class));
-        verify(soldeService).debiter(eq("G0001"), eq(Tarifs.PART_PAR_JOUEUR));
-        verify(paiementService).payerParticipation(eq(123L), eq(Tarifs.PART_PAR_JOUEUR));
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/service/SiteServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/service/SiteServiceTest.java
@@ -1,5 +1,6 @@
 package be.ephec.padel.backend.service;
 
+import be.ephec.padel.backend.dto.request.UpdateSiteHorairesRequest;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Site;
@@ -7,8 +8,11 @@ import be.ephec.padel.backend.repository.SiteRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -106,5 +110,69 @@ class SiteServiceTest {
 
         verify(siteRepo).existsByNom("Site A");
         verify(siteRepo).save(any(Site.class));
+    }
+
+    @Test
+    void updateHoraires_ok_met_a_jour_ouverture_fermeture_et_jours() {
+        // arrange
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepo.findById(1L)).thenReturn(Optional.of(site));
+
+        UpdateSiteHorairesRequest req = new UpdateSiteHorairesRequest();
+        req.setHeureOuverture(LocalTime.of(8, 0));
+        req.setHeureFermeture(LocalTime.of(22, 0));
+        req.setJoursFermeture(Set.of(DayOfWeek.SUNDAY));
+
+        // act
+        Site updated = service.updateHoraires(1L, req);
+
+        // assert
+        assertSame(site, updated);
+        assertEquals(LocalTime.of(8, 0), updated.getHeureOuverture());
+        assertEquals(LocalTime.of(22, 0), updated.getHeureFermeture());
+        assertTrue(updated.getJoursFermeture().contains(DayOfWeek.SUNDAY));
+
+        verify(siteRepo).findById(1L);
+        verifyNoMoreInteractions(siteRepo);
+    }
+
+    @Test
+    void updateHoraires_refuse_si_ouverture_apres_ou_egale_fermeture() {
+        // arrange
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepo.findById(1L)).thenReturn(Optional.of(site));
+
+        UpdateSiteHorairesRequest req = new UpdateSiteHorairesRequest();
+        req.setHeureOuverture(LocalTime.of(22, 0));
+        req.setHeureFermeture(LocalTime.of(22, 0)); // égal -> KO
+        req.setJoursFermeture(Set.of(DayOfWeek.MONDAY));
+
+        // act + assert
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> service.updateHoraires(1L, req));
+
+        assertTrue(ex.getMessage().toLowerCase().contains("ouverture"));
+
+        // le site ne doit pas être modifié
+        assertNull(site.getHeureOuverture());
+        assertNull(site.getHeureFermeture());
+        assertTrue(site.getJoursFermeture() == null || site.getJoursFermeture().isEmpty());
+
+        verify(siteRepo).findById(1L);
+        verifyNoMoreInteractions(siteRepo);
+    }
+
+    // (optionnel mais utile)
+    @Test
+    void updateHoraires_site_introuvable_notFound() {
+        when(siteRepo.findById(99L)).thenReturn(Optional.empty());
+
+        UpdateSiteHorairesRequest req = new UpdateSiteHorairesRequest();
+        req.setHeureOuverture(LocalTime.of(8, 0));
+        req.setHeureFermeture(LocalTime.of(22, 0));
+
+        assertThrows(NotFoundException.class, () -> service.updateHoraires(99L, req));
+        verify(siteRepo).findById(99L);
+        verifyNoMoreInteractions(siteRepo);
     }
 }


### PR DESCRIPTION
Ajout horaires ouverture/fermeture + jours fermés par site (DayOfWeek)

Ajout fermetures globales (LocalDate) + endpoints REST

Refus création match si fermeture globale / jour fermé / hors horaires

Ajout tests : MatchCreationIntegrationTest + FermetureGlobaleControllerTest