### PR TITLE
feat(match): détail d’un match avec participants et gestion accès  privé /public

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
@@ -3,6 +3,7 @@ package be.ephec.padel.backend.controller;
 import be.ephec.padel.backend.dto.request.CreateMatchRequest;
 import be.ephec.padel.backend.dto.response.ApiErrorDto;
 import be.ephec.padel.backend.dto.response.MatchDto;
+import be.ephec.padel.backend.dto.response.MatchDetailDto;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.service.MatchPadelService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,15 +34,23 @@ public class MatchController {
         this.matchPadelService = matchPadelService;
     }
 
-    @Operation(summary = "Récupérer un match", description = "Retourne le match (DTO) par son identifiant.")
+    @Operation(
+            summary = "Récupérer le détail d’un match",
+            description = "Retourne le détail d’un match. Un match PUBLIC est visible par tous. "
+                    + "Un match PRIVE est visible uniquement par l’organisateur et les participants."
+    )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Match trouvé"),
+            @ApiResponse(responseCode = "403", description = "Accès refusé à ce match privé",
+                    content = @Content(schema = @Schema(implementation = ApiErrorDto.class))),
             @ApiResponse(responseCode = "404", description = "Match introuvable",
                     content = @Content(schema = @Schema(implementation = ApiErrorDto.class)))
     })
     @GetMapping("/{id}")
-    public ResponseEntity<MatchDto> getOne(@PathVariable Long id) {
-        return ResponseEntity.ok(matchPadelService.getMatchDto(id));
+    public ResponseEntity<MatchDetailDto> getOne(
+            @PathVariable Long id,
+            @RequestParam(required = false) String matricule) {
+        return ResponseEntity.ok(matchPadelService.getMatchDetailDto(id, matricule));
     }
 
     @Operation(summary = "Créer un match", description = "Crée un match (PUBLIC ou PRIVE) si les règles métier sont respectées.")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDetailDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDetailDto.java
@@ -1,0 +1,141 @@
+package be.ephec.padel.backend.dto.response;
+
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public class MatchDetailDto {
+
+    private Long id;
+
+    private LocalDate dateDebut;
+    private LocalTime heureDebut;
+
+    private Long siteId;
+    private String siteNom;
+
+    private Long terrainId;
+    private String terrainNom;
+
+    private String organisateurMatricule;
+    private String organisateurNom;
+
+    private MatchVisibilite visibilite;
+
+    private int nbParticipants;
+    private int placesRestantes;
+    private boolean complet;
+
+    private BigDecimal montantTotal;
+    private BigDecimal montantPaye;
+    private BigDecimal resteAPayer;
+
+    private List<ParticipantDto> participants;
+
+    public MatchDetailDto(Long id,
+                          LocalDate dateDebut,
+                          LocalTime heureDebut,
+                          Long siteId,
+                          String siteNom,
+                          Long terrainId,
+                          String terrainNom,
+                          String organisateurMatricule,
+                          String organisateurNom,
+                          MatchVisibilite visibilite,
+                          int nbParticipants,
+                          int placesRestantes,
+                          boolean complet,
+                          BigDecimal montantTotal,
+                          BigDecimal montantPaye,
+                          BigDecimal resteAPayer,
+                          List<ParticipantDto> participants) {
+        this.id = id;
+        this.dateDebut = dateDebut;
+        this.heureDebut = heureDebut;
+        this.siteId = siteId;
+        this.siteNom = siteNom;
+        this.terrainId = terrainId;
+        this.terrainNom = terrainNom;
+        this.organisateurMatricule = organisateurMatricule;
+        this.organisateurNom = organisateurNom;
+        this.visibilite = visibilite;
+        this.nbParticipants = nbParticipants;
+        this.placesRestantes = placesRestantes;
+        this.complet = complet;
+        this.montantTotal = montantTotal;
+        this.montantPaye = montantPaye;
+        this.resteAPayer = resteAPayer;
+        this.participants = participants;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public LocalDate getDateDebut() {
+        return dateDebut;
+    }
+
+    public LocalTime getHeureDebut() {
+        return heureDebut;
+    }
+
+    public Long getSiteId() {
+        return siteId;
+    }
+
+    public String getSiteNom() {
+        return siteNom;
+    }
+
+    public Long getTerrainId() {
+        return terrainId;
+    }
+
+    public String getTerrainNom() {
+        return terrainNom;
+    }
+
+    public String getOrganisateurMatricule() {
+        return organisateurMatricule;
+    }
+
+    public String getOrganisateurNom() {
+        return organisateurNom;
+    }
+
+    public MatchVisibilite getVisibilite() {
+        return visibilite;
+    }
+
+    public int getNbParticipants() {
+        return nbParticipants;
+    }
+
+    public int getPlacesRestantes() {
+        return placesRestantes;
+    }
+
+    public boolean isComplet() {
+        return complet;
+    }
+
+    public BigDecimal getMontantTotal() {
+        return montantTotal;
+    }
+
+    public BigDecimal getMontantPaye() {
+        return montantPaye;
+    }
+
+    public BigDecimal getResteAPayer() {
+        return resteAPayer;
+    }
+
+    public List<ParticipantDto> getParticipants() {
+        return participants;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDto.java
@@ -21,7 +21,7 @@ public class MatchDto {
     // ✅ nouveaux champs
     private BigDecimal montantTotal;   // 60.00
     private BigDecimal montantPaye;    // somme des paiements
-    public BigDecimal resteAPayer;    // montantTotal - montantPaye (min 0)
+    private BigDecimal resteAPayer;    // montantTotal - montantPaye (min 0)
 
     public MatchDto(Long id,
                     Long terrainId,

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/ParticipantDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/ParticipantDto.java
@@ -1,0 +1,20 @@
+package be.ephec.padel.backend.dto.response;
+
+public class ParticipantDto {
+
+    private String matricule;
+    private String nom;
+
+    public ParticipantDto(String matricule, String nom) {
+        this.matricule = matricule;
+        this.nom = nom;
+    }
+
+    public String getMatricule() {
+        return matricule;
+    }
+
+    public String getNom() {
+        return nom;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/error/ApiExceptionHandler.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/error/ApiExceptionHandler.java
@@ -3,6 +3,7 @@ package be.ephec.padel.backend.error;
 import be.ephec.padel.backend.dto.response.ApiErrorDto;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.exception.ForbiddenException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
@@ -176,6 +177,20 @@ public class ApiExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ApiErrorDto> handleForbidden(
+            ForbiddenException ex,
+            HttpServletRequest request) {
+
+        ApiErrorDto error = buildError(
+                HttpStatus.FORBIDDEN,
+                ex.getMessage(),
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
     }
 
     private ApiErrorDto buildError(

--- a/backend/backend/src/main/java/be/ephec/padel/backend/exception/ForbiddenException.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package be.ephec.padel.backend.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchDetailMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchDetailMapper.java
@@ -1,0 +1,60 @@
+package be.ephec.padel.backend.mapper;
+
+import be.ephec.padel.backend.dto.response.MatchDetailDto;
+import be.ephec.padel.backend.dto.response.ParticipantDto;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public final class MatchDetailMapper {
+
+    private static final int CAPACITE_MATCH = 4;
+
+    private MatchDetailMapper() {
+    }
+
+    public static MatchDetailDto toDto(MatchPadel m,
+                                       BigDecimal montantTotal,
+                                       BigDecimal montantPaye,
+                                       BigDecimal resteAPayer) {
+
+        int nbParticipants = (m.getParticipations() != null) ? m.getParticipations().size() : 0;
+        int placesRestantes = Math.max(0, CAPACITE_MATCH - nbParticipants);
+        boolean complet = nbParticipants >= CAPACITE_MATCH;
+
+        List<ParticipantDto> participants = (m.getParticipations() == null)
+                ? List.of()
+                : m.getParticipations().stream()
+                .map(MatchDetailMapper::toParticipantDto)
+                .toList();
+
+        return new MatchDetailDto(
+                m.getId(),
+                m.getDateDebut().toLocalDate(),
+                m.getDateDebut().toLocalTime().withSecond(0).withNano(0),
+                m.getTerrain().getSite().getId(),
+                m.getTerrain().getSite().getNom(),
+                m.getTerrain().getId(),
+                m.getTerrain().getNom(),
+                m.getOrganisateur().getMatricule(),
+                m.getOrganisateur().getNom(),
+                m.getVisibilite(),
+                nbParticipants,
+                placesRestantes,
+                complet,
+                montantTotal,
+                montantPaye,
+                resteAPayer,
+                participants
+        );
+    }
+
+    private static ParticipantDto toParticipantDto(Participation p) {
+        return new ParticipantDto(
+                p.getJoueur().getMatricule(),
+                p.getJoueur().getNom()
+        );
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -2,9 +2,12 @@ package be.ephec.padel.backend.service;
 
 import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.dto.response.MatchDto;
+import be.ephec.padel.backend.dto.response.MatchDetailDto;
 import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.ForbiddenException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.mapper.MatchMapper;
+import be.ephec.padel.backend.mapper.MatchDetailMapper;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
@@ -289,5 +292,46 @@ public class MatchPadelService {
         return rows.stream()
                 .map(row -> PublicMatchSummaryMapper.toDto(row, Tarifs.PART_PAR_JOUEUR))
                 .collect(Collectors.toList());
+    }
+    private boolean peutVoirMatchPrive(MatchPadel match, String matricule) {
+        if (matricule == null || matricule.isBlank()) {
+            return false;
+        }
+
+        if (match.getOrganisateur() != null
+                && matricule.equals(match.getOrganisateur().getMatricule())) {
+            return true;
+        }
+
+        if (match.getParticipations() == null) {
+            return false;
+        }
+
+        return match.getParticipations().stream()
+                .map(Participation::getJoueur)
+                .filter(j -> j != null && j.getMatricule() != null)
+                .anyMatch(j -> matricule.equals(j.getMatricule()));
+    }
+    @Transactional(readOnly = true)
+    public MatchDetailDto getMatchDetailDto(Long id, String matricule) {
+        MatchPadel m = getMatch(id);
+
+        if (m.getVisibilite() == MatchVisibilite.PRIVE && !peutVoirMatchPrive(m, matricule)) {
+            throw new ForbiddenException("Accès refusé à ce match privé.");
+        }
+
+        BigDecimal montantTotal = Tarifs.PRIX_MATCH;
+
+        BigDecimal montantPaye = paiementRepository.sumMontantByMatchId(id);
+        if (montantPaye == null) {
+            montantPaye = BigDecimal.ZERO;
+        }
+
+        BigDecimal resteAPayer = montantTotal.subtract(montantPaye);
+        if (resteAPayer.signum() < 0) {
+            resteAPayer = BigDecimal.ZERO;
+        }
+
+        return MatchDetailMapper.toDto(m, montantTotal, montantPaye, resteAPayer);
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
@@ -1,8 +1,10 @@
 package be.ephec.padel.backend.unit.service;
 
 import be.ephec.padel.backend.common.Tarifs;
+import be.ephec.padel.backend.dto.response.MatchDetailDto;
 import be.ephec.padel.backend.dto.response.MatchDto;
 import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.ForbiddenException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.*;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
@@ -590,5 +592,158 @@ class MatchPadelServiceTest {
                 () -> service.getPublicMatchSummaries(from, to, null));
 
         verify(matchRepo, never()).findPublicMatchSummaries(any(), any(), any(), any());
+    }
+    @Test
+    void getMatchDetailDto_public_sansMatricule_ok() {
+        MatchPadel match = mock(MatchPadel.class);
+        when(match.getId()).thenReturn(1L);
+        when(match.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
+        when(match.getDateDebut()).thenReturn(LocalDateTime.of(2030, 1, 1, 10, 0));
+
+        Terrain terrain = mock(Terrain.class);
+        Site site = mock(Site.class);
+        Joueur orga = mock(Joueur.class);
+
+        when(site.getId()).thenReturn(5L);
+        when(site.getNom()).thenReturn("Site Delta");
+
+        when(terrain.getId()).thenReturn(10L);
+        when(terrain.getNom()).thenReturn("Terrain 1");
+        when(terrain.getSite()).thenReturn(site);
+
+        when(orga.getMatricule()).thenReturn("G0001");
+        when(orga.getNom()).thenReturn("Orga");
+
+        when(match.getTerrain()).thenReturn(terrain);
+        when(match.getOrganisateur()).thenReturn(orga);
+        when(match.getParticipations()).thenReturn(List.of());
+
+        when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
+        when(paiementRepo.sumMontantByMatchId(1L)).thenReturn(BigDecimal.ZERO);
+
+        MatchDetailDto dto = service.getMatchDetailDto(1L, null);
+
+        assertEquals(1L, dto.getId());
+        assertEquals("Site Delta", dto.getSiteNom());
+        assertEquals("Terrain 1", dto.getTerrainNom());
+        assertEquals("G0001", dto.getOrganisateurMatricule());
+        assertEquals(0, dto.getNbParticipants());
+        assertEquals(4, dto.getPlacesRestantes());
+        assertFalse(dto.isComplet());
+    }
+    @Test
+    void getMatchDetailDto_prive_sansMatricule_refuse() {
+        MatchPadel match = mock(MatchPadel.class);
+        when(match.getVisibilite()).thenReturn(MatchVisibilite.PRIVE);
+
+        when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
+
+        assertThrows(ForbiddenException.class,
+                () -> service.getMatchDetailDto(1L, null));
+
+        verify(paiementRepo, never()).sumMontantByMatchId(anyLong());
+    }
+    @Test
+    void getMatchDetailDto_prive_organisateur_ok() {
+        MatchPadel match = mock(MatchPadel.class);
+        when(match.getId()).thenReturn(1L);
+        when(match.getVisibilite()).thenReturn(MatchVisibilite.PRIVE);
+        when(match.getDateDebut()).thenReturn(LocalDateTime.of(2030, 1, 1, 10, 0));
+
+        Terrain terrain = mock(Terrain.class);
+        Site site = mock(Site.class);
+        Joueur orga = mock(Joueur.class);
+
+        when(site.getId()).thenReturn(5L);
+        when(site.getNom()).thenReturn("Site Delta");
+
+        when(terrain.getId()).thenReturn(10L);
+        when(terrain.getNom()).thenReturn("Terrain 1");
+        when(terrain.getSite()).thenReturn(site);
+
+        when(orga.getMatricule()).thenReturn("G0001");
+        when(orga.getNom()).thenReturn("Orga");
+
+        when(match.getTerrain()).thenReturn(terrain);
+        when(match.getOrganisateur()).thenReturn(orga);
+        when(match.getParticipations()).thenReturn(List.of());
+
+        when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
+        when(paiementRepo.sumMontantByMatchId(1L)).thenReturn(BigDecimal.ZERO);
+
+        MatchDetailDto dto = service.getMatchDetailDto(1L, "G0001");
+
+        assertEquals(1L, dto.getId());
+        assertEquals("G0001", dto.getOrganisateurMatricule());
+    }
+    @Test
+    void getMatchDetailDto_prive_participant_ok() {
+        MatchPadel match = mock(MatchPadel.class);
+        when(match.getId()).thenReturn(1L);
+        when(match.getVisibilite()).thenReturn(MatchVisibilite.PRIVE);
+        when(match.getDateDebut()).thenReturn(LocalDateTime.of(2030, 1, 1, 10, 0));
+
+        Terrain terrain = mock(Terrain.class);
+        Site site = mock(Site.class);
+        Joueur orga = mock(Joueur.class);
+        Joueur joueur = mock(Joueur.class);
+        Participation participation = mock(Participation.class);
+
+        when(site.getId()).thenReturn(5L);
+        when(site.getNom()).thenReturn("Site Delta");
+
+        when(terrain.getId()).thenReturn(10L);
+        when(terrain.getNom()).thenReturn("Terrain 1");
+        when(terrain.getSite()).thenReturn(site);
+
+        when(orga.getMatricule()).thenReturn("G0001");
+        when(orga.getNom()).thenReturn("Orga");
+
+        when(joueur.getMatricule()).thenReturn("J0001");
+        when(joueur.getNom()).thenReturn("Alice");
+
+        when(participation.getJoueur()).thenReturn(joueur);
+
+        when(match.getTerrain()).thenReturn(terrain);
+        when(match.getOrganisateur()).thenReturn(orga);
+        when(match.getParticipations()).thenReturn(List.of(participation));
+
+        when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
+        when(paiementRepo.sumMontantByMatchId(1L)).thenReturn(BigDecimal.ZERO);
+
+        MatchDetailDto dto = service.getMatchDetailDto(1L, "J0001");
+
+        assertEquals(1, dto.getParticipants().size());
+        assertEquals("J0001", dto.getParticipants().get(0).getMatricule());
+    }
+    @Test
+    void getMatchDetailDto_prive_autreJoueur_refuse() {
+        MatchPadel match = mock(MatchPadel.class);
+        Joueur orga = mock(Joueur.class);
+        Joueur joueur = mock(Joueur.class);
+        Participation participation = mock(Participation.class);
+
+        when(match.getVisibilite()).thenReturn(MatchVisibilite.PRIVE);
+
+        when(orga.getMatricule()).thenReturn("G0001");
+        when(match.getOrganisateur()).thenReturn(orga);
+
+        when(joueur.getMatricule()).thenReturn("J0001");
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(match.getParticipations()).thenReturn(List.of(participation));
+
+        when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
+
+        assertThrows(ForbiddenException.class,
+                () -> service.getMatchDetailDto(1L, "X9999"));
+
+        verify(paiementRepo, never()).sumMontantByMatchId(anyLong());
+    }
+    @Test
+    void getMatchDetailDto_introuvable_notFound() {
+        when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class,
+                () -> service.getMatchDetailDto(1L, null));
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/contract/MatchControllerContract404Test.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/contract/MatchControllerContract404Test.java
@@ -23,7 +23,7 @@ class MatchControllerContract404Test {
     @Test
     @WithMockUser // <-- ajout
     void getMatch_notFound_returns404_withApiErrorFormat() throws Exception {
-        when(matchPadelService.getMatchDto(999L))
+        when(matchPadelService.getMatchDetailDto(999L,null))
                 .thenThrow(new NotFoundException("Match 999 introuvable"));
 
         mockMvc.perform(get("/api/v1/matchs/999"))

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
@@ -2,10 +2,13 @@ package be.ephec.padel.backend.web.controller;
 
 import be.ephec.padel.backend.config.SecurityConfig;
 import be.ephec.padel.backend.controller.MatchController;
+import be.ephec.padel.backend.dto.response.MatchDetailDto;
 import be.ephec.padel.backend.dto.response.MatchDto;
+import be.ephec.padel.backend.dto.response.ParticipantDto;
 import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
 import be.ephec.padel.backend.error.ApiExceptionHandler;
 import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.ForbiddenException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
@@ -80,33 +83,29 @@ class MatchControllerTest {
                 new BigDecimal("15.00")
         );
     }
-
-    @Test
-    void getOne_sansAuth_200_et_json() throws Exception {
-        when(matchPadelService.getMatchDto(1L)).thenReturn(sampleDto(1L));
-
-        mvc.perform(get("/api/v1/matchs/1"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.id").value(1))
-                .andExpect(jsonPath("$.terrainId").value(10))
-                .andExpect(jsonPath("$.terrainNom").value("T1"))
-                .andExpect(jsonPath("$.siteId").value(5))
-                .andExpect(jsonPath("$.organisateurMatricule").value("G0001"))
-                .andExpect(jsonPath("$.visibilite").value("PUBLIC"))
-                .andExpect(jsonPath("$.nbParticipants").value(2))
-                .andExpect(jsonPath("$.montantTotal").value(60.0))
-                .andExpect(jsonPath("$.montantPaye").value(15.0))
-                .andExpect(jsonPath("$.resteAPayer").value(45.0));
-    }
-
-    @Test
-    void getOne_notFound_404() throws Exception {
-        when(matchPadelService.getMatchDto(99L))
-                .thenThrow(new NotFoundException("Match introuvable"));
-
-        mvc.perform(get("/api/v1/matchs/99"))
-                .andExpect(status().isNotFound());
+    private MatchDetailDto sampleDetailDto(Long id, MatchVisibilite visibilite) {
+        return new MatchDetailDto(
+                id,
+                LocalDate.of(2030, 1, 1),
+                LocalTime.of(10, 0),
+                5L,
+                "Site Delta",
+                10L,
+                "Terrain 1",
+                "G0001",
+                "Organisateur",
+                visibilite,
+                2,
+                2,
+                false,
+                new BigDecimal("60.00"),
+                new BigDecimal("15.00"),
+                new BigDecimal("45.00"),
+                List.of(
+                        new ParticipantDto("G0001", "Organisateur"),
+                        new ParticipantDto("J0001", "Alice")
+                )
+        );
     }
 
     @Test
@@ -193,5 +192,77 @@ class MatchControllerTest {
                         .param("from", "2030-02-01")
                         .param("to", "2030-01-01"))
                 .andExpect(status().isBadRequest());
+    }
+    @Test
+    void getOne_public_sansMatricule_200() throws Exception {
+        when(matchPadelService.getMatchDetailDto(1L, null))
+                .thenReturn(sampleDetailDto(1L, MatchVisibilite.PUBLIC));
+
+        mvc.perform(get("/api/v1/matchs/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.dateDebut").value("2030-01-01"))
+                .andExpect(jsonPath("$.heureDebut").value("10:00:00"))
+                .andExpect(jsonPath("$.siteNom").value("Site Delta"))
+                .andExpect(jsonPath("$.terrainNom").value("Terrain 1"))
+                .andExpect(jsonPath("$.organisateurMatricule").value("G0001"))
+                .andExpect(jsonPath("$.visibilite").value("PUBLIC"))
+                .andExpect(jsonPath("$.participants[0].matricule").value("G0001"))
+                .andExpect(jsonPath("$.participants[1].matricule").value("J0001"))
+                 .andExpect(jsonPath("$.organisateurNom").value("Organisateur"))
+                .andExpect(jsonPath("$.nbParticipants").value(2))
+                .andExpect(jsonPath("$.placesRestantes").value(2))
+                .andExpect(jsonPath("$.complet").value(false))
+                .andExpect(jsonPath("$.montantTotal").value(60.0))
+                .andExpect(jsonPath("$.montantPaye").value(15.0))
+                .andExpect(jsonPath("$.resteAPayer").value(45.0));
+    }
+    @Test
+    void getOne_prive_sansMatricule_403() throws Exception {
+        when(matchPadelService.getMatchDetailDto(1L, null))
+                .thenThrow(new ForbiddenException("Accès refusé à ce match privé."));
+
+        mvc.perform(get("/api/v1/matchs/1"))
+                .andExpect(status().isForbidden());
+    }
+    @Test
+    void getOne_prive_organisateur_200() throws Exception {
+        when(matchPadelService.getMatchDetailDto(1L, "G0001"))
+                .thenReturn(sampleDetailDto(1L, MatchVisibilite.PRIVE));
+
+        mvc.perform(get("/api/v1/matchs/1")
+                        .param("matricule", "G0001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.visibilite").value("PRIVE"))
+                .andExpect(jsonPath("$.organisateurMatricule").value("G0001"));
+    }
+    @Test
+    void getOne_prive_participant_200() throws Exception {
+        when(matchPadelService.getMatchDetailDto(1L, "J0001"))
+                .thenReturn(sampleDetailDto(1L, MatchVisibilite.PRIVE));
+
+        mvc.perform(get("/api/v1/matchs/1")
+                        .param("matricule", "J0001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.visibilite").value("PRIVE"))
+                .andExpect(jsonPath("$.participants[1].matricule").value("J0001"));
+    }
+    @Test
+    void getOne_prive_autreJoueur_403() throws Exception {
+        when(matchPadelService.getMatchDetailDto(1L, "X9999"))
+                .thenThrow(new ForbiddenException("Accès refusé à ce match privé."));
+
+        mvc.perform(get("/api/v1/matchs/1")
+                        .param("matricule", "X9999"))
+                .andExpect(status().isForbidden());
+    }
+    @Test
+    void getOne_notFound_404_detail() throws Exception {
+        when(matchPadelService.getMatchDetailDto(99L, null))
+                .thenThrow(new NotFoundException("Match introuvable"));
+
+        mvc.perform(get("/api/v1/matchs/99"))
+                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION

- ajout MatchDetailDto et ParticipantDto
- ajout MatchDetailMapper
- implémentation getMatchDetailDto dans MatchPadelService
- gestion des règles d’accès (public / privé avec organisateur ou participant)
- ajout ForbiddenException + handler 403
- mise à jour GET /api/v1/matchs/{id} avec paramètre matricule optionnel
- mise à jour des tests service et controller (200 / 403 / 404)
- mise à jour du contrat API et Swagger