### PR TITLE
issue 53 : ajout du listing des matchs publics avec résumé et filtres

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
@@ -12,8 +12,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
+
+import java.time.LocalDate;
+import java.util.List;
 
 import java.net.URI;
 
@@ -59,5 +64,26 @@ public class MatchController {
         MatchDto dto = matchPadelService.getMatchDto(created.getId());
         URI location = URI.create("/api/v1/matchs/" + created.getId());
         return ResponseEntity.created(location).body(dto);
+    }
+    @Operation(
+            summary = "Lister les matchs publics",
+            description = "Retourne la liste des matchs PUBLIC avec un résumé utile pour le frontend."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Liste récupérée"),
+            @ApiResponse(responseCode = "400", description = "Paramètres invalides",
+                    content = @Content(schema = @Schema(implementation = ApiErrorDto.class)))
+    })
+    @GetMapping("/public")
+    public ResponseEntity<List<PublicMatchSummaryDto>> getPublicMatches(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate from,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate to,
+            @RequestParam(required = false) Long siteId) {
+
+        return ResponseEntity.ok(matchPadelService.getPublicMatchSummaries(from, to, siteId));
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PublicMatchSummaryDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PublicMatchSummaryDto.java
@@ -1,0 +1,66 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class PublicMatchSummaryDto {
+
+    private Long id;
+    private LocalDate dateDebut;
+    private LocalTime heureDebut;
+
+
+    private Long siteId;
+    private String siteNom;
+
+    private Long terrainId;
+    private String terrainNom;
+
+    private String organisateurMatricule;
+
+    private int nbParticipants;
+    private int placesRestantes;
+    private boolean complet;
+
+    private BigDecimal montantParJoueur;
+
+    public PublicMatchSummaryDto(Long id,
+                                 LocalDate dateDebut,
+                                 LocalTime heureDebut,
+                                 Long siteId,
+                                 String siteNom,
+                                 Long terrainId,
+                                 String terrainNom,
+                                 String organisateurMatricule,
+                                 int nbParticipants,
+                                 int placesRestantes,
+                                 boolean complet,
+                                 BigDecimal montantParJoueur) {
+        this.id = id;
+        this.dateDebut = dateDebut;
+        this.heureDebut = heureDebut;
+        this.siteId = siteId;
+        this.siteNom = siteNom;
+        this.terrainId = terrainId;
+        this.terrainNom = terrainNom;
+        this.organisateurMatricule = organisateurMatricule;
+        this.nbParticipants = nbParticipants;
+        this.placesRestantes = placesRestantes;
+        this.complet = complet;
+        this.montantParJoueur = montantParJoueur;
+    }
+
+    public Long getId() { return id; }
+    public LocalDate getDateDebut() { return dateDebut; }
+    public LocalTime getHeureDebut() { return heureDebut; }
+    public Long getSiteId() { return siteId; }
+    public String getSiteNom() { return siteNom; }
+    public Long getTerrainId() { return terrainId; }
+    public String getTerrainNom() { return terrainNom; }
+    public String getOrganisateurMatricule() { return organisateurMatricule; }
+    public int getNbParticipants() { return nbParticipants; }
+    public int getPlacesRestantes() { return placesRestantes; }
+    public boolean isComplet() { return complet; }
+    public BigDecimal getMontantParJoueur() { return montantParJoueur; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/PublicMatchSummaryMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/PublicMatchSummaryMapper.java
@@ -1,0 +1,36 @@
+package be.ephec.padel.backend.mapper;
+
+import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
+import be.ephec.padel.backend.repository.projection.PublicMatchSummaryProjection;
+
+import java.math.BigDecimal;
+
+public final class PublicMatchSummaryMapper {
+
+    private static final int CAPACITE_MATCH = 4;
+
+    private PublicMatchSummaryMapper() {
+    }
+
+    public static PublicMatchSummaryDto toDto(PublicMatchSummaryProjection p, BigDecimal montantParJoueur) {
+        int nbParticipants = (int) p.getNbParticipants();
+        int placesRestantes = Math.max(0, CAPACITE_MATCH - nbParticipants);
+        boolean complet = nbParticipants >= CAPACITE_MATCH;
+
+        return new PublicMatchSummaryDto(
+                p.getId(),
+                p.getDateDebut().toLocalDate(),
+                p.getDateDebut().toLocalTime().withSecond(0).withNano(0),
+                p.getSiteId(),
+                p.getSiteNom(),
+                p.getTerrainId(),
+                p.getTerrainNom(),
+                p.getOrganisateurMatricule(),
+                nbParticipants,
+                placesRestantes,
+                complet,
+                montantParJoueur
+        );
+
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.repository.projection.PublicMatchSummaryProjection;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -96,5 +98,38 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
           and m.terrain.site.id = :siteId
     """)
     long countByDateDebutBetweenAndSiteId(LocalDateTime from, LocalDateTime to, Long siteId);
+    @Query("""
+    select
+        m.id as id,
+        m.dateDebut as dateDebut,
+        s.id as siteId,
+        s.nom as siteNom,
+        t.id as terrainId,
+        t.nom as terrainNom,
+        o.matricule as organisateurMatricule,
+        count(p.id) as nbParticipants
+    from MatchPadel m
+    join m.terrain t
+    join t.site s
+    join m.organisateur o
+    left join m.participations p
+    where m.visibilite = :visibilite
+      and (:from is null or m.dateDebut >= :from)
+      and (:to is null or m.dateDebut <= :to)
+      and (:siteId is null or s.id = :siteId)
+    group by
+        m.id, m.dateDebut,
+        s.id, s.nom,
+        t.id, t.nom,
+        o.matricule
+    order by m.dateDebut asc
+""")
+    List<PublicMatchSummaryProjection> findPublicMatchSummaries(
+            @Param("visibilite") MatchVisibilite visibilite,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to,
+            @Param("siteId") Long siteId
+    );
+
 }
 

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/projection/PublicMatchSummaryProjection.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/projection/PublicMatchSummaryProjection.java
@@ -1,0 +1,19 @@
+package be.ephec.padel.backend.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface PublicMatchSummaryProjection {
+
+    Long getId();
+    LocalDateTime getDateDebut();
+
+    Long getSiteId();
+    String getSiteNom();
+
+    Long getTerrainId();
+    String getTerrainNom();
+
+    String getOrganisateurMatricule();
+
+    long getNbParticipants();
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -20,6 +20,12 @@ import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.TerrainRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
+import be.ephec.padel.backend.mapper.PublicMatchSummaryMapper;
+import be.ephec.padel.backend.repository.projection.PublicMatchSummaryProjection;
+
+import java.time.LocalDate;
+import java.util.stream.Collectors;
 
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
@@ -255,5 +261,33 @@ public class MatchPadelService {
             }
             default -> throw new BusinessException("Type joueur inconnu.");
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<PublicMatchSummaryDto> getPublicMatchSummaries(LocalDate from,
+                                                               LocalDate to,
+                                                               Long siteId) {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new BusinessException("Le paramètre 'from' doit être antérieur ou égal à 'to'.");
+        }
+
+        LocalDateTime fromDateTime = (from != null)
+                ? from.atStartOfDay()
+                : LocalDate.now().atStartOfDay();
+
+        LocalDateTime toDateTime = (to != null)
+                ? to.atTime(LocalTime.MAX)
+                : null;
+
+        List<PublicMatchSummaryProjection> rows = matchPadelRepository.findPublicMatchSummaries(
+                MatchVisibilite.PUBLIC,
+                fromDateTime,
+                toDateTime,
+                siteId
+        );
+
+        return rows.stream()
+                .map(row -> PublicMatchSummaryMapper.toDto(row, Tarifs.PART_PAR_JOUEUR))
+                .collect(Collectors.toList());
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/repository/MatchPadelRepositoryTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/repository/MatchPadelRepositoryTest.java
@@ -34,14 +34,22 @@ class MatchPadelRepositoryTest extends SqlServerTestContainerConfig {
 
         Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
 
-        MatchPadel m1 = matchPadelRepository.save(new MatchPadel(t1, orga, LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC));
-        MatchPadel m2 = matchPadelRepository.save(new MatchPadel(t1, orga, LocalDateTime.now().plusDays(2), MatchVisibilite.PRIVE));
-        matchPadelRepository.save(new MatchPadel(t2, orga, LocalDateTime.now().plusDays(3), MatchVisibilite.PUBLIC));
+        MatchPadel m1 = matchPadelRepository.save(
+                new MatchPadel(t1, orga, LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC)
+        );
+        MatchPadel m2 = matchPadelRepository.save(
+                new MatchPadel(t1, orga, LocalDateTime.now().plusDays(2), MatchVisibilite.PRIVE)
+        );
+        matchPadelRepository.save(
+                new MatchPadel(t2, orga, LocalDateTime.now().plusDays(3), MatchVisibilite.PUBLIC)
+        );
 
         List<MatchPadel> matchsT1 = matchPadelRepository.findByTerrainId(t1.getId());
 
         assertThat(matchsT1).hasSize(2);
-        assertThat(matchsT1).extracting(MatchPadel::getId).containsExactlyInAnyOrder(m1.getId(), m2.getId());
+        assertThat(matchsT1)
+                .extracting(MatchPadel::getId)
+                .containsExactlyInAnyOrder(m1.getId(), m2.getId());
     }
 
     @Test
@@ -64,7 +72,9 @@ class MatchPadelRepositoryTest extends SqlServerTestContainerConfig {
         );
 
         assertThat(res).hasSize(2);
-        assertThat(res).extracting(MatchPadel::getId).containsExactlyInAnyOrder(m1.getId(), m2.getId());
+        assertThat(res)
+                .extracting(MatchPadel::getId)
+                .containsExactlyInAnyOrder(m1.getId(), m2.getId());
     }
 
     @Test
@@ -75,16 +85,14 @@ class MatchPadelRepositoryTest extends SqlServerTestContainerConfig {
         Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
         Joueur j1 = joueurRepository.save(new Joueur("J001", "Alice", TypeJoueur.GLOBAL));
 
-        MatchPadel m = matchPadelRepository.save(new MatchPadel(
-                t, orga, LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC
-        ));
+        MatchPadel m = matchPadelRepository.save(
+                new MatchPadel(t, orga, LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC)
+        );
 
-        // Maintenir les 2 côtés (recommandé)
         Participation part = new Participation(m, j1);
         m.addParticipation(part);
         participationRepository.save(part);
 
-        // Important : forcer écriture DB + vider le contexte pour éviter de relire l'objet "cached"
         em.flush();
         em.clear();
 
@@ -104,5 +112,70 @@ class MatchPadelRepositoryTest extends SqlServerTestContainerConfig {
 
         assertThat(loaded.getParticipations()).hasSize(1);
         assertThat(loaded.getParticipations().get(0).getJoueur().getMatricule()).isEqualTo("J001");
+    }
+
+    @Test
+    void findPublicMatchSummaries_retourne_seulement_les_matchs_publics() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        MatchPadel publicMatch = matchPadelRepository.save(
+                new MatchPadel(t, orga, LocalDateTime.of(2030, 1, 1, 10, 0), MatchVisibilite.PUBLIC)
+        );
+        matchPadelRepository.save(
+                new MatchPadel(t, orga, LocalDateTime.of(2030, 1, 2, 10, 0), MatchVisibilite.PRIVE)
+        );
+
+        em.flush();
+        em.clear();
+
+        var rows = matchPadelRepository.findPublicMatchSummaries(
+                MatchVisibilite.PUBLIC,
+                null,
+                null,
+                null
+        );
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getId()).isEqualTo(publicMatch.getId());
+        assertThat(rows.get(0).getNbParticipants()).isEqualTo(0L);
+    }
+
+    @Test
+    void findPublicMatchSummaries_compte_correctement_les_participations() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+        Joueur j1 = joueurRepository.save(new Joueur("J001", "Alice", TypeJoueur.GLOBAL));
+        Joueur j2 = joueurRepository.save(new Joueur("J002", "Bob", TypeJoueur.GLOBAL));
+
+        MatchPadel publicMatch = matchPadelRepository.save(
+                new MatchPadel(t, orga, LocalDateTime.of(2030, 1, 1, 10, 0), MatchVisibilite.PUBLIC)
+        );
+
+        Participation p1 = new Participation(publicMatch, j1);
+        Participation p2 = new Participation(publicMatch, j2);
+
+        publicMatch.addParticipation(p1);
+        publicMatch.addParticipation(p2);
+
+        participationRepository.save(p1);
+        participationRepository.save(p2);
+
+        em.flush();
+        em.clear();
+
+        var rows = matchPadelRepository.findPublicMatchSummaries(
+                MatchVisibilite.PUBLIC,
+                null,
+                null,
+                null
+        );
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getId()).isEqualTo(publicMatch.getId());
+        assertThat(rows.get(0).getNbParticipants()).isEqualTo(2L);
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
@@ -13,8 +13,11 @@ import be.ephec.padel.backend.service.PaiementService;
 import be.ephec.padel.backend.service.SoldeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
+import be.ephec.padel.backend.repository.projection.PublicMatchSummaryProjection;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
@@ -518,5 +521,74 @@ class MatchPadelServiceTest {
 
         MatchPadel res = service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC);
         assertSame(savedMatch, res);
+    }
+    @Test
+    void getPublicMatchSummaries_calcule_placesRestantes_et_complet() {
+        PublicMatchSummaryProjection row = mock(PublicMatchSummaryProjection.class);
+
+        when(row.getId()).thenReturn(1L);
+        when(row.getDateDebut()).thenReturn(LocalDateTime.of(2030, 1, 1, 10, 0));
+        when(row.getSiteId()).thenReturn(5L);
+        when(row.getSiteNom()).thenReturn("Site Delta");
+        when(row.getTerrainId()).thenReturn(10L);
+        when(row.getTerrainNom()).thenReturn("Terrain 1");
+        when(row.getOrganisateurMatricule()).thenReturn("G0001");
+        when(row.getNbParticipants()).thenReturn(2L);
+
+        when(matchRepo.findPublicMatchSummaries(
+                eq(MatchVisibilite.PUBLIC),
+                any(LocalDateTime.class),
+                isNull(),
+                isNull()
+        )).thenReturn(List.of(row));
+
+        List<PublicMatchSummaryDto> dtos = service.getPublicMatchSummaries(null, null, null);
+
+        assertEquals(1, dtos.size());
+        PublicMatchSummaryDto dto = dtos.get(0);
+
+        assertEquals(1L, dto.getId());
+        assertEquals("Site Delta", dto.getSiteNom());
+        assertEquals("Terrain 1", dto.getTerrainNom());
+        assertEquals(2, dto.getNbParticipants());
+        assertEquals(2, dto.getPlacesRestantes());
+        assertFalse(dto.isComplet());
+        assertEquals(0, Tarifs.PART_PAR_JOUEUR.compareTo(dto.getMontantParJoueur()));
+    }
+    @Test
+    void getPublicMatchSummaries_match_complet_si_4_participants() {
+        PublicMatchSummaryProjection row = mock(PublicMatchSummaryProjection.class);
+
+        when(row.getId()).thenReturn(1L);
+        when(row.getDateDebut()).thenReturn(LocalDateTime.of(2030, 1, 1, 10, 0));
+        when(row.getSiteId()).thenReturn(5L);
+        when(row.getSiteNom()).thenReturn("Site Delta");
+        when(row.getTerrainId()).thenReturn(10L);
+        when(row.getTerrainNom()).thenReturn("Terrain 1");
+        when(row.getOrganisateurMatricule()).thenReturn("G0001");
+        when(row.getNbParticipants()).thenReturn(4L);
+
+        when(matchRepo.findPublicMatchSummaries(
+                eq(MatchVisibilite.PUBLIC),
+                any(LocalDateTime.class),
+                isNull(),
+                isNull()
+        )).thenReturn(List.of(row));
+
+        PublicMatchSummaryDto dto = service.getPublicMatchSummaries(null, null, null).get(0);
+
+        assertEquals(4, dto.getNbParticipants());
+        assertEquals(0, dto.getPlacesRestantes());
+        assertTrue(dto.isComplet());
+    }
+    @Test
+    void getPublicMatchSummaries_throw_businessException_si_from_apres_to() {
+        LocalDate from = LocalDate.of(2030, 2, 1);
+        LocalDate to = LocalDate.of(2030, 1, 1);
+
+        assertThrows(BusinessException.class,
+                () -> service.getPublicMatchSummaries(from, to, null));
+
+        verify(matchRepo, never()).findPublicMatchSummaries(any(), any(), any(), any());
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
@@ -3,8 +3,10 @@ package be.ephec.padel.backend.web.controller;
 import be.ephec.padel.backend.config.SecurityConfig;
 import be.ephec.padel.backend.controller.MatchController;
 import be.ephec.padel.backend.dto.response.MatchDto;
-import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
 import be.ephec.padel.backend.error.ApiExceptionHandler;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.service.MatchPadelService;
@@ -17,13 +19,24 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = MatchController.class)
 @Import({SecurityConfig.class, ApiExceptionHandler.class})
@@ -51,9 +64,22 @@ class MatchControllerTest {
         );
     }
 
-    // ----------------
-    // GET /api/v1/matchs/{id}  (PUBLIC car /api/v1/** permitAll)
-    // ----------------
+    private PublicMatchSummaryDto samplePublicSummary(Long id) {
+        return new PublicMatchSummaryDto(
+                id,
+                LocalDate.of(2030, 1, 1),
+                LocalTime.of(10, 0),
+                5L,
+                "Site Delta",
+                10L,
+                "Terrain 1",
+                "G0001",
+                2,
+                2,
+                false,
+                new BigDecimal("15.00")
+        );
+    }
 
     @Test
     void getOne_sansAuth_200_et_json() throws Exception {
@@ -69,7 +95,6 @@ class MatchControllerTest {
                 .andExpect(jsonPath("$.organisateurMatricule").value("G0001"))
                 .andExpect(jsonPath("$.visibilite").value("PUBLIC"))
                 .andExpect(jsonPath("$.nbParticipants").value(2))
-                // ✅ plus robuste: on compare la valeur numérique, pas le format (60 vs 60.0 vs 60.00)
                 .andExpect(jsonPath("$.montantTotal").value(60.0))
                 .andExpect(jsonPath("$.montantPaye").value(15.0))
                 .andExpect(jsonPath("$.resteAPayer").value(45.0));
@@ -77,24 +102,22 @@ class MatchControllerTest {
 
     @Test
     void getOne_notFound_404() throws Exception {
-        when(matchPadelService.getMatchDto(99L)).thenThrow(new NotFoundException("Match introuvable"));
+        when(matchPadelService.getMatchDto(99L))
+                .thenThrow(new NotFoundException("Match introuvable"));
 
         mvc.perform(get("/api/v1/matchs/99"))
                 .andExpect(status().isNotFound());
     }
 
-    // ----------------
-    // POST /api/v1/matchs  (PUBLIC car /api/v1/** permitAll)
-    // ----------------
-
     @Test
     void create_sansAuth_201_location_et_body() throws Exception {
-        // mock création -> renvoie MatchPadel avec id
-        MatchPadel created = org.mockito.Mockito.mock(MatchPadel.class);
+        MatchPadel created = mock(MatchPadel.class);
         when(created.getId()).thenReturn(123L);
 
-        when(matchPadelService.creerMatch(any(), any(), any(), any())).thenReturn(created);
-        when(matchPadelService.getMatchDto(123L)).thenReturn(sampleDto(123L));
+        when(matchPadelService.creerMatch(anyLong(), anyString(), any(), any()))
+                .thenReturn(created);
+        when(matchPadelService.getMatchDto(123L))
+                .thenReturn(sampleDto(123L));
 
         mvc.perform(post("/api/v1/matchs")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -117,6 +140,58 @@ class MatchControllerTest {
         mvc.perform(post("/api/v1/matchs")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getPublicMatches_sansAuth_200_et_json() throws Exception {
+        when(matchPadelService.getPublicMatchSummaries(null, null, null))
+                .thenReturn(List.of(samplePublicSummary(1L), samplePublicSummary(2L)));
+
+        mvc.perform(get("/api/v1/matchs/public"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].dateDebut").value("2030-01-01"))
+                .andExpect(jsonPath("$[0].heureDebut").value("10:00:00"))
+                .andExpect(jsonPath("$[0].siteNom").value("Site Delta"))
+                .andExpect(jsonPath("$[0].terrainNom").value("Terrain 1"))
+                .andExpect(jsonPath("$[0].nbParticipants").value(2))
+                .andExpect(jsonPath("$[0].placesRestantes").value(2))
+                .andExpect(jsonPath("$[0].complet").value(false))
+                .andExpect(jsonPath("$[0].montantParJoueur").value(15.0));
+    }
+
+    @Test
+    void getPublicMatches_avecFiltres_transmis_au_service() throws Exception {
+        LocalDate from = LocalDate.of(2030, 1, 1);
+        LocalDate to = LocalDate.of(2030, 1, 31);
+
+        when(matchPadelService.getPublicMatchSummaries(from, to, 5L))
+                .thenReturn(List.of());
+
+        mvc.perform(get("/api/v1/matchs/public")
+                        .param("from", "2030-01-01")
+                        .param("to", "2030-01-31")
+                        .param("siteId", "5"))
+                .andExpect(status().isOk());
+
+        verify(matchPadelService).getPublicMatchSummaries(from, to, 5L);
+    }
+
+    @Test
+    void getPublicMatches_badRequest_si_intervalle_invalide() throws Exception {
+        when(matchPadelService.getPublicMatchSummaries(
+                eq(LocalDate.of(2030, 2, 1)),
+                eq(LocalDate.of(2030, 1, 1)),
+                eq(null)
+        )).thenThrow(new BusinessException(
+                "Le paramètre 'from' doit être antérieur ou égal à 'to'."
+        ));
+
+        mvc.perform(get("/api/v1/matchs/public")
+                        .param("from", "2030-02-01")
+                        .param("to", "2030-01-01"))
                 .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
- ajout de PublicMatchSummaryDto et du mapper associé
- implémentation du endpoint GET /api/v1/matchs/public
- ajout des filtres optionnels (from, to, siteId)
- calcul du nombre de participants, des places restantes et de l’état complet
- ajout de la requête repository avec projection
- ajout des tests service, repository et controller