### PR TITLE
feat(joueur): ajout de l’endpoint mes matchs (#55)

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/JoueurController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/JoueurController.java
@@ -3,6 +3,7 @@ package be.ephec.padel.backend.controller;
 import be.ephec.padel.backend.dto.request.JoueurCreateRequest;
 import be.ephec.padel.backend.dto.response.DetteDto;
 import be.ephec.padel.backend.dto.response.JoueurDto;
+import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
 import be.ephec.padel.backend.mapper.JoueurMapper;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.service.JoueurService;
@@ -43,6 +44,11 @@ public class JoueurController {
     public ResponseEntity<DetteDto> hasDette(@PathVariable String matricule) {
         boolean dette = joueurService.aDette(matricule);
         return ResponseEntity.ok(new DetteDto(dette));
+    }
+
+    @GetMapping("/{matricule}/matchs")
+    public ResponseEntity<List<PlayerMatchSummaryDto>> getPlayerMatches(@PathVariable String matricule) {
+        return ResponseEntity.ok(joueurService.getPlayerMatches(matricule));
     }
 
     @SecurityRequirement(name = "basicAuth")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/enums/MatchTemporalStatusDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/enums/MatchTemporalStatusDto.java
@@ -1,0 +1,7 @@
+package be.ephec.padel.backend.dto.enums;
+
+public enum MatchTemporalStatusDto {
+    PASSE,
+    AUJOURD_HUI,
+    FUTUR
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/enums/PlayerMatchRoleDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/enums/PlayerMatchRoleDto.java
@@ -1,0 +1,6 @@
+package be.ephec.padel.backend.dto.enums;
+
+public enum PlayerMatchRoleDto {
+    ORGANISATEUR,
+    PARTICIPANT
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PlayerMatchSummaryDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PlayerMatchSummaryDto.java
@@ -1,0 +1,22 @@
+package be.ephec.padel.backend.dto.response;
+
+import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
+import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+
+import java.time.LocalDateTime;
+
+public record PlayerMatchSummaryDto(
+        Long id,
+        LocalDateTime dateDebut,
+        Long siteId,
+        String siteNom,
+        Long terrainId,
+        String terrainNom,
+        MatchVisibilite visibilite,
+        PlayerMatchRoleDto roleJoueur,
+        MatchTemporalStatusDto statutTemporel,
+        Integer joursAvantMatch,
+        boolean paiementJoueurEffectue
+) {
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
     List<Participation> findByMatch_Id(Long matchId);
     List<Participation> findByJoueur_Matricule(String matricule);
+    List<Participation> findByJoueur_MatriculeOrderByMatch_DateDebutAsc(String matricule);
     boolean existsByMatch_IdAndJoueur_Matricule(Long matchId, String joueurMatricule);
 
     Optional<Participation> findByMatch_IdAndJoueur_Matricule(Long matchId, String matricule);

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
@@ -1,16 +1,24 @@
 package be.ephec.padel.backend.service;
 
+import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
+import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.entities.Site;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.SiteRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Service
@@ -19,10 +27,12 @@ public class JoueurService {
 
     private final JoueurRepository joueurRepository;
     private final SiteRepository siteRepository;
+    private final ParticipationRepository participationRepository;
 
-    public JoueurService(JoueurRepository joueurRepository, SiteRepository siteRepository) {
+    public JoueurService(JoueurRepository joueurRepository, SiteRepository siteRepository, ParticipationRepository participationRepository) {
         this.joueurRepository = joueurRepository;
         this.siteRepository = siteRepository;
+        this.participationRepository = participationRepository;
     }
 
     public Joueur creerJoueur(String matricule, String nom, TypeJoueur type, Long siteId) {
@@ -86,5 +96,56 @@ public class JoueurService {
         if (!matricule.matches(pattern)) {
             throw new BusinessException("Matricule invalide pour le type " + type + " : " + matricule);
         }
+    }
+    private PlayerMatchSummaryDto toPlayerMatchSummaryDto(Participation participation,
+                                                          String matricule,
+                                                          LocalDate today) {
+        MatchPadel match = participation.getMatch();
+        LocalDate dateMatch = match.getDateDebut().toLocalDate();
+
+        PlayerMatchRoleDto roleJoueur =
+                match.getOrganisateur().getMatricule().equals(matricule)
+                        ? PlayerMatchRoleDto.ORGANISATEUR
+                        : PlayerMatchRoleDto.PARTICIPANT;
+
+        MatchTemporalStatusDto statutTemporel;
+        Integer joursAvantMatch = null;
+
+        if (dateMatch.isBefore(today)) {
+            statutTemporel = MatchTemporalStatusDto.PASSE;
+        } else if (dateMatch.isEqual(today)) {
+            statutTemporel = MatchTemporalStatusDto.AUJOURD_HUI;
+        } else {
+            statutTemporel = MatchTemporalStatusDto.FUTUR;
+            joursAvantMatch = (int) ChronoUnit.DAYS.between(today, dateMatch);
+        }
+
+        boolean paiementJoueurEffectue = !participation.getPaiements().isEmpty();
+
+        return new PlayerMatchSummaryDto(
+                match.getId(),
+                match.getDateDebut(),
+                match.getTerrain().getSite().getId(),
+                match.getTerrain().getSite().getNom(),
+                match.getTerrain().getId(),
+                match.getTerrain().getNom(),
+                match.getVisibilite(),
+                roleJoueur,
+                statutTemporel,
+                joursAvantMatch,
+                paiementJoueurEffectue
+        );
+    }
+    public List<PlayerMatchSummaryDto> getPlayerMatches(String matricule) {
+        getJoueur(matricule);
+
+        List<Participation> participations =
+                participationRepository.findByJoueur_MatriculeOrderByMatch_DateDebutAsc(matricule);
+
+        LocalDate today = LocalDate.now();
+
+        return participations.stream()
+                .map(participation -> toPlayerMatchSummaryDto(participation, matricule, today))
+                .toList();
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/JoueurServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/JoueurServiceTest.java
@@ -1,17 +1,24 @@
 package be.ephec.padel.backend.unit.service;
 
+import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
+import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
-import be.ephec.padel.backend.model.entities.Joueur;
-import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.*;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.SiteRepository;
 import be.ephec.padel.backend.service.JoueurService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,11 +32,58 @@ class JoueurServiceTest {
     private SiteRepository siteRepo;
     private JoueurService service;
 
+    private ParticipationRepository participationRepo;
+
     @BeforeEach
     void setup() {
         joueurRepo = mock(JoueurRepository.class);
         siteRepo = mock(SiteRepository.class);
-        service = new JoueurService(joueurRepo, siteRepo);
+        participationRepo = mock(ParticipationRepository.class);
+        service = new JoueurService(joueurRepo, siteRepo, participationRepo);
+    }
+
+    private Participation mockParticipation(String organisateurMatricule,
+                                            String joueurMatricule,
+                                            LocalDate dateMatch,
+                                            MatchVisibilite visibilite,
+                                            boolean paiementEffectue,
+                                            Long terrainId,
+                                            String terrainNom,
+                                            Long siteId,
+                                            String siteNom) {
+        Participation participation = mock(Participation.class);
+        MatchPadel match = mock(MatchPadel.class);
+        Joueur organisateur = mock(Joueur.class);
+        Joueur joueur = mock(Joueur.class);
+        Terrain terrain = mock(Terrain.class);
+        Site site = mock(Site.class);
+
+        when(participation.getMatch()).thenReturn(match);
+        when(participation.getJoueur()).thenReturn(joueur);
+
+        when(match.getId()).thenReturn(999L);
+        when(match.getDateDebut()).thenReturn(LocalDateTime.of(dateMatch, LocalTime.of(10, 0)));
+        when(match.getVisibilite()).thenReturn(visibilite);
+        when(match.getOrganisateur()).thenReturn(organisateur);
+        when(match.getTerrain()).thenReturn(terrain);
+
+        when(organisateur.getMatricule()).thenReturn(organisateurMatricule);
+        when(joueur.getMatricule()).thenReturn(joueurMatricule);
+
+        when(terrain.getId()).thenReturn(terrainId);
+        when(terrain.getNom()).thenReturn(terrainNom);
+        when(terrain.getSite()).thenReturn(site);
+
+        when(site.getId()).thenReturn(siteId);
+        when(site.getNom()).thenReturn(siteNom);
+
+        if (paiementEffectue) {
+            when(participation.getPaiements()).thenReturn(List.of(mock(Paiement.class)));
+        } else {
+            when(participation.getPaiements()).thenReturn(List.of());
+        }
+
+        return participation;
     }
 
     // ----------------
@@ -238,5 +292,214 @@ class JoueurServiceTest {
         when(joueurRepo.findById("G0001")).thenReturn(Optional.of(j));
 
         assertDoesNotThrow(() -> service.verifierPasDeDette("G0001"));
+    }
+// ----------------
+// getPlayerMatches
+// ----------------
+
+    @Test
+    void getPlayerMatches_joueurIntrouvable_notFound() {
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> service.getPlayerMatches("G0001"));
+
+        verify(joueurRepo).findById("G0001");
+        verifyNoInteractions(participationRepo);
+    }
+
+    @Test
+    void getPlayerMatches_joueurExistant_sansParticipation_retourneListeVide() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of());
+
+        List<PlayerMatchSummaryDto> result = service.getPlayerMatches("G0001");
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(joueurRepo).findById("G0001");
+        verify(participationRepo).findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001");
+    }
+
+    @Test
+    void getPlayerMatches_matchFutur_participant_nonPaye() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        Participation participation = mockParticipation(
+                "G9999",                // organisateur
+                "G0001",                // joueur courant
+                LocalDate.now().plusDays(5),
+                MatchVisibilite.PUBLIC,
+                false,                  // paiement
+                10L,
+                "Terrain 1",
+                1L,
+                "Site Delta"
+        );
+
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of(participation));
+
+        List<PlayerMatchSummaryDto> result = service.getPlayerMatches("G0001");
+
+        assertEquals(1, result.size());
+
+        PlayerMatchSummaryDto dto = result.get(0);
+        assertEquals(PlayerMatchRoleDto.PARTICIPANT, dto.roleJoueur());
+        assertEquals(MatchTemporalStatusDto.FUTUR, dto.statutTemporel());
+        assertEquals(5, dto.joursAvantMatch());
+        assertFalse(dto.paiementJoueurEffectue());
+        assertEquals(MatchVisibilite.PUBLIC, dto.visibilite());
+        assertEquals(10L, dto.terrainId());
+        assertEquals("Terrain 1", dto.terrainNom());
+        assertEquals(1L, dto.siteId());
+        assertEquals("Site Delta", dto.siteNom());
+    }
+
+    @Test
+    void getPlayerMatches_matchFutur_organisateur_paye() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        Participation participation = mockParticipation(
+                "G0001",                // organisateur = joueur courant
+                "G0001",
+                LocalDate.now().plusDays(3),
+                MatchVisibilite.PRIVE,
+                true,
+                20L,
+                "Terrain Central",
+                2L,
+                "Site Omega"
+        );
+
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of(participation));
+
+        List<PlayerMatchSummaryDto> result = service.getPlayerMatches("G0001");
+
+        assertEquals(1, result.size());
+
+        PlayerMatchSummaryDto dto = result.get(0);
+        assertEquals(PlayerMatchRoleDto.ORGANISATEUR, dto.roleJoueur());
+        assertEquals(MatchTemporalStatusDto.FUTUR, dto.statutTemporel());
+        assertEquals(3, dto.joursAvantMatch());
+        assertTrue(dto.paiementJoueurEffectue());
+        assertEquals(MatchVisibilite.PRIVE, dto.visibilite());
+        assertEquals(20L, dto.terrainId());
+        assertEquals("Terrain Central", dto.terrainNom());
+        assertEquals(2L, dto.siteId());
+        assertEquals("Site Omega", dto.siteNom());
+    }
+
+    @Test
+    void getPlayerMatches_matchAujourdHui_retourneStatutAujourdHui_et_joursNull() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        Participation participation = mockParticipation(
+                "G9999",
+                "G0001",
+                LocalDate.now(),
+                MatchVisibilite.PUBLIC,
+                true,
+                30L,
+                "Terrain 3",
+                3L,
+                "Site Today"
+        );
+
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of(participation));
+
+        List<PlayerMatchSummaryDto> result = service.getPlayerMatches("G0001");
+
+        assertEquals(1, result.size());
+
+        PlayerMatchSummaryDto dto = result.get(0);
+        assertEquals(MatchTemporalStatusDto.AUJOURD_HUI, dto.statutTemporel());
+        assertNull(dto.joursAvantMatch());
+        assertTrue(dto.paiementJoueurEffectue());
+    }
+
+    @Test
+    void getPlayerMatches_matchPasse_retourneStatutPasse_et_joursNull() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        Participation participation = mockParticipation(
+                "G9999",
+                "G0001",
+                LocalDate.now().minusDays(2),
+                MatchVisibilite.PRIVE,
+                false,
+                40L,
+                "Terrain 4",
+                4L,
+                "Site Past"
+        );
+
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of(participation));
+
+        List<PlayerMatchSummaryDto> result = service.getPlayerMatches("G0001");
+
+        assertEquals(1, result.size());
+
+        PlayerMatchSummaryDto dto = result.get(0);
+        assertEquals(MatchTemporalStatusDto.PASSE, dto.statutTemporel());
+        assertNull(dto.joursAvantMatch());
+        assertFalse(dto.paiementJoueurEffectue());
+        assertEquals(MatchVisibilite.PRIVE, dto.visibilite());
+    }
+
+    @Test
+    void getPlayerMatches_plusieursParticipations_conserveOrdreDuRepository() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        Participation first = mockParticipation(
+                "G9999",
+                "G0001",
+                LocalDate.now().plusDays(1),
+                MatchVisibilite.PUBLIC,
+                false,
+                11L,
+                "Terrain A",
+                101L,
+                "Site A"
+        );
+
+        Participation second = mockParticipation(
+                "G0001",
+                "G0001",
+                LocalDate.now().plusDays(4),
+                MatchVisibilite.PRIVE,
+                true,
+                22L,
+                "Terrain B",
+                202L,
+                "Site B"
+        );
+
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of(first, second));
+
+        List<PlayerMatchSummaryDto> result = service.getPlayerMatches("G0001");
+
+        assertEquals(2, result.size());
+
+        assertEquals(11L, result.get(0).terrainId());
+        assertEquals("Terrain A", result.get(0).terrainNom());
+        assertEquals(PlayerMatchRoleDto.PARTICIPANT, result.get(0).roleJoueur());
+        assertFalse(result.get(0).paiementJoueurEffectue());
+
+        assertEquals(22L, result.get(1).terrainId());
+        assertEquals("Terrain B", result.get(1).terrainNom());
+        assertEquals(PlayerMatchRoleDto.ORGANISATEUR, result.get(1).roleJoueur());
+        assertTrue(result.get(1).paiementJoueurEffectue());
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/JoueurControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/JoueurControllerTest.java
@@ -2,9 +2,13 @@ package be.ephec.padel.backend.web.controller;
 
 import be.ephec.padel.backend.config.SecurityConfig;
 import be.ephec.padel.backend.controller.JoueurController;
+import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
+import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
 import be.ephec.padel.backend.error.ApiExceptionHandler;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.service.JoueurService;
 import org.junit.jupiter.api.Test;
@@ -16,6 +20,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -36,6 +41,7 @@ class JoueurControllerTest {
     private Joueur realJoueur(String matricule, String nom, TypeJoueur type) {
         return new Joueur(matricule, nom, type);
     }
+
 
     // ===== Issue 62 : public doit être refusé sur listing / création =====
 
@@ -158,5 +164,60 @@ class JoueurControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andExpect(status().isBadRequest());
+    }
+    @Test
+    void getPlayerMatches_retourne200_etListeVide() throws Exception {
+        when(joueurService.getPlayerMatches("G0001")).thenReturn(List.of());
+
+        mvc.perform(get("/api/v1/joueurs/G0001/matchs")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+    @Test
+    void getPlayerMatches_retourne200_etListeDeMatchs() throws Exception {
+        PlayerMatchSummaryDto dto = new PlayerMatchSummaryDto(
+                1L,
+                LocalDateTime.of(2030, 1, 10, 10, 0),
+                100L,
+                "Site Delta",
+                200L,
+                "Terrain 1",
+                MatchVisibilite.PUBLIC,
+                PlayerMatchRoleDto.PARTICIPANT,
+                MatchTemporalStatusDto.FUTUR,
+                5,
+                false
+        );
+
+        when(joueurService.getPlayerMatches("G0001")).thenReturn(List.of(dto));
+
+        mvc.perform(get("/api/v1/joueurs/G0001/matchs")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].siteId").value(100))
+                .andExpect(jsonPath("$[0].siteNom").value("Site Delta"))
+                .andExpect(jsonPath("$[0].terrainId").value(200))
+                .andExpect(jsonPath("$[0].terrainNom").value("Terrain 1"))
+                .andExpect(jsonPath("$[0].visibilite").value("PUBLIC"))
+                .andExpect(jsonPath("$[0].roleJoueur").value("PARTICIPANT"))
+                .andExpect(jsonPath("$[0].statutTemporel").value("FUTUR"))
+                .andExpect(jsonPath("$[0].joursAvantMatch").value(5))
+                .andExpect(jsonPath("$[0].paiementJoueurEffectue").value(false));
+    }
+    @Test
+    void getPlayerMatches_joueurIntrouvable_retourne404() throws Exception {
+        when(joueurService.getPlayerMatches("G9999"))
+                .thenThrow(new NotFoundException("Joueur introuvable"));
+
+        mvc.perform(get("/api/v1/joueurs/G9999/matchs")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
- ajout de GET /api/v1/joueurs/{matricule}/matchs
- création du DTO de synthèse PlayerMatchSummaryDto
- implémentation de la logique métier dans JoueurService (rôle joueur, statut temporel, jours avant match, paiement)
- retour 404 si joueur introuvable, liste vide sinon
- ajout des tests service et controller
- validation via Swagger