### PR TITLE
Issue #62 - Sécurisation endpoints sensibles + Swagger (Authorize)

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/config/OpenApiConfig.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/config/OpenApiConfig.java
@@ -1,8 +1,7 @@
 package be.ephec.padel.backend.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,11 +12,13 @@ public class OpenApiConfig {
     @Bean
     public OpenAPI openAPI() {
         final String schemeName = "basicAuth";
+
         return new OpenAPI()
-                .addSecurityItem(new SecurityRequirement().addList(schemeName))
-                .components(new Components().addSecuritySchemes(schemeName,
+                .components(new Components().addSecuritySchemes(
+                        schemeName,
                         new SecurityScheme()
                                 .type(SecurityScheme.Type.HTTP)
-                                .scheme("basic")));
+                                .scheme("basic")
+                ));
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.http.HttpMethod;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,27 +60,50 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
+        return http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+
+                        // Swagger / OpenAPI
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
 
-                        // Global-only
+                        // ===== ADMIN =====
+
+                        // Stats globales : ADMIN_GLOBAL uniquement
                         .requestMatchers("/api/v1/admin/stats/**").hasRole("ADMIN_GLOBAL")
 
-                        // Global ou Site
+                        // Endpoints admin par site : ADMIN_GLOBAL ou ADMIN_SITE
                         .requestMatchers("/api/v1/admin/sites/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")
+
+                        // Autres endpoints admin : ADMIN_GLOBAL ou ADMIN_SITE
                         .requestMatchers("/api/v1/admin/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")
 
-                        // API publique
+                        // ===== API publique mais avec exceptions sensibles (Issue 62) =====
+
+                        // Joueurs : listing + création réservés à l'admin global
+                        .requestMatchers(HttpMethod.GET, "/api/v1/joueurs").hasRole("ADMIN_GLOBAL")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/joueurs").hasRole("ADMIN_GLOBAL")
+
+                        // Sites : création + update horaires réservés à l'admin global
+                        .requestMatchers(HttpMethod.POST, "/api/v1/sites").hasRole("ADMIN_GLOBAL")
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/sites/*/horaires").hasRole("ADMIN_GLOBAL")
+
+                        // Terrains : création réservée à l'admin global
+                        .requestMatchers(HttpMethod.POST, "/api/v1/terrains").hasRole("ADMIN_GLOBAL")
+
+                        // Fermetures globales : création + suppression réservées à l'admin global
+                        .requestMatchers(HttpMethod.POST, "/api/v1/fermetures-globales").hasRole("ADMIN_GLOBAL")
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/fermetures-globales/*").hasRole("ADMIN_GLOBAL")
+
+                        // Tout le reste sous /api/v1 reste public (pour l’instant)
                         .requestMatchers("/api/v1/**").permitAll()
 
+                        // Fallback
                         .anyRequest().authenticated()
                 )
-                .httpBasic(Customizer.withDefaults());
-
-        return http.build();
+                .httpBasic(Customizer.withDefaults())
+                .build();
     }
 
     @Bean

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminGlobalController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminGlobalController.java
@@ -4,12 +4,14 @@ import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
 import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
 import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
 import be.ephec.padel.backend.service.AdminStatsService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.Map;
 
+@SecurityRequirement(name = "basicAuth")
 @RestController
 @RequestMapping("/api/v1/admin")
 public class AdminGlobalController {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminSiteController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminSiteController.java
@@ -6,6 +6,7 @@ import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
 import be.ephec.padel.backend.dto.response.JoueurAdminDto;
 import be.ephec.padel.backend.service.AdminSiteService;
 import be.ephec.padel.backend.service.AdminSiteStatsService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
+@SecurityRequirement(name = "basicAuth")
 @RestController
 @RequestMapping("/api/v1/admin/sites")
 @Tag(name = "Admin Site")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/FermetureGlobaleController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/FermetureGlobaleController.java
@@ -5,6 +5,7 @@ import be.ephec.padel.backend.dto.response.FermetureGlobaleDto;
 import be.ephec.padel.backend.mapper.FermetureGlobaleMapper;
 import be.ephec.padel.backend.model.entities.FermetureGlobale;
 import be.ephec.padel.backend.service.FermetureGlobaleService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,6 +30,7 @@ public class FermetureGlobaleController {
         );
     }
 
+    @SecurityRequirement(name = "basicAuth")
     @PostMapping
     public ResponseEntity<FermetureGlobaleDto> create(@Valid @RequestBody CreateFermetureGlobaleRequest req) {
         FermetureGlobale created = service.creer(req);
@@ -36,6 +38,7 @@ public class FermetureGlobaleController {
         return ResponseEntity.created(location).body(FermetureGlobaleMapper.toDto(created));
     }
 
+    @SecurityRequirement(name = "basicAuth")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         service.supprimer(id);

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/JoueurController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/JoueurController.java
@@ -6,6 +6,7 @@ import be.ephec.padel.backend.dto.response.JoueurDto;
 import be.ephec.padel.backend.mapper.JoueurMapper;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.service.JoueurService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +24,7 @@ public class JoueurController {
         this.joueurService = joueurService;
     }
 
+    @SecurityRequirement(name = "basicAuth")
     @GetMapping
     public ResponseEntity<List<JoueurDto>> list() {
         List<JoueurDto> dtos = joueurService.lister().stream()
@@ -43,6 +45,7 @@ public class JoueurController {
         return ResponseEntity.ok(new DetteDto(dette));
     }
 
+    @SecurityRequirement(name = "basicAuth")
     @PostMapping
     public ResponseEntity<JoueurDto> create(@Valid @RequestBody JoueurCreateRequest req) {
         Joueur created = joueurService.creerJoueur(

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/SiteController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/SiteController.java
@@ -6,6 +6,7 @@ import be.ephec.padel.backend.dto.response.SiteDto;
 import be.ephec.padel.backend.mapper.SiteMapper;
 import be.ephec.padel.backend.model.entities.Site;
 import be.ephec.padel.backend.service.SiteService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -37,6 +38,7 @@ public class SiteController {
         return ResponseEntity.ok(SiteMapper.toDto(site));
     }
 
+    @SecurityRequirement(name = "basicAuth")
     @PostMapping
     public ResponseEntity<SiteDto> create(@Valid @RequestBody CreateSiteRequest req) {
         Site created = siteService.creerSite(req.getNom(), req.getVille());
@@ -45,6 +47,8 @@ public class SiteController {
         return ResponseEntity.created(location)
                 .body(SiteMapper.toDto(created));
     }
+
+    @SecurityRequirement(name = "basicAuth")
     @PutMapping("/{id}/horaires")
     public ResponseEntity<SiteDto> updateHoraires(
             @PathVariable Long id,

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/TerrainController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/TerrainController.java
@@ -5,6 +5,7 @@ import be.ephec.padel.backend.dto.response.TerrainDto;
 import be.ephec.padel.backend.mapper.TerrainMapper;
 import be.ephec.padel.backend.model.entities.Terrain;
 import be.ephec.padel.backend.service.TerrainService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -43,6 +44,7 @@ public class TerrainController {
         return ResponseEntity.ok(TerrainMapper.toDto(terrain));
     }
 
+    @SecurityRequirement(name = "basicAuth")
     @PostMapping
     public ResponseEntity<TerrainDto> create(
             @Valid @RequestBody CreateTerrainRequest req) {

--- a/backend/backend/src/main/resources/application.properties
+++ b/backend/backend/src/main/resources/application.properties
@@ -3,6 +3,7 @@ spring.application.name=backend
 spring.datasource.url=jdbc:sqlserver://localhost:14333;databaseName=padel;encrypt=true;trustServerCertificate=true
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
+springdoc.enable-spring-security=false
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
@@ -13,3 +14,4 @@ app.security.admin.global.username=${ADMIN_GLOBAL_USERNAME}
 app.security.admin.global.password=${ADMIN_GLOBAL_PASSWORD}
 app.security.admin.site.password=${ADMIN_SITE_PASSWORD}
 app.security.admin.site.users=${ADMIN_SITE_USERS}
+

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/FermetureGlobaleControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/FermetureGlobaleControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.containsString;
@@ -26,13 +27,37 @@ class FermetureGlobaleControllerTest extends SqlServerTestContainerConfig {
         fermetureGlobaleRepository.deleteAll();
     }
 
+    // ===== Issue 62 : public refusé sur WRITE =====
+
     @Test
+    void public_ne_peut_pas_creer_401() throws Exception {
+        mvc.perform(post("/api/v1/fermetures-globales")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"date\":\"2026-03-15\",\"motif\":\"Maintenance\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void public_ne_peut_pas_supprimer_401() throws Exception {
+        mvc.perform(delete("/api/v1/fermetures-globales/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // GET reste public
+    @Test
+    void get_list_public_ok_200() throws Exception {
+        mvc.perform(get("/api/v1/fermetures-globales"))
+                .andExpect(status().isOk());
+    }
+
+    // ===== Admin global : WRITE autorisé =====
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void post_cree_fermeture_globale_et_get_list_la_retourne() throws Exception {
         mvc.perform(post("/api/v1/fermetures-globales")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                { "date": "2026-03-15", "motif": "Maintenance" }
-                                """))
+                        .content("{\"date\":\"2026-03-15\",\"motif\":\"Maintenance\"}"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", containsString("/api/v1/fermetures-globales/")))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -47,33 +72,32 @@ class FermetureGlobaleControllerTest extends SqlServerTestContainerConfig {
     }
 
     @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void post_refuse_doublon_date() throws Exception {
         mvc.perform(post("/api/v1/fermetures-globales")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{ \"date\": \"2026-03-15\", \"motif\": \"A\" }"))
+                        .content("{\"date\":\"2026-03-15\",\"motif\":\"A\"}"))
                 .andExpect(status().isCreated());
 
         mvc.perform(post("/api/v1/fermetures-globales")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{ \"date\": \"2026-03-15\", \"motif\": \"B\" }"))
+                        .content("{\"date\":\"2026-03-15\",\"motif\":\"B\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.message").value(containsString("existe déjà")));
     }
 
     @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void delete_supprime_et_retourne_204() throws Exception {
-        String body = "{ \"date\": \"2026-03-15\", \"motif\": \"Maintenance\" }";
-
         String location = mvc.perform(post("/api/v1/fermetures-globales")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
+                        .content("{\"date\":\"2026-03-15\",\"motif\":\"Maintenance\"}"))
                 .andExpect(status().isCreated())
                 .andReturn()
                 .getResponse()
                 .getHeader("Location");
 
-        // Location = /api/v1/fermetures-globales/{id}
         String id = location.substring(location.lastIndexOf('/') + 1);
 
         mvc.perform(delete("/api/v1/fermetures-globales/" + id))

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/JoueurControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/JoueurControllerTest.java
@@ -12,8 +12,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -35,7 +37,33 @@ class JoueurControllerTest {
         return new Joueur(matricule, nom, type);
     }
 
+    // ===== Issue 62 : public doit être refusé sur listing / création =====
+
     @Test
+    void public_ne_peut_pas_lister_401() throws Exception {
+        mvc.perform(get("/api/v1/joueurs"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void public_ne_peut_pas_creer_401() throws Exception {
+        mvc.perform(post("/api/v1/joueurs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "matricule": "G0001",
+                                  "nom": "Alice",
+                                  "type": "GLOBAL",
+                                  "siteId": null
+                                }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ===== Admin global : listing / création autorisés =====
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void list_ok_200_jsonArray() throws Exception {
         when(joueurService.lister()).thenReturn(List.of(
                 realJoueur("G0001", "Alice", TypeJoueur.GLOBAL),
@@ -52,6 +80,8 @@ class JoueurControllerTest {
                 .andExpect(jsonPath("$[1].nom").value("Bob"))
                 .andExpect(jsonPath("$[1].type").value("LIBRE"));
     }
+
+    // ===== Endpoints publics conservés (pas d'auth "joueur" dans le projet) =====
 
     @Test
     void getOne_ok_200() throws Exception {
@@ -96,6 +126,7 @@ class JoueurControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void create_ok_201_location_et_body() throws Exception {
         Joueur created = realJoueur("G0001", "Alice", TypeJoueur.GLOBAL);
 
@@ -121,6 +152,7 @@ class JoueurControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void create_validation_400_si_body_invalide() throws Exception {
         mvc.perform(post("/api/v1/joueurs")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/SiteControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/SiteControllerTest.java
@@ -12,14 +12,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = SiteController.class)
@@ -84,7 +83,22 @@ class SiteControllerTest {
                 .andExpect(jsonPath("$.message").value("Site introuvable"));
     }
 
+    // ===== Issue 62 : public refusé sur WRITE =====
+
     @Test
+    void public_ne_peut_pas_creer_site_401() throws Exception {
+        mvc.perform(post("/api/v1/sites")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "nom": "Nouveau Site", "ville": "Charleroi" }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ===== Admin global : WRITE autorisé =====
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void create_ok_201_location_et_body() throws Exception {
         Site created = org.mockito.Mockito.mock(Site.class);
         when(created.getId()).thenReturn(123L);
@@ -94,7 +108,6 @@ class SiteControllerTest {
         when(siteService.creerSite(anyString(), anyString())).thenReturn(created);
 
         mvc.perform(post("/api/v1/sites")
-                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -111,9 +124,9 @@ class SiteControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void create_validation_400_nom_blank() throws Exception {
         mvc.perform(post("/api/v1/sites")
-                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -127,12 +140,12 @@ class SiteControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void create_business_400_nom_deja_utilise() throws Exception {
         when(siteService.creerSite("Dup", "Bruxelles"))
                 .thenThrow(new BusinessException("Nom de site déjà utilisé"));
 
         mvc.perform(post("/api/v1/sites")
-                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/TerrainControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/TerrainControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,10 +35,6 @@ class TerrainControllerTest {
     @MockitoBean
     TerrainService terrainService;
 
-    /**
-     * Construit de vraies entités JPA (pas des mocks Mockito) et force les IDs via ReflectionTestUtils.
-     * => évite UnfinishedStubbingException et problèmes de méthodes finales/proxies.
-     */
     private Terrain terrain(Long id, String nom, Long siteId) {
         Site s = new Site("SiteTest", "VilleTest");
         ReflectionTestUtils.setField(s, "id", siteId);
@@ -102,16 +99,27 @@ class TerrainControllerTest {
                 .andExpect(jsonPath("$.message").value("Terrain introuvable"));
     }
 
+    // ===== Issue 62 : public refusé sur WRITE =====
+
     @Test
+    void public_ne_peut_pas_creer_terrain_401() throws Exception {
+        mvc.perform(post("/api/v1/terrains")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nom\":\"T1\",\"siteId\":10}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ===== Admin global : WRITE autorisé =====
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void create_ok_201_location_et_body() throws Exception {
         when(terrainService.creerTerrain(eq("T1"), eq(10L)))
                 .thenReturn(terrain(123L, "T1", 10L));
 
         mvc.perform(post("/api/v1/terrains")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                { "nom": "T1", "siteId": 10 }
-                                """))
+                        .content("{\"nom\":\"T1\",\"siteId\":10}"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/api/v1/terrains/123"))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -121,6 +129,7 @@ class TerrainControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void create_validation_400_si_body_invalide() throws Exception {
         mvc.perform(post("/api/v1/terrains")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -130,15 +139,14 @@ class TerrainControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
     void create_businessException_400() throws Exception {
         when(terrainService.creerTerrain(eq("T1"), eq(10L)))
                 .thenThrow(new BusinessException("Terrain déjà existant"));
 
         mvc.perform(post("/api/v1/terrains")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                { "nom": "T1", "siteId": 10 }
-                                """))
+                        .content("{\"nom\":\"T1\",\"siteId\":10}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.message").value("Terrain déjà existant"));


### PR DESCRIPTION
Closes #62.

Sécurise les endpoints sensibles : GET/POST /joueurs, POST /sites, PUT /sites/{id}/horaires, POST /terrains, POST/DELETE /fermetures-globales → ADMIN_GLOBAL.

Swagger : Basic Auth via Authorize + cadenas uniquement sur les endpoints protégés (springdoc.enable-spring-security=false + @SecurityRequirement ciblés).

Tests controllers mis à jour/ajoutés pour couvrir 401 public et OK admin.