### PR TITLE
Issue #40: implémentation premier paye premier servi et test

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -1,7 +1,9 @@
 package be.ephec.padel.backend.repository;
 
 import be.ephec.padel.backend.model.entities.MatchPadel;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -32,7 +34,6 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
     boolean existsByTerrainIdAndDateDebutBetween(@Param("terrainId") Long terrainId,
                                                  @Param("start") LocalDateTime start,
                                                  @Param("end") LocalDateTime end);
-
     @Query("""
         select distinct m
         from MatchPadel m
@@ -43,4 +44,13 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
         where m.id = :id
         """)
     Optional<MatchPadel> findByIdWithDetails(@Param("id") Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select m from MatchPadel m
+        left join fetch m.participations p
+        left join fetch p.joueur
+        where m.id = :id
+    """)
+    Optional<MatchPadel> findByIdForUpdateWithParticipations(@Param("id") Long id);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 @Service
 @Transactional
@@ -40,23 +41,27 @@ public class ParticipationService {
     }
 
     public Participation rejoindreEtPayerMatchPublic(Long matchId, String joueurMatricule, BigDecimal montant) {
-        MatchPadel match = getMatchOrThrow(matchId);
+
+        MatchPadel match = matchPadelRepository.findByIdForUpdateWithParticipations(matchId)
+                .orElseThrow(() -> new NotFoundException("Match introuvable"));
 
         if (match.getVisibilite() != MatchVisibilite.PUBLIC) {
             throw new BusinessException("Match privé : seule l'organisation peut ajouter des joueurs.");
         }
 
-        // ✅ En match PUBLIC : paiement obligatoire et complet (= 15.00)
         BigDecimal m = validerMontantPublic(montant);
 
         Joueur joueur = getJoueurOrThrow(joueurMatricule);
 
         verifierNonDejaInscrit(matchId, joueurMatricule);
-        verifierPlaceDisponible(matchId);
+
+        // ✅ place dispo vérifiée sous verrou
+        if (match.getParticipations().size() >= 4) {
+            throw new BusinessException("Match déjà complet");
+        }
 
         Participation saved = participationRepository.save(new Participation(match, joueur));
 
-        // dette puis paiement immédiat (validation au paiement)
         soldeService.debiter(joueurMatricule, PART_JOUEUR);
         paiementService.payerParticipation(saved.getId(), m);
 
@@ -94,7 +99,7 @@ public class ParticipationService {
         if (montant == null) throw new BusinessException("Montant obligatoire");
         if (montant.signum() <= 0) throw new BusinessException("Montant invalide");
 
-        BigDecimal m = montant.setScale(2, BigDecimal.ROUND_HALF_UP);
+        BigDecimal m = montant.setScale(2, RoundingMode.HALF_UP);
         if (m.compareTo(PART_JOUEUR) != 0) {
             throw new BusinessException("Pour un match public, le paiement doit être de " + PART_JOUEUR);
         }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/service/ParticipationPremierPayePremierServiTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/service/ParticipationPremierPayePremierServiTest.java
@@ -1,0 +1,126 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.common.Tarifs;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Set;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ParticipationPremierPayePremierServiTest extends SqlServerTestContainerConfig {
+
+    @Autowired ParticipationService participationService;
+
+    @Autowired SiteRepository siteRepository;
+    @Autowired TerrainRepository terrainRepository;
+    @Autowired JoueurRepository joueurRepository;
+    @Autowired MatchPadelRepository matchPadelRepository;
+    @Autowired ParticipationRepository participationRepository;
+    @Autowired PaiementRepository paiementRepository;
+    @Autowired MouvementSoldeRepository mouvementSoldeRepository;
+
+    private MatchPadel match;
+    private Joueur j4;
+    private Joueur j5;
+
+    @BeforeEach
+    void setup() {
+        // Clean (ordre FK)
+        paiementRepository.deleteAll();
+        participationRepository.deleteAll();
+        matchPadelRepository.deleteAll();
+        mouvementSoldeRepository.deleteAll();
+        terrainRepository.deleteAll();
+        joueurRepository.deleteAll();
+        siteRepository.deleteAll();
+
+        Site site = new Site("Site", "Ville", LocalTime.of(8, 0), LocalTime.of(22, 0));
+        site.setJoursFermeture(Set.of());
+        site = siteRepository.save(site);
+
+        Terrain terrain = new Terrain("T1", site);
+        terrain = terrainRepository.save(terrain);
+
+        Joueur orga = new Joueur("G0001", "Orga", TypeJoueur.GLOBAL);
+        orga = joueurRepository.save(orga);
+
+        // Match PUBLIC dans le futur
+        match = new MatchPadel(terrain, orga, LocalDateTime.now().plusDays(2).withHour(10).withMinute(0).withSecond(0).withNano(0), MatchVisibilite.PUBLIC);
+        match = matchPadelRepository.save(match);
+
+        // 3 joueurs déjà inscrits (on remplit jusqu’à 3)
+        Joueur j1 = joueurRepository.save(new Joueur("G0002", "J1", TypeJoueur.GLOBAL));
+        Joueur j2 = joueurRepository.save(new Joueur("G0003", "J2", TypeJoueur.GLOBAL));
+        Joueur j3 = joueurRepository.save(new Joueur("G0004", "J3", TypeJoueur.GLOBAL));
+
+        participationRepository.save(new Participation(match, j1));
+        participationRepository.save(new Participation(match, j2));
+        participationRepository.save(new Participation(match, j3));
+
+        // 2 candidats concurrents pour la 4e place
+        j4 = joueurRepository.save(new Joueur("G0005", "J4", TypeJoueur.GLOBAL));
+        j5 = joueurRepository.save(new Joueur("G0006", "J5", TypeJoueur.GLOBAL));
+    }
+
+    @Test
+    void premier_paye_premier_servi_sur_derniere_place() throws Exception {
+        int threads = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+
+        Callable<Boolean> task1 = () -> runJoinPay(ready, start, match.getId(), j4.getMatricule());
+        Callable<Boolean> task2 = () -> runJoinPay(ready, start, match.getId(), j5.getMatricule());
+
+        Future<Boolean> f1 = executor.submit(task1);
+        Future<Boolean> f2 = executor.submit(task2);
+
+        // attendre que les 2 threads soient prêts, puis démarrer en même temps
+        ready.await(5, TimeUnit.SECONDS);
+        start.countDown();
+
+        boolean r1 = f1.get(10, TimeUnit.SECONDS);
+        boolean r2 = f2.get(10, TimeUnit.SECONDS);
+
+        executor.shutdownNow();
+
+        // exactement 1 succès
+        assertNotEquals(r1, r2);
+
+        // et au final : 4 participations max
+        int nb = participationRepository.countByMatch_Id(match.getId());
+        assertEquals(4, nb);
+    }
+
+    private boolean runJoinPay(CountDownLatch ready,
+                               CountDownLatch start,
+                               Long matchId,
+                               String matricule) throws InterruptedException {
+        ready.countDown();
+        start.await(5, TimeUnit.SECONDS);
+
+        try {
+            participationService.rejoindreEtPayerMatchPublic(matchId, matricule, Tarifs.PART_PAR_JOUEUR);
+            return true;
+        } catch (BusinessException ex) {
+            // l’un des deux doit tomber ici ("Match déjà complet")
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Ajout verrou pessimiste (PESSIMISTIC_WRITE) lors de l’inscription payante à un match PUBLIC

Vérification des places restantes sous verrou puis inscription + débit + paiement dans une transaction

Ajout test de concurrence (2 threads sur la dernière place) : 1 succès, 1 refus, max 4 participants

Et à la fin :