### PR TITLE
feat(joueur): ajouter la vue des matchs organisés (#56)

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/JoueurController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/JoueurController.java
@@ -3,6 +3,7 @@ package be.ephec.padel.backend.controller;
 import be.ephec.padel.backend.dto.request.JoueurCreateRequest;
 import be.ephec.padel.backend.dto.response.DetteDto;
 import be.ephec.padel.backend.dto.response.JoueurDto;
+import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
 import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
 import be.ephec.padel.backend.mapper.JoueurMapper;
 import be.ephec.padel.backend.model.entities.Joueur;
@@ -49,6 +50,11 @@ public class JoueurController {
     @GetMapping("/{matricule}/matchs")
     public ResponseEntity<List<PlayerMatchSummaryDto>> getPlayerMatches(@PathVariable String matricule) {
         return ResponseEntity.ok(joueurService.getPlayerMatches(matricule));
+    }
+
+    @GetMapping("/{matricule}/matchs/organises")
+    public ResponseEntity<List<OrganizerMatchSummaryDto>> getOrganizedMatches(@PathVariable String matricule) {
+        return ResponseEntity.ok(joueurService.getOrganizedMatches(matricule));
     }
 
     @SecurityRequirement(name = "basicAuth")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/OrganizerMatchSummaryDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/OrganizerMatchSummaryDto.java
@@ -1,0 +1,23 @@
+package be.ephec.padel.backend.dto.response;
+
+import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+
+import java.time.LocalDateTime;
+
+public record OrganizerMatchSummaryDto(
+        Long id,
+        LocalDateTime dateDebut,
+        Long siteId,
+        String siteNom,
+        Long terrainId,
+        String terrainNom,
+        MatchVisibilite visibilite,
+        int nbParticipants,
+        int placesRestantes,
+        boolean complet,
+        MatchTemporalStatusDto statutTemporel,
+        Integer joursAvantMatch,
+        boolean risquePenaliteJ1
+) {
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -17,7 +17,9 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
 
     @Query("select m from MatchPadel m where m.terrain.id = :terrainId")
     List<MatchPadel> findByTerrainId(@Param("terrainId") Long terrainId);
+
     List<MatchPadel> findByDateDebutBetween(LocalDateTime start, LocalDateTime end);
+
     @Query("""
         select m
         from MatchPadel m
@@ -36,6 +38,7 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
     boolean existsByTerrainIdAndDateDebutBetween(@Param("terrainId") Long terrainId,
                                                  @Param("start") LocalDateTime start,
                                                  @Param("end") LocalDateTime end);
+
     @Query("""
         select distinct m
         from MatchPadel m
@@ -81,13 +84,13 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
 """)
     List<MatchPadel> findAtraiterDebutMatchAvecDetails(@Param("from") LocalDateTime from,
                                                        @Param("to") LocalDateTime to);
+
     @Query("""
     select count(m)
     from MatchPadel m
     where m.dateDebut >= :from
       and m.dateDebut < :to
 """)
-
     long countByDateDebutBetween(LocalDateTime from, LocalDateTime to);
 
     @Query("""
@@ -98,6 +101,7 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
           and m.terrain.site.id = :siteId
     """)
     long countByDateDebutBetweenAndSiteId(LocalDateTime from, LocalDateTime to, Long siteId);
+
     @Query("""
     select
         m.id as id,
@@ -130,6 +134,16 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
             @Param("to") LocalDateTime to,
             @Param("siteId") Long siteId
     );
-
+    @Query("""
+    select distinct m
+    from MatchPadel m
+    join fetch m.terrain t
+    join fetch t.site
+    join fetch m.organisateur o
+    left join fetch m.participations p
+    where o.matricule = :matricule
+    order by m.dateDebut asc
+""")
+    List<MatchPadel> findOrganizedMatchesWithDetailsByMatricule(@Param("matricule") String matricule);
 }
 

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
@@ -2,6 +2,7 @@ package be.ephec.padel.backend.service;
 
 import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
 import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
 import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
@@ -9,8 +10,10 @@ import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.SiteRepository;
 import org.springframework.stereotype.Service;
@@ -25,14 +28,21 @@ import java.util.List;
 @Transactional
 public class JoueurService {
 
+    private static final int CAPACITE_MATCH = 4;
+
     private final JoueurRepository joueurRepository;
     private final SiteRepository siteRepository;
     private final ParticipationRepository participationRepository;
+    private final MatchPadelRepository matchPadelRepository;
 
-    public JoueurService(JoueurRepository joueurRepository, SiteRepository siteRepository, ParticipationRepository participationRepository) {
+    public JoueurService(JoueurRepository joueurRepository,
+                         SiteRepository siteRepository,
+                         ParticipationRepository participationRepository,
+                         MatchPadelRepository matchPadelRepository) {
         this.joueurRepository = joueurRepository;
         this.siteRepository = siteRepository;
         this.participationRepository = participationRepository;
+        this.matchPadelRepository = matchPadelRepository;
     }
 
     public Joueur creerJoueur(String matricule, String nom, TypeJoueur type, Long siteId) {
@@ -53,7 +63,6 @@ public class JoueurService {
             site = siteRepository.findById(siteId)
                     .orElseThrow(() -> new NotFoundException("Site introuvable"));
         } else {
-            // Correction : éviter GLOBAL/LIBRE rattachés par erreur à un site
             if (siteId != null) {
                 throw new BusinessException("Seul un joueur SITE peut avoir un site.");
             }
@@ -97,6 +106,7 @@ public class JoueurService {
             throw new BusinessException("Matricule invalide pour le type " + type + " : " + matricule);
         }
     }
+
     private PlayerMatchSummaryDto toPlayerMatchSummaryDto(Participation participation,
                                                           String matricule,
                                                           LocalDate today) {
@@ -136,6 +146,7 @@ public class JoueurService {
                 paiementJoueurEffectue
         );
     }
+
     public List<PlayerMatchSummaryDto> getPlayerMatches(String matricule) {
         getJoueur(matricule);
 
@@ -146,6 +157,61 @@ public class JoueurService {
 
         return participations.stream()
                 .map(participation -> toPlayerMatchSummaryDto(participation, matricule, today))
+                .toList();
+    }
+
+    private OrganizerMatchSummaryDto toOrganizerMatchSummaryDto(MatchPadel match, LocalDate today) {
+        LocalDate dateMatch = match.getDateDebut().toLocalDate();
+
+        MatchTemporalStatusDto statutTemporel;
+        Integer joursAvantMatch = null;
+
+        if (dateMatch.isBefore(today)) {
+            statutTemporel = MatchTemporalStatusDto.PASSE;
+        } else if (dateMatch.isEqual(today)) {
+            statutTemporel = MatchTemporalStatusDto.AUJOURD_HUI;
+        } else {
+            statutTemporel = MatchTemporalStatusDto.FUTUR;
+            joursAvantMatch = (int) ChronoUnit.DAYS.between(today, dateMatch);
+        }
+
+        int nbParticipants = match.getParticipations().size();
+        int placesRestantes = Math.max(0, CAPACITE_MATCH - nbParticipants);
+        boolean complet = nbParticipants >= CAPACITE_MATCH;
+
+        boolean risquePenaliteJ1 =
+                match.getVisibilite() == MatchVisibilite.PRIVE
+                        && !complet
+                        && statutTemporel == MatchTemporalStatusDto.FUTUR
+                        && joursAvantMatch != null
+                        && joursAvantMatch <= 1;
+
+        return new OrganizerMatchSummaryDto(
+                match.getId(),
+                match.getDateDebut(),
+                match.getTerrain().getSite().getId(),
+                match.getTerrain().getSite().getNom(),
+                match.getTerrain().getId(),
+                match.getTerrain().getNom(),
+                match.getVisibilite(),
+                nbParticipants,
+                placesRestantes,
+                complet,
+                statutTemporel,
+                joursAvantMatch,
+                risquePenaliteJ1
+        );
+    }
+    public List<OrganizerMatchSummaryDto> getOrganizedMatches(String matricule) {
+        getJoueur(matricule);
+
+        List<MatchPadel> matchs =
+                matchPadelRepository.findOrganizedMatchesWithDetailsByMatricule(matricule);
+
+        LocalDate today = LocalDate.now();
+
+        return matchs.stream()
+                .map(match -> toOrganizerMatchSummaryDto(match, today))
                 .toList();
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/JoueurServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/JoueurServiceTest.java
@@ -3,6 +3,7 @@ package be.ephec.padel.backend.unit.service;
 import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
 import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
 import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
+import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.*;
@@ -11,6 +12,7 @@ import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.service.JoueurService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +33,7 @@ class JoueurServiceTest {
     private JoueurRepository joueurRepo;
     private SiteRepository siteRepo;
     private JoueurService service;
-
+    private MatchPadelRepository matchPadelRepo;
     private ParticipationRepository participationRepo;
 
     @BeforeEach
@@ -39,7 +41,8 @@ class JoueurServiceTest {
         joueurRepo = mock(JoueurRepository.class);
         siteRepo = mock(SiteRepository.class);
         participationRepo = mock(ParticipationRepository.class);
-        service = new JoueurService(joueurRepo, siteRepo, participationRepo);
+        matchPadelRepo = mock(MatchPadelRepository.class);
+        service = new JoueurService(joueurRepo, siteRepo, participationRepo,matchPadelRepo);
     }
 
     private Participation mockParticipation(String organisateurMatricule,
@@ -85,11 +88,41 @@ class JoueurServiceTest {
 
         return participation;
     }
+    private MatchPadel mockOrganizedMatch(LocalDate dateMatch,
+                                          MatchVisibilite visibilite,
+                                          int nbParticipations,
+                                          Long matchId,
+                                          Long terrainId,
+                                          String terrainNom,
+                                          Long siteId,
+                                          String siteNom) {
+        MatchPadel match = mock(MatchPadel.class);
+        Terrain terrain = mock(Terrain.class);
+        Site site = mock(Site.class);
+        Joueur organisateur = mock(Joueur.class);
 
-    // ----------------
-    // creerJoueur validations
-    // ----------------
+        when(match.getId()).thenReturn(matchId);
+        when(match.getDateDebut()).thenReturn(LocalDateTime.of(dateMatch, LocalTime.of(10, 0)));
+        when(match.getVisibilite()).thenReturn(visibilite);
+        when(match.getTerrain()).thenReturn(terrain);
+        when(match.getOrganisateur()).thenReturn(organisateur);
 
+        when(terrain.getId()).thenReturn(terrainId);
+        when(terrain.getNom()).thenReturn(terrainNom);
+        when(terrain.getSite()).thenReturn(site);
+
+        when(site.getId()).thenReturn(siteId);
+        when(site.getNom()).thenReturn(siteNom);
+
+        when(organisateur.getMatricule()).thenReturn("G0001");
+
+        List<Participation> participations = java.util.stream.IntStream.range(0, nbParticipations)
+                .mapToObj(i -> mock(Participation.class))
+                .toList();
+        when(match.getParticipations()).thenReturn(participations);
+
+        return match;
+    }
     @Test
     void creerJoueur_matriculeNull_ouBlank_refuse() {
         assertThrows(BusinessException.class, () -> service.creerJoueur(null, "Nom", TypeJoueur.GLOBAL, null));
@@ -501,5 +534,230 @@ class JoueurServiceTest {
         assertEquals("Terrain B", result.get(1).terrainNom());
         assertEquals(PlayerMatchRoleDto.ORGANISATEUR, result.get(1).roleJoueur());
         assertTrue(result.get(1).paiementJoueurEffectue());
+    }
+    // ----------------
+// getOrganizedMatches
+// ----------------
+
+    @Test
+    void getOrganizedMatches_joueurIntrouvable_notFound() {
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> service.getOrganizedMatches("G0001"));
+
+        verify(joueurRepo).findById("G0001");
+        verifyNoInteractions(matchPadelRepo);
+    }
+
+    @Test
+    void getOrganizedMatches_joueurExistant_sansMatchOrganise_retourneListeVide() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+        when(matchPadelRepo.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of());
+
+        List<OrganizerMatchSummaryDto> result = service.getOrganizedMatches("G0001");
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(joueurRepo).findById("G0001");
+        verify(matchPadelRepo).findOrganizedMatchesWithDetailsByMatricule("G0001");
+    }
+
+    @Test
+    void getOrganizedMatches_matchFuturPriveIncomplet_risquePenaliteTrue() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        MatchPadel match = mockOrganizedMatch(
+                LocalDate.now().plusDays(1),
+                MatchVisibilite.PRIVE,
+                2,
+                1L,
+                10L,
+                "Terrain 1",
+                100L,
+                "Site Delta"
+        );
+
+        when(matchPadelRepo.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of(match));
+
+        List<OrganizerMatchSummaryDto> result = service.getOrganizedMatches("G0001");
+
+        assertEquals(1, result.size());
+
+        OrganizerMatchSummaryDto dto = result.get(0);
+        assertEquals(1L, dto.id());
+        assertEquals(10L, dto.terrainId());
+        assertEquals("Terrain 1", dto.terrainNom());
+        assertEquals(100L, dto.siteId());
+        assertEquals("Site Delta", dto.siteNom());
+        assertEquals(MatchVisibilite.PRIVE, dto.visibilite());
+        assertEquals(2, dto.nbParticipants());
+        assertEquals(2, dto.placesRestantes());
+        assertFalse(dto.complet());
+        assertEquals(MatchTemporalStatusDto.FUTUR, dto.statutTemporel());
+        assertEquals(1, dto.joursAvantMatch());
+        assertTrue(dto.risquePenaliteJ1());
+    }
+
+    @Test
+    void getOrganizedMatches_matchFuturPublicIncomplet_risquePenaliteFalse() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        MatchPadel match = mockOrganizedMatch(
+                LocalDate.now().plusDays(1),
+                MatchVisibilite.PUBLIC,
+                2,
+                2L,
+                20L,
+                "Terrain 2",
+                200L,
+                "Site Omega"
+        );
+
+        when(matchPadelRepo.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of(match));
+
+        List<OrganizerMatchSummaryDto> result = service.getOrganizedMatches("G0001");
+
+        OrganizerMatchSummaryDto dto = result.get(0);
+        assertEquals(MatchVisibilite.PUBLIC, dto.visibilite());
+        assertEquals(2, dto.nbParticipants());
+        assertEquals(2, dto.placesRestantes());
+        assertFalse(dto.complet());
+        assertEquals(MatchTemporalStatusDto.FUTUR, dto.statutTemporel());
+        assertEquals(1, dto.joursAvantMatch());
+        assertFalse(dto.risquePenaliteJ1());
+    }
+
+    @Test
+    void getOrganizedMatches_matchComplet_placesRestantesZero_et_pasDeRisque() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        MatchPadel match = mockOrganizedMatch(
+                LocalDate.now().plusDays(3),
+                MatchVisibilite.PRIVE,
+                4,
+                3L,
+                30L,
+                "Terrain 3",
+                300L,
+                "Site Full"
+        );
+
+        when(matchPadelRepo.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of(match));
+
+        List<OrganizerMatchSummaryDto> result = service.getOrganizedMatches("G0001");
+
+        OrganizerMatchSummaryDto dto = result.get(0);
+        assertEquals(4, dto.nbParticipants());
+        assertEquals(0, dto.placesRestantes());
+        assertTrue(dto.complet());
+        assertEquals(MatchTemporalStatusDto.FUTUR, dto.statutTemporel());
+        assertEquals(3, dto.joursAvantMatch());
+        assertFalse(dto.risquePenaliteJ1());
+    }
+
+    @Test
+    void getOrganizedMatches_matchAujourdHui_statutAujourdHui_et_joursNull() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        MatchPadel match = mockOrganizedMatch(
+                LocalDate.now(),
+                MatchVisibilite.PRIVE,
+                3,
+                4L,
+                40L,
+                "Terrain 4",
+                400L,
+                "Site Today"
+        );
+
+        when(matchPadelRepo.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of(match));
+
+        List<OrganizerMatchSummaryDto> result = service.getOrganizedMatches("G0001");
+
+        OrganizerMatchSummaryDto dto = result.get(0);
+        assertEquals(MatchTemporalStatusDto.AUJOURD_HUI, dto.statutTemporel());
+        assertNull(dto.joursAvantMatch());
+        assertFalse(dto.risquePenaliteJ1());
+    }
+
+    @Test
+    void getOrganizedMatches_matchPasse_statutPasse_et_joursNull() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        MatchPadel match = mockOrganizedMatch(
+                LocalDate.now().minusDays(2),
+                MatchVisibilite.PRIVE,
+                1,
+                5L,
+                50L,
+                "Terrain 5",
+                500L,
+                "Site Past"
+        );
+
+        when(matchPadelRepo.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of(match));
+
+        List<OrganizerMatchSummaryDto> result = service.getOrganizedMatches("G0001");
+
+        OrganizerMatchSummaryDto dto = result.get(0);
+        assertEquals(MatchTemporalStatusDto.PASSE, dto.statutTemporel());
+        assertNull(dto.joursAvantMatch());
+        assertFalse(dto.risquePenaliteJ1());
+    }
+
+    @Test
+    void getOrganizedMatches_plusieursMatchs_conserveOrdreDuRepository() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        MatchPadel first = mockOrganizedMatch(
+                LocalDate.now().plusDays(1),
+                MatchVisibilite.PUBLIC,
+                1,
+                10L,
+                101L,
+                "Terrain A",
+                1001L,
+                "Site A"
+        );
+
+        MatchPadel second = mockOrganizedMatch(
+                LocalDate.now().plusDays(4),
+                MatchVisibilite.PRIVE,
+                3,
+                20L,
+                202L,
+                "Terrain B",
+                2002L,
+                "Site B"
+        );
+
+        when(matchPadelRepo.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of(first, second));
+
+        List<OrganizerMatchSummaryDto> result = service.getOrganizedMatches("G0001");
+
+        assertEquals(2, result.size());
+
+        assertEquals(10L, result.get(0).id());
+        assertEquals(101L, result.get(0).terrainId());
+        assertEquals("Terrain A", result.get(0).terrainNom());
+
+        assertEquals(20L, result.get(1).id());
+        assertEquals(202L, result.get(1).terrainId());
+        assertEquals("Terrain B", result.get(1).terrainNom());
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/JoueurControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/JoueurControllerTest.java
@@ -5,6 +5,7 @@ import be.ephec.padel.backend.controller.JoueurController;
 import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
 import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
 import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
+import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
 import be.ephec.padel.backend.error.ApiExceptionHandler;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
@@ -217,6 +218,67 @@ class JoueurControllerTest {
                 .thenThrow(new NotFoundException("Joueur introuvable"));
 
         mvc.perform(get("/api/v1/joueurs/G9999/matchs")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+    @Test
+    void getOrganizedMatches_retourne200_etListeVide() throws Exception {
+        when(joueurService.getOrganizedMatches("G0001")).thenReturn(List.of());
+
+        mvc.perform(get("/api/v1/joueurs/G0001/matchs/organises")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void getOrganizedMatches_retourne200_etListeDeMatchs() throws Exception {
+        OrganizerMatchSummaryDto dto = new OrganizerMatchSummaryDto(
+                1L,
+                LocalDateTime.of(2030, 1, 10, 10, 0),
+                100L,
+                "Site Delta",
+                200L,
+                "Terrain 1",
+                MatchVisibilite.PRIVE,
+                2,
+                2,
+                false,
+                MatchTemporalStatusDto.FUTUR,
+                1,
+                true
+        );
+
+        when(joueurService.getOrganizedMatches("G0001")).thenReturn(List.of(dto));
+
+        mvc.perform(get("/api/v1/joueurs/G0001/matchs/organises")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].siteId").value(100))
+                .andExpect(jsonPath("$[0].siteNom").value("Site Delta"))
+                .andExpect(jsonPath("$[0].terrainId").value(200))
+                .andExpect(jsonPath("$[0].terrainNom").value("Terrain 1"))
+                .andExpect(jsonPath("$[0].visibilite").value("PRIVE"))
+                .andExpect(jsonPath("$[0].nbParticipants").value(2))
+                .andExpect(jsonPath("$[0].placesRestantes").value(2))
+                .andExpect(jsonPath("$[0].complet").value(false))
+                .andExpect(jsonPath("$[0].statutTemporel").value("FUTUR"))
+                .andExpect(jsonPath("$[0].joursAvantMatch").value(1))
+                .andExpect(jsonPath("$[0].risquePenaliteJ1").value(true));
+    }
+
+    @Test
+    void getOrganizedMatches_joueurIntrouvable_retourne404() throws Exception {
+        when(joueurService.getOrganizedMatches("G9999"))
+                .thenThrow(new NotFoundException("Joueur introuvable"));
+
+        mvc.perform(get("/api/v1/joueurs/G9999/matchs/organises")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
     }


### PR DESCRIPTION
Ajout de l’endpoint GET /api/v1/joueurs/{matricule}/matchs/organises permettant de récupérer les matchs dont le joueur est organisateur.

Implémentation d’un DTO OrganizerMatchSummaryDto avec :
- résumé du match (date, site, terrain, visibilite)
- état de remplissage (nbParticipants, placesRestantes, complet)
- statut temporel (PASSÉ, AUJOURD’HUI, FUTUR)
- joursAvantMatch
- indicateur risquePenaliteJ1 pour les matchs privés incomplets à J-1

La logique repose sur MatchPadel (et non Participation), en cohérence avec une vue organisateur orientée gestion du remplissage.

Le détail complet des matchs reste accessible via l’endpoint existant (#54).

Ajout des tests unitaires et controller associés.