### PR TITLE
feat(#51): admin stats (CA/matchs/dettes) + security tests

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminStatsController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminStatsController.java
@@ -1,0 +1,42 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
+import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
+import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
+import be.ephec.padel.backend.service.AdminStatsService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+import static org.springframework.format.annotation.DateTimeFormat.ISO;
+
+@RestController
+@RequestMapping("/api/v1/admin/stats")
+@Tag(name = "Admin Stats")
+public class AdminStatsController {
+
+    private final AdminStatsService adminStatsService;
+
+    public AdminStatsController(AdminStatsService adminStatsService) {
+        this.adminStatsService = adminStatsService;
+    }
+
+    @GetMapping("/ca")
+    public AdminCaStatsDto ca(@RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate from,
+                              @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate to) {
+        return adminStatsService.getCa(from, to);
+    }
+
+    @GetMapping("/matchs")
+    public AdminMatchsStatsDto matchs(@RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate from,
+                                      @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate to) {
+        return adminStatsService.getNbMatchs(from, to);
+    }
+
+    @GetMapping("/dettes")
+    public AdminDettesStatsDto dettes() {
+        return adminStatsService.getDettes();
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminCaStatsDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminCaStatsDto.java
@@ -1,0 +1,29 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class AdminCaStatsDto {
+
+    private final BigDecimal caTotal;
+    private final LocalDate from;
+    private final LocalDate to;
+
+    public AdminCaStatsDto(BigDecimal caTotal, LocalDate from, LocalDate to) {
+        this.caTotal = caTotal;
+        this.from = from;
+        this.to = to;
+    }
+
+    public BigDecimal getCaTotal() {
+        return caTotal;
+    }
+
+    public LocalDate getFrom() {
+        return from;
+    }
+
+    public LocalDate getTo() {
+        return to;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminDettesStatsDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminDettesStatsDto.java
@@ -1,0 +1,22 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.math.BigDecimal;
+
+public class AdminDettesStatsDto {
+
+    private final BigDecimal detteTotale;
+    private final long nbJoueursEnDette;
+
+    public AdminDettesStatsDto(BigDecimal detteTotale, long nbJoueursEnDette) {
+        this.detteTotale = detteTotale;
+        this.nbJoueursEnDette = nbJoueursEnDette;
+    }
+
+    public BigDecimal getDetteTotale() {
+        return detteTotale;
+    }
+
+    public long getNbJoueursEnDette() {
+        return nbJoueursEnDette;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminMatchsStatsDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminMatchsStatsDto.java
@@ -1,0 +1,28 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.time.LocalDate;
+
+public class AdminMatchsStatsDto {
+
+    private final long nbMatchs;
+    private final LocalDate from;
+    private final LocalDate to;
+
+    public AdminMatchsStatsDto(long nbMatchs, LocalDate from, LocalDate to) {
+        this.nbMatchs = nbMatchs;
+        this.from = from;
+        this.to = to;
+    }
+
+    public long getNbMatchs() {
+        return nbMatchs;
+    }
+
+    public LocalDate getFrom() {
+        return from;
+    }
+
+    public LocalDate getTo() {
+        return to;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/JoueurRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/JoueurRepository.java
@@ -2,11 +2,27 @@ package be.ephec.padel.backend.repository;
 
 import be.ephec.padel.backend.model.entities.Joueur;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 public interface JoueurRepository extends JpaRepository<Joueur, String> {
+
     Optional<Joueur> findById(String matricule); // déjà fourni par JpaRepository
     boolean existsById(String matricule);
-}
 
+    @Query("""
+        select coalesce(sum(j.solde), 0)
+        from Joueur j
+        where j.solde > 0
+    """)
+    BigDecimal sumDettes();
+
+    @Query("""
+        select count(j)
+        from Joueur j
+        where j.solde > 0
+    """)
+    long countJoueursEnDette();
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -79,4 +79,12 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
 """)
     List<MatchPadel> findAtraiterDebutMatchAvecDetails(@Param("from") LocalDateTime from,
                                                        @Param("to") LocalDateTime to);
+    @Query("""
+    select count(m)
+    from MatchPadel m
+    where m.dateDebut >= :from
+      and m.dateDebut < :to
+""")
+    long countByDateDebutBetween(@Param("from") LocalDateTime from,
+                                 @Param("to") LocalDateTime to);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
@@ -4,6 +4,7 @@ import be.ephec.padel.backend.model.entities.Paiement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import java.time.LocalDateTime;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -28,4 +29,12 @@ public interface PaiementRepository extends JpaRepository<Paiement, Long> {
     where m.id = :matchId
 """)
     BigDecimal sumMontantByMatchId(@Param("matchId") Long matchId);
+    @Query("""
+    select coalesce(sum(p.montant), 0)
+    from Paiement p
+    where p.datePaiement >= :from
+      and p.datePaiement < :to
+""")
+    BigDecimal sumMontantByDatePaiementBetween(@Param("from") LocalDateTime from,
+                                               @Param("to") LocalDateTime to);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminStatsService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminStatsService.java
@@ -1,0 +1,67 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
+import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
+import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@Transactional(readOnly = true)
+public class AdminStatsService {
+
+    private final PaiementRepository paiementRepository;
+    private final MatchPadelRepository matchPadelRepository;
+    private final JoueurRepository joueurRepository;
+
+    public AdminStatsService(PaiementRepository paiementRepository,
+                             MatchPadelRepository matchPadelRepository,
+                             JoueurRepository joueurRepository) {
+        this.paiementRepository = paiementRepository;
+        this.matchPadelRepository = matchPadelRepository;
+        this.joueurRepository = joueurRepository;
+    }
+
+    public AdminCaStatsDto getCa(LocalDate from, LocalDate to) {
+        validatePeriod(from, to);
+
+        LocalDateTime fromStart = from.atStartOfDay();
+        LocalDateTime toExclusive = to.plusDays(1).atStartOfDay();
+
+        BigDecimal ca = paiementRepository.sumMontantByDatePaiementBetween(fromStart, toExclusive);
+        return new AdminCaStatsDto(ca, from, to);
+    }
+
+    public AdminMatchsStatsDto getNbMatchs(LocalDate from, LocalDate to) {
+        validatePeriod(from, to);
+
+        LocalDateTime fromStart = from.atStartOfDay();
+        LocalDateTime toExclusive = to.plusDays(1).atStartOfDay();
+
+        long nb = matchPadelRepository.countByDateDebutBetween(fromStart, toExclusive);
+        return new AdminMatchsStatsDto(nb, from, to);
+    }
+
+    public AdminDettesStatsDto getDettes() {
+        BigDecimal detteTotale = joueurRepository.sumDettes();
+        long nbJoueursEnDette = joueurRepository.countJoueursEnDette();
+        return new AdminDettesStatsDto(detteTotale, nbJoueursEnDette);
+    }
+
+    private void validatePeriod(LocalDate from, LocalDate to) {
+        if (from == null || to == null) {
+            throw new BusinessException("Les paramètres 'from' et 'to' sont obligatoires.");
+        }
+        if (from.isAfter(to)) {
+            throw new BusinessException("La date 'from' doit être <= à la date 'to'.");
+        }
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminStatsControllerSecurityTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminStatsControllerSecurityTest.java
@@ -1,0 +1,136 @@
+package be.ephec.padel.backend.web.security;
+
+import be.ephec.padel.backend.config.SecurityConfig;
+import be.ephec.padel.backend.controller.AdminStatsController;
+import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
+import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
+import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
+import be.ephec.padel.backend.service.AdminStatsService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = AdminStatsController.class)
+@Import(SecurityConfig.class)
+class AdminStatsControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminStatsService adminStatsService;
+
+    // ---------- /ca ----------
+
+    @Test
+    void ca_sansAuthentification_retourne401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/stats/ca")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-31"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = {"USER"})
+    void ca_avecRoleNonAdmin_retourne403() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/stats/ca")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-31"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void ca_avecRoleAdmin_retourne200_etPayloadOk() throws Exception {
+        when(adminStatsService.getCa(any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(new AdminCaStatsDto(new BigDecimal("30.00"),
+                        LocalDate.of(2026, 1, 1),
+                        LocalDate.of(2026, 1, 31)));
+
+        mockMvc.perform(get("/api/v1/admin/stats/ca")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-31"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.caTotal").value(30.00))
+                .andExpect(jsonPath("$.from").value("2026-01-01"))
+                .andExpect(jsonPath("$.to").value("2026-01-31"));
+    }
+
+    // ---------- /matchs ----------
+
+    @Test
+    void matchs_sansAuthentification_retourne401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/stats/matchs")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-31"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = {"USER"})
+    void matchs_avecRoleNonAdmin_retourne403() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/stats/matchs")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-31"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void matchs_avecRoleAdmin_retourne200_etPayloadOk() throws Exception {
+        when(adminStatsService.getNbMatchs(any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(new AdminMatchsStatsDto(12,
+                        LocalDate.of(2026, 1, 1),
+                        LocalDate.of(2026, 1, 31)));
+
+        mockMvc.perform(get("/api/v1/admin/stats/matchs")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-31"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.nbMatchs").value(12))
+                .andExpect(jsonPath("$.from").value("2026-01-01"))
+                .andExpect(jsonPath("$.to").value("2026-01-31"));
+    }
+
+    // ---------- /dettes ----------
+
+    @Test
+    void dettes_sansAuthentification_retourne401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/stats/dettes"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = {"USER"})
+    void dettes_avecRoleNonAdmin_retourne403() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/stats/dettes"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void dettes_avecRoleAdmin_retourne200_etPayloadOk() throws Exception {
+        when(adminStatsService.getDettes())
+                .thenReturn(new AdminDettesStatsDto(new BigDecimal("45.00"), 3));
+
+        mockMvc.perform(get("/api/v1/admin/stats/dettes"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.detteTotale").value(45.00))
+                .andExpect(jsonPath("$.nbJoueursEnDette").value(3));
+    }
+}


### PR DESCRIPTION
## Objectif
Ajout des endpoints de statistiques côté admin :
- GET /api/v1/admin/stats/ca?from&to : chiffre d’affaires sur une période
- GET /api/v1/admin/stats/matchs?from&to : nombre de matchs sur une période
- GET /api/v1/admin/stats/dettes : dette totale + nombre de joueurs en dette

## Implémentation
- Validation de la période dans le service (paramètres `from`/`to` obligatoires + `from <= to`)
- Requêtes d’agrégation côté DB (SUM/COUNT) avec `COALESCE` pour renvoyer 0 si aucun résultat
- Endpoints protégés sous `/api/v1/admin/**` (rôle ADMIN)

## Tests / Vérifications
- Tests MockMvc de sécurité : 401 / 403 / 200 + vérification du payload JSON
- Vérification manuelle via Swagger UI : CA, dettes et nb de matchs affichés correctement

Closes #51