### PR TITLE
19# Validation + erreurs + Swagger (ApiErrorDto)

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/config/OpenApiConfig.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package be.ephec.padel.backend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("basicAuth",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("basic")
+                ))
+                .addSecurityItem(new SecurityRequirement().addList("basicAuth"));
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
@@ -1,15 +1,23 @@
 package be.ephec.padel.backend.controller;
 
 import be.ephec.padel.backend.dto.request.CreateMatchRequest;
+import be.ephec.padel.backend.dto.response.ApiErrorDto;
 import be.ephec.padel.backend.dto.response.MatchDto;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.service.MatchPadelService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
+@Tag(name = "Matchs", description = "Gestion des matchs de padel")
 @RestController
 @RequestMapping("/api/v1/matchs")
 public class MatchController {
@@ -20,11 +28,25 @@ public class MatchController {
         this.matchPadelService = matchPadelService;
     }
 
+    @Operation(summary = "Récupérer un match", description = "Retourne le match (DTO) par son identifiant.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Match trouvé"),
+            @ApiResponse(responseCode = "404", description = "Match introuvable",
+                    content = @Content(schema = @Schema(implementation = ApiErrorDto.class)))
+    })
     @GetMapping("/{id}")
     public ResponseEntity<MatchDto> getOne(@PathVariable Long id) {
         return ResponseEntity.ok(matchPadelService.getMatchDto(id));
     }
 
+    @Operation(summary = "Créer un match", description = "Crée un match (PUBLIC ou PRIVE) si les règles métier sont respectées.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Match créé"),
+            @ApiResponse(responseCode = "400", description = "Validation ou règle métier non respectée",
+                    content = @Content(schema = @Schema(implementation = ApiErrorDto.class))),
+            @ApiResponse(responseCode = "404", description = "Terrain / site / organisateur introuvable",
+                    content = @Content(schema = @Schema(implementation = ApiErrorDto.class)))
+    })
     @PostMapping
     public ResponseEntity<MatchDto> create(@Valid @RequestBody CreateMatchRequest req) {
         MatchPadel created = matchPadelService.creerMatch(

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateMatchRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateMatchRequest.java
@@ -1,20 +1,21 @@
 package be.ephec.padel.backend.dto.request;
 
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 import java.time.LocalDateTime;
 
 public class CreateMatchRequest {
 
     @NotNull
+    @Positive
     private Long terrainId;
 
     @NotBlank
     private String organisateurMatricule;
 
-    @NotNull
+    @NotNull(message = "Date de début obligatoire")
+    @Future(message = "La date de début doit être dans le futur")
     private LocalDateTime dateDebut;
 
     @NotNull

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateTerrainRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateTerrainRequest.java
@@ -2,6 +2,7 @@ package be.ephec.padel.backend.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public class CreateTerrainRequest {
 
@@ -9,6 +10,7 @@ public class CreateTerrainRequest {
     private String nom;
 
     @NotNull
+    @Positive
     private Long siteId;
 
     public String getNom() { return nom; }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/ApiErrorDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/ApiErrorDto.java
@@ -1,20 +1,32 @@
 package be.ephec.padel.backend.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 import java.util.Map;
 
+@Schema(description = "Format standard d'erreur renvoyé par l'API")
 public class ApiErrorDto {
 
+    @Schema(example = "2026-02-27T22:22:23.984853714")
     private LocalDateTime timestamp;
+
+    @Schema(example = "400")
     private int status;
+
+    @Schema(example = "Bad Request")
     private String error;
+
+    @Schema(example = "Validation failed")
     private String message;
+
+    @Schema(example = "/api/v1/matchs")
     private String path;
 
-    /**
-     * Optionnel : détails de validation (champ/param -> message).
-     * Null si pas applicable.
-     */
+    @Schema(
+            description = "Détails de validation (champ/param -> message). Null si pas applicable.",
+            example = "{\"dateDebut\":\"La date de début doit être dans le futur\",\"terrainId\":\"doit être supérieur à 0\"}"
+    )
     private Map<String, String> details;
 
     public ApiErrorDto() {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/error/ApiExceptionHandler.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/error/ApiExceptionHandler.java
@@ -8,13 +8,15 @@ import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RestControllerAdvice
@@ -50,14 +52,52 @@ public class ApiExceptionHandler {
         return ResponseEntity.badRequest().body(error);
     }
 
+    // ✅ 403 (auth ok, mais pas les droits)
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiErrorDto> handleAccessDenied(
+            AccessDeniedException ex,
+            HttpServletRequest request) {
+
+        ApiErrorDto error = buildError(
+                HttpStatus.FORBIDDEN,
+                "Access denied",
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+    }
+
+    // ✅ 401 (pas authentifié / auth invalide)
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiErrorDto> handleAuthentication(
+            AuthenticationException ex,
+            HttpServletRequest request) {
+
+        ApiErrorDto error = buildError(
+                HttpStatus.UNAUTHORIZED,
+                "Authentication required",
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiErrorDto> handleValidation(
             MethodArgumentNotValidException ex,
             HttpServletRequest request) {
 
-        Map<String, String> details = new HashMap<>();
-        ex.getBindingResult().getFieldErrors()
-                .forEach(err -> details.put(err.getField(), err.getDefaultMessage()));
+        // ✅ ne pas écraser : on garde le premier message et on concatène si plusieurs erreurs
+        Map<String, String> details = new LinkedHashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(err -> {
+            details.merge(
+                    err.getField(),
+                    err.getDefaultMessage(),
+                    (oldMsg, newMsg) -> oldMsg + "; " + newMsg
+            );
+        });
 
         ApiErrorDto error = buildError(
                 HttpStatus.BAD_REQUEST,
@@ -74,10 +114,11 @@ public class ApiExceptionHandler {
             ConstraintViolationException ex,
             HttpServletRequest request) {
 
-        Map<String, String> details = new HashMap<>();
-        ex.getConstraintViolations().forEach(v -> details.put(
+        Map<String, String> details = new LinkedHashMap<>();
+        ex.getConstraintViolations().forEach(v -> details.merge(
                 v.getPropertyPath().toString(),
-                v.getMessage()
+                v.getMessage(),
+                (oldMsg, newMsg) -> oldMsg + "; " + newMsg
         ));
 
         ApiErrorDto error = buildError(
@@ -127,7 +168,6 @@ public class ApiExceptionHandler {
             Exception ex,
             HttpServletRequest request) {
 
-        // Ne pas exposer les détails internes en production.
         ApiErrorDto error = buildError(
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 "Unexpected error",
@@ -151,7 +191,6 @@ public class ApiExceptionHandler {
         dto.setMessage(message);
         dto.setPath(path);
         dto.setDetails(details);
-
         return dto;
     }
 }


### PR DESCRIPTION
Validation DTO renforcée et @Valid vérifié sur les endpoints.

Gestion d’erreurs standardisée via ApiErrorDto (400/404/500 + détails de validation).

Swagger amélioré : ApiErrorDto documenté + réponses d’erreur sur endpoints clés + BasicAuth via Authorize.

mvn clean test OK.