### PR TITLE
feat(#52): endpoint admin joueurs par site + tests sécurité

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminSiteController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminSiteController.java
@@ -1,0 +1,25 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.response.JoueurAdminDto;
+import be.ephec.padel.backend.service.AdminSiteService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/sites")
+@Tag(name = "Admin Sites")
+public class AdminSiteController {
+
+    private final AdminSiteService adminSiteService;
+
+    public AdminSiteController(AdminSiteService adminSiteService) {
+        this.adminSiteService = adminSiteService;
+    }
+
+    @GetMapping("/{siteId}/joueurs")
+    public List<JoueurAdminDto> getJoueurs(@PathVariable Long siteId) {
+        return adminSiteService.getJoueursBySite(siteId);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/JoueurAdminDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/JoueurAdminDto.java
@@ -1,0 +1,25 @@
+package be.ephec.padel.backend.dto.response;
+
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+
+import java.math.BigDecimal;
+
+public class JoueurAdminDto {
+
+    private final String matricule;
+    private final String nom;
+    private final TypeJoueur type;
+    private final BigDecimal solde;
+
+    public JoueurAdminDto(String matricule, String nom, TypeJoueur type, BigDecimal solde) {
+        this.matricule = matricule;
+        this.nom = nom;
+        this.type = type;
+        this.solde = solde;
+    }
+
+    public String getMatricule() { return matricule; }
+    public String getNom() { return nom; }
+    public TypeJoueur getType() { return type; }
+    public BigDecimal getSolde() { return solde; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/JoueurRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/JoueurRepository.java
@@ -5,12 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 public interface JoueurRepository extends JpaRepository<Joueur, String> {
 
     Optional<Joueur> findById(String matricule); // déjà fourni par JpaRepository
     boolean existsById(String matricule);
+    List<Joueur> findBySite_Id(Long siteId);
 
     @Query("""
         select coalesce(sum(j.solde), 0)

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminSiteService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminSiteService.java
@@ -1,0 +1,41 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.dto.response.JoueurAdminDto;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class AdminSiteService {
+
+    private final SiteRepository siteRepository;
+    private final JoueurRepository joueurRepository;
+
+    public AdminSiteService(SiteRepository siteRepository, JoueurRepository joueurRepository) {
+        this.siteRepository = siteRepository;
+        this.joueurRepository = joueurRepository;
+    }
+
+    public List<JoueurAdminDto> getJoueursBySite(Long siteId) {
+        if (!siteRepository.existsById(siteId)) {
+            throw new NotFoundException("Site introuvable: " + siteId);
+        }
+
+        List<Joueur> joueurs = joueurRepository.findBySite_Id(siteId);
+
+        return joueurs.stream()
+                .map(j -> new JoueurAdminDto(
+                        j.getMatricule(),
+                        j.getNom(),
+                        j.getType(),
+                        j.getSolde()
+                ))
+                .toList();
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminSiteControllerSecurityTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminSiteControllerSecurityTest.java
@@ -1,0 +1,73 @@
+package be.ephec.padel.backend.web.security;
+
+import be.ephec.padel.backend.config.SecurityConfig;
+import be.ephec.padel.backend.controller.AdminSiteController;
+import be.ephec.padel.backend.dto.response.JoueurAdminDto;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.service.AdminSiteService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = AdminSiteController.class)
+@Import(SecurityConfig.class)
+class AdminSiteControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminSiteService adminSiteService;
+
+    @Test
+    void sansAuth_retourne401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/sites/1/joueurs"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = {"USER"})
+    void nonAdmin_retourne403() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/sites/1/joueurs"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void admin_retourne200_etListe() throws Exception {
+        when(adminSiteService.getJoueursBySite(1L)).thenReturn(List.of(
+                new JoueurAdminDto("J001", "Dupont", TypeJoueur.SITE, new BigDecimal("15.00"))
+        ));
+
+        mockMvc.perform(get("/api/v1/admin/sites/1/joueurs"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$[0].matricule").value("J001"))
+                .andExpect(jsonPath("$[0].nom").value("Dupont"))
+                .andExpect(jsonPath("$[0].type").value("SITE"))
+                .andExpect(jsonPath("$[0].solde").value(15.00));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void admin_siteInexistant_retourne404() throws Exception {
+        when(adminSiteService.getJoueursBySite(eq(999L)))
+                .thenThrow(new NotFoundException("Site introuvable: 999"));
+
+        mockMvc.perform(get("/api/v1/admin/sites/999/joueurs"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Objectif
- Documentation d'utilisation (Swagger + Basic Auth + exemples)
- Ajout endpoint admin : GET /api/v1/admin/sites/{siteId}/joueurs

## Détails
- Endpoint protégé sous /api/v1/admin/** (ADMIN)
- DTO dédié (pas d'entité exposée)
- 404 si site inexistant

## Tests
- mvn clean test OK
- MockMvc : 401 / 403 / 200 (+ 404)

Closes #52