### PR TITLE
feat: gestion des fermetures de site avec validation avancée (#50)

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/FermetureSiteAdminController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/FermetureSiteAdminController.java
@@ -1,0 +1,99 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.request.CreateFermetureSiteDateRequest;
+import be.ephec.padel.backend.dto.request.CreateFermetureSitePeriodeRequest;
+import be.ephec.padel.backend.dto.request.UpdateFermetureSiteDateRequest;
+import be.ephec.padel.backend.dto.request.UpdateFermetureSitePeriodeRequest;
+import be.ephec.padel.backend.dto.response.FermetureSiteDto;
+import be.ephec.padel.backend.mapper.FermetureSiteMapper;
+import be.ephec.padel.backend.model.entities.FermetureSite;
+import be.ephec.padel.backend.service.FermetureSiteService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/sites/{siteId}/fermetures")
+public class FermetureSiteAdminController {
+
+    private final FermetureSiteService fermetureSiteService;
+
+    public FermetureSiteAdminController(FermetureSiteService fermetureSiteService) {
+        this.fermetureSiteService = fermetureSiteService;
+    }
+
+    @PostMapping("/date")
+    public ResponseEntity<FermetureSiteDto> createDate(@PathVariable Long siteId,
+                                                       @RequestBody CreateFermetureSiteDateRequest request) {
+        FermetureSite created = fermetureSiteService.creerDate(siteId, request);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path("/api/v1/admin/sites/{siteId}/fermetures/{fermetureId}")
+                .buildAndExpand(siteId, created.getId())
+                .toUri();
+
+        return ResponseEntity
+                .created(location)
+                .body(FermetureSiteMapper.toDto(created));
+    }
+
+    @PostMapping("/periode")
+    public ResponseEntity<FermetureSiteDto> createPeriode(@PathVariable Long siteId,
+                                                          @RequestBody CreateFermetureSitePeriodeRequest request) {
+        FermetureSite created = fermetureSiteService.creerPeriode(siteId, request);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path("/api/v1/admin/sites/{siteId}/fermetures/{fermetureId}")
+                .buildAndExpand(siteId, created.getId())
+                .toUri();
+
+        return ResponseEntity
+                .created(location)
+                .body(FermetureSiteMapper.toDto(created));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<FermetureSiteDto>> getAllBySite(@PathVariable Long siteId) {
+        List<FermetureSiteDto> result = fermetureSiteService.listerParSite(siteId)
+                .stream()
+                .map(FermetureSiteMapper::toDto)
+                .toList();
+
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{fermetureId}")
+    public ResponseEntity<FermetureSiteDto> getOne(@PathVariable Long siteId,
+                                                   @PathVariable Long fermetureId) {
+        FermetureSite fermeture = fermetureSiteService.getById(siteId, fermetureId);
+        return ResponseEntity.ok(FermetureSiteMapper.toDto(fermeture));
+    }
+
+    @PutMapping("/{fermetureId}/date")
+    public ResponseEntity<FermetureSiteDto> updateDate(@PathVariable Long siteId,
+                                                       @PathVariable Long fermetureId,
+                                                       @RequestBody UpdateFermetureSiteDateRequest request) {
+        FermetureSite updated = fermetureSiteService.updateDate(siteId, fermetureId, request);
+        return ResponseEntity.ok(FermetureSiteMapper.toDto(updated));
+    }
+
+    @PutMapping("/{fermetureId}/periode")
+    public ResponseEntity<FermetureSiteDto> updatePeriode(@PathVariable Long siteId,
+                                                          @PathVariable Long fermetureId,
+                                                          @RequestBody UpdateFermetureSitePeriodeRequest request) {
+        FermetureSite updated = fermetureSiteService.updatePeriode(siteId, fermetureId, request);
+        return ResponseEntity.ok(FermetureSiteMapper.toDto(updated));
+    }
+
+    @DeleteMapping("/{fermetureId}")
+    public ResponseEntity<Void> delete(@PathVariable Long siteId,
+                                       @PathVariable Long fermetureId) {
+        fermetureSiteService.delete(siteId, fermetureId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateFermetureSiteDateRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateFermetureSiteDateRequest.java
@@ -1,0 +1,25 @@
+package be.ephec.padel.backend.dto.request;
+
+import java.time.LocalDate;
+
+public class CreateFermetureSiteDateRequest {
+
+    private LocalDate date;
+    private String motif;
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public String getMotif() {
+        return motif;
+    }
+
+    public void setMotif(String motif) {
+        this.motif = motif;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateFermetureSitePeriodeRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/CreateFermetureSitePeriodeRequest.java
@@ -1,0 +1,34 @@
+package be.ephec.padel.backend.dto.request;
+
+import java.time.LocalDate;
+
+public class CreateFermetureSitePeriodeRequest {
+
+    private LocalDate dateDebut;
+    private LocalDate dateFin;
+    private String motif;
+
+    public LocalDate getDateDebut() {
+        return dateDebut;
+    }
+
+    public void setDateDebut(LocalDate dateDebut) {
+        this.dateDebut = dateDebut;
+    }
+
+    public LocalDate getDateFin() {
+        return dateFin;
+    }
+
+    public void setDateFin(LocalDate dateFin) {
+        this.dateFin = dateFin;
+    }
+
+    public String getMotif() {
+        return motif;
+    }
+
+    public void setMotif(String motif) {
+        this.motif = motif;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/UpdateFermetureSiteDateRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/UpdateFermetureSiteDateRequest.java
@@ -1,0 +1,25 @@
+package be.ephec.padel.backend.dto.request;
+
+import java.time.LocalDate;
+
+public class UpdateFermetureSiteDateRequest {
+
+    private LocalDate date;
+    private String motif;
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public String getMotif() {
+        return motif;
+    }
+
+    public void setMotif(String motif) {
+        this.motif = motif;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/UpdateFermetureSitePeriodeRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/UpdateFermetureSitePeriodeRequest.java
@@ -1,0 +1,34 @@
+package be.ephec.padel.backend.dto.request;
+
+import java.time.LocalDate;
+
+public class UpdateFermetureSitePeriodeRequest {
+
+    private LocalDate dateDebut;
+    private LocalDate dateFin;
+    private String motif;
+
+    public LocalDate getDateDebut() {
+        return dateDebut;
+    }
+
+    public void setDateDebut(LocalDate dateDebut) {
+        this.dateDebut = dateDebut;
+    }
+
+    public LocalDate getDateFin() {
+        return dateFin;
+    }
+
+    public void setDateFin(LocalDate dateFin) {
+        this.dateFin = dateFin;
+    }
+
+    public String getMotif() {
+        return motif;
+    }
+
+    public void setMotif(String motif) {
+        this.motif = motif;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/FermetureSiteDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/FermetureSiteDto.java
@@ -1,0 +1,51 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.time.LocalDate;
+
+public class FermetureSiteDto {
+
+    private Long id;
+    private Long siteId;
+    private LocalDate date;
+    private LocalDate dateDebut;
+    private LocalDate dateFin;
+    private String motif;
+
+    public FermetureSiteDto(Long id,
+                            Long siteId,
+                            LocalDate date,
+                            LocalDate dateDebut,
+                            LocalDate dateFin,
+                            String motif) {
+        this.id = id;
+        this.siteId = siteId;
+        this.date = date;
+        this.dateDebut = dateDebut;
+        this.dateFin = dateFin;
+        this.motif = motif;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getSiteId() {
+        return siteId;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public LocalDate getDateDebut() {
+        return dateDebut;
+    }
+
+    public LocalDate getDateFin() {
+        return dateFin;
+    }
+
+    public String getMotif() {
+        return motif;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/FermetureSiteMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/FermetureSiteMapper.java
@@ -1,0 +1,30 @@
+package be.ephec.padel.backend.mapper;
+
+import be.ephec.padel.backend.dto.response.FermetureSiteDto;
+import be.ephec.padel.backend.model.entities.FermetureSite;
+
+public final class FermetureSiteMapper {
+
+    private FermetureSiteMapper() {
+    }
+
+    public static FermetureSiteDto toDto(FermetureSite f) {
+        if (f == null) {
+            return null;
+        }
+
+        Long siteId = null;
+        if (f.getSite() != null) {
+            siteId = f.getSite().getId();
+        }
+
+        return new FermetureSiteDto(
+                f.getId(),
+                siteId,
+                f.getDate(),
+                f.getDateDebut(),
+                f.getDateFin(),
+                f.getMotif()
+        );
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/FermetureSite.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/FermetureSite.java
@@ -1,0 +1,54 @@
+package be.ephec.padel.backend.model.entities;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "fermeture_site")
+public class FermetureSite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "site_id", nullable = false)
+    private Site site;
+
+    @Column(name = "date_fermeture")
+    private LocalDate date;
+
+    @Column(name = "date_debut")
+    private LocalDate dateDebut;
+
+    @Column(name = "date_fin")
+    private LocalDate dateFin;
+
+    @Column(name = "motif")
+    private String motif;
+
+    public FermetureSite() {
+    }
+
+    public FermetureSite(Site site, LocalDate date, LocalDate dateDebut, LocalDate dateFin, String motif) {
+        this.site = site;
+        this.date = date;
+        this.dateDebut = dateDebut;
+        this.dateFin = dateFin;
+        this.motif = motif;
+    }
+
+    public Long getId() { return id; }
+    public Site getSite() { return site; }
+    public LocalDate getDate() { return date; }
+    public LocalDate getDateDebut() { return dateDebut; }
+    public LocalDate getDateFin() { return dateFin; }
+    public String getMotif() { return motif; }
+
+    public void setSite(Site site) { this.site = site; }
+    public void setDate(LocalDate date) { this.date = date; }
+    public void setDateDebut(LocalDate dateDebut) { this.dateDebut = dateDebut; }
+    public void setDateFin(LocalDate dateFin) { this.dateFin = dateFin; }
+    public void setMotif(String motif) { this.motif = motif; }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/FermetureSiteRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/FermetureSiteRepository.java
@@ -1,0 +1,42 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.FermetureSite;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface FermetureSiteRepository extends JpaRepository<FermetureSite, Long> {
+
+    List<FermetureSite> findBySiteIdOrderByDateAscDateDebutAsc(Long siteId);
+
+    Optional<FermetureSite> findByIdAndSiteId(Long id, Long siteId);
+
+    boolean existsBySiteIdAndDate(Long siteId, LocalDate date);
+
+    boolean existsBySiteIdAndDateDebutAndDateFin(Long siteId, LocalDate dateDebut, LocalDate dateFin);
+
+    boolean existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(
+            Long siteId,
+            LocalDate date1,
+            LocalDate date2
+    );
+
+    boolean existsBySiteIdAndDateBetween(Long siteId, LocalDate start, LocalDate end);
+
+    @Query("""
+           select count(f) > 0
+           from FermetureSite f
+           where f.site.id = :siteId
+             and f.dateDebut is not null
+             and f.dateFin is not null
+             and f.dateDebut <= :newEnd
+             and f.dateFin >= :newStart
+           """)
+    boolean existsPeriodeChevauchante(@Param("siteId") Long siteId,
+                                      @Param("newStart") LocalDate newStart,
+                                      @Param("newEnd") LocalDate newEnd);
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/FermetureSiteService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/FermetureSiteService.java
@@ -1,0 +1,259 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.dto.request.CreateFermetureSiteDateRequest;
+import be.ephec.padel.backend.dto.request.CreateFermetureSitePeriodeRequest;
+import be.ephec.padel.backend.dto.request.UpdateFermetureSiteDateRequest;
+import be.ephec.padel.backend.dto.request.UpdateFermetureSitePeriodeRequest;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.FermetureSite;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.repository.FermetureSiteRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.security.ServiceAutorisationAdmin;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+public class FermetureSiteService {
+
+    private final FermetureSiteRepository fermetureSiteRepository;
+    private final SiteRepository siteRepository;
+    private final ServiceAutorisationAdmin serviceAutorisationAdmin;
+
+    public FermetureSiteService(FermetureSiteRepository fermetureSiteRepository,
+                                SiteRepository siteRepository,
+                                ServiceAutorisationAdmin serviceAutorisationAdmin) {
+        this.fermetureSiteRepository = fermetureSiteRepository;
+        this.siteRepository = siteRepository;
+        this.serviceAutorisationAdmin = serviceAutorisationAdmin;
+    }
+
+    @Transactional(readOnly = true)
+    public List<FermetureSite> listerParSite(Long siteId) {
+        serviceAutorisationAdmin.verifierAccesAuSite(siteId);
+        getSiteOrThrow(siteId);
+        return fermetureSiteRepository.findBySiteIdOrderByDateAscDateDebutAsc(siteId);
+    }
+
+    @Transactional(readOnly = true)
+    public FermetureSite getById(Long siteId, Long fermetureId) {
+        serviceAutorisationAdmin.verifierAccesAuSite(siteId);
+
+        if (fermetureId == null) {
+            throw new BusinessException("Id fermeture obligatoire");
+        }
+
+        getSiteOrThrow(siteId);
+
+        return fermetureSiteRepository.findByIdAndSiteId(fermetureId, siteId)
+                .orElseThrow(() -> new NotFoundException("Fermeture site introuvable"));
+    }
+
+    public FermetureSite creerDate(Long siteId, CreateFermetureSiteDateRequest req) {
+        serviceAutorisationAdmin.verifierAccesAuSite(siteId);
+
+        Site site = getSiteOrThrow(siteId);
+        validerRequestDate(req);
+
+        if (fermetureSiteRepository.existsBySiteIdAndDate(siteId, req.getDate())) {
+            throw new BusinessException("Une fermeture existe déjà pour cette date");
+        }
+
+        if (fermetureSiteRepository.existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(
+                siteId, req.getDate(), req.getDate())) {
+            throw new BusinessException("Cette date est déjà couverte par une période de fermeture");
+        }
+
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+        fermeture.setDate(req.getDate());
+        fermeture.setDateDebut(null);
+        fermeture.setDateFin(null);
+        fermeture.setMotif(req.getMotif());
+
+        return fermetureSiteRepository.save(fermeture);
+    }
+
+    public FermetureSite creerPeriode(Long siteId, CreateFermetureSitePeriodeRequest req) {
+        serviceAutorisationAdmin.verifierAccesAuSite(siteId);
+
+        Site site = getSiteOrThrow(siteId);
+        validerRequestPeriode(req);
+
+        if (fermetureSiteRepository.existsBySiteIdAndDateDebutAndDateFin(
+                siteId, req.getDateDebut(), req.getDateFin())) {
+            throw new BusinessException("Une fermeture existe déjà pour cette période");
+        }
+
+        if (fermetureSiteRepository.existsPeriodeChevauchante(
+                siteId, req.getDateDebut(), req.getDateFin())) {
+            throw new BusinessException("Cette période chevauche une autre fermeture");
+        }
+
+        if (fermetureSiteRepository.existsBySiteIdAndDateBetween(
+                siteId, req.getDateDebut(), req.getDateFin())) {
+            throw new BusinessException("Cette période contient déjà une date de fermeture");
+        }
+
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+        fermeture.setDate(null);
+        fermeture.setDateDebut(req.getDateDebut());
+        fermeture.setDateFin(req.getDateFin());
+        fermeture.setMotif(req.getMotif());
+
+        return fermetureSiteRepository.save(fermeture);
+    }
+
+    public FermetureSite updateDate(Long siteId, Long fermetureId, UpdateFermetureSiteDateRequest req) {
+        FermetureSite fermeture = getById(siteId, fermetureId);
+        validerRequestDate(req);
+
+        boolean duplicateDate = fermetureSiteRepository.existsBySiteIdAndDate(siteId, req.getDate());
+        boolean sameAsCurrentDate = req.getDate().equals(fermeture.getDate());
+
+        if (duplicateDate && !sameAsCurrentDate) {
+            throw new BusinessException("Une fermeture existe déjà pour cette date");
+        }
+
+        boolean coveredByPeriod = fermetureSiteRepository.existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(
+                siteId, req.getDate(), req.getDate());
+
+        if (coveredByPeriod) {
+            throw new BusinessException("Cette date est déjà couverte par une période de fermeture");
+        }
+
+        fermeture.setDate(req.getDate());
+        fermeture.setDateDebut(null);
+        fermeture.setDateFin(null);
+        fermeture.setMotif(req.getMotif());
+
+        return fermetureSiteRepository.save(fermeture);
+    }
+
+    public FermetureSite updatePeriode(Long siteId, Long fermetureId, UpdateFermetureSitePeriodeRequest req) {
+        FermetureSite fermeture = getById(siteId, fermetureId);
+        validerRequestPeriode(req);
+
+        boolean sameAsCurrent =
+                req.getDateDebut().equals(fermeture.getDateDebut())
+                        && req.getDateFin().equals(fermeture.getDateFin());
+
+        boolean duplicate = fermetureSiteRepository.existsBySiteIdAndDateDebutAndDateFin(
+                siteId, req.getDateDebut(), req.getDateFin());
+
+        if (duplicate && !sameAsCurrent) {
+            throw new BusinessException("Une fermeture existe déjà pour cette période");
+        }
+
+        verifierChevauchementPeriodePourUpdate(siteId, fermetureId, req.getDateDebut(), req.getDateFin());
+
+        fermeture.setDate(null);
+        fermeture.setDateDebut(req.getDateDebut());
+        fermeture.setDateFin(req.getDateFin());
+        fermeture.setMotif(req.getMotif());
+
+        return fermetureSiteRepository.save(fermeture);
+    }
+
+    public void delete(Long siteId, Long fermetureId) {
+        FermetureSite fermeture = getById(siteId, fermetureId);
+        fermetureSiteRepository.delete(fermeture);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isDateFermeePourSite(Long siteId, LocalDate date) {
+        if (siteId == null) {
+            throw new BusinessException("Id site obligatoire");
+        }
+        if (date == null) {
+            throw new BusinessException("Date obligatoire");
+        }
+
+        return fermetureSiteRepository.existsBySiteIdAndDate(siteId, date)
+                || fermetureSiteRepository.existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(
+                siteId, date, date
+        );
+    }
+
+    private Site getSiteOrThrow(Long siteId) {
+        if (siteId == null) {
+            throw new BusinessException("Id site obligatoire");
+        }
+
+        return siteRepository.findById(siteId)
+                .orElseThrow(() -> new NotFoundException("Site introuvable"));
+    }
+
+    private void validerRequestDate(CreateFermetureSiteDateRequest req) {
+        if (req == null) {
+            throw new BusinessException("Requête obligatoire");
+        }
+        if (req.getDate() == null) {
+            throw new BusinessException("Date obligatoire");
+        }
+    }
+
+    private void validerRequestDate(UpdateFermetureSiteDateRequest req) {
+        if (req == null) {
+            throw new BusinessException("Requête obligatoire");
+        }
+        if (req.getDate() == null) {
+            throw new BusinessException("Date obligatoire");
+        }
+    }
+
+    private void validerRequestPeriode(CreateFermetureSitePeriodeRequest req) {
+        if (req == null) {
+            throw new BusinessException("Requête obligatoire");
+        }
+        if (req.getDateDebut() == null || req.getDateFin() == null) {
+            throw new BusinessException("La période doit contenir une date de début et une date de fin");
+        }
+        if (req.getDateFin().isBefore(req.getDateDebut())) {
+            throw new BusinessException("La date de fin doit être après ou égale à la date de début");
+        }
+    }
+
+    private void validerRequestPeriode(UpdateFermetureSitePeriodeRequest req) {
+        if (req == null) {
+            throw new BusinessException("Requête obligatoire");
+        }
+        if (req.getDateDebut() == null || req.getDateFin() == null) {
+            throw new BusinessException("La période doit contenir une date de début et une date de fin");
+        }
+        if (req.getDateFin().isBefore(req.getDateDebut())) {
+            throw new BusinessException("La date de fin doit être après ou égale à la date de début");
+        }
+    }
+    private void verifierChevauchementPeriodePourUpdate(Long siteId,
+                                                        Long fermetureId,
+                                                        LocalDate newStart,
+                                                        LocalDate newEnd) {
+        List<FermetureSite> fermetures = fermetureSiteRepository.findBySiteIdOrderByDateAscDateDebutAsc(siteId);
+
+        for (FermetureSite f : fermetures) {
+            if (f.getId().equals(fermetureId)) {
+                continue;
+            }
+
+            if (f.getDate() != null) {
+                if (!f.getDate().isBefore(newStart) && !f.getDate().isAfter(newEnd)) {
+                    throw new BusinessException("Cette période contient déjà une date de fermeture");
+                }
+            }
+
+            if (f.getDateDebut() != null && f.getDateFin() != null) {
+                boolean overlap = !f.getDateDebut().isAfter(newEnd) && !f.getDateFin().isBefore(newStart);
+                if (overlap) {
+                    throw new BusinessException("Cette période chevauche une autre fermeture");
+                }
+            }
+        }
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -21,6 +21,7 @@ import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.service.FermetureSiteService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
@@ -52,6 +53,7 @@ public class MatchPadelService {
     private final SoldeService soldeService;
     private final ParticipationRepository participationRepository;
     private final PaiementService paiementService;
+    private final FermetureSiteService fermetureSiteService;
     private final PaiementRepository paiementRepository;
     private final FermetureGlobaleRepository fermetureGlobaleRepository;
 
@@ -60,7 +62,7 @@ public class MatchPadelService {
                              JoueurRepository joueurRepository,
                              SoldeService soldeService,
                              ParticipationRepository participationRepository,
-                             PaiementService paiementService,
+                             PaiementService paiementService, FermetureSiteService fermetureSiteService,
                              PaiementRepository paiementRepository,
                              FermetureGlobaleRepository fermetureGlobaleRepository) {
         this.matchPadelRepository = matchPadelRepository;
@@ -71,6 +73,7 @@ public class MatchPadelService {
         this.paiementService = paiementService;
         this.paiementRepository = paiementRepository;
         this.fermetureGlobaleRepository = fermetureGlobaleRepository;
+        this.fermetureSiteService = fermetureSiteService;
     }
 
     @Transactional(readOnly = true)
@@ -177,6 +180,7 @@ public class MatchPadelService {
         verifierDroitReservation(organisateur, terrain, dateDebut, now);
         verifierFermetureGlobale(dateDebut);
         verifierOuvertureSite(terrain, dateDebut);
+        verifierFermetureSite(terrain, dateDebut);
         verifierTerrainDisponible(terrainId, dateDebut);
 
         MatchPadel match = new MatchPadel(terrain, organisateur, dateDebut, visibilite);
@@ -263,6 +267,21 @@ public class MatchPadelService {
                 }
             }
             default -> throw new BusinessException("Type joueur inconnu.");
+        }
+    }
+    private void verifierFermetureSite(Terrain terrain, LocalDateTime dateDebut) {
+        if (terrain == null || terrain.getSite() == null || terrain.getSite().getId() == null) {
+            throw new BusinessException("Terrain sans site associé.");
+        }
+        if (dateDebut == null) {
+            throw new BusinessException("Date début obligatoire");
+        }
+
+        Long siteId = terrain.getSite().getId();
+        LocalDate date = dateDebut.toLocalDate();
+
+        if (fermetureSiteService.isDateFermeePourSite(siteId, date)) {
+            throw new BusinessException("Réservation impossible : site fermé à cette date.");
         }
     }
 

--- a/backend/backend/src/main/resources/db/changelog/002-fermeture-site.yaml
+++ b/backend/backend/src/main/resources/db/changelog/002-fermeture-site.yaml
@@ -1,0 +1,61 @@
+databaseChangeLog:
+  - changeSet:
+      id: 002-1-create-fermeture-site
+      author: fanoa
+      changes:
+        - createTable:
+            tableName: fermeture_site
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_fermeture_site
+                    nullable: false
+              - column:
+                  name: site_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: date_fermeture
+                  type: date
+              - column:
+                  name: date_debut
+                  type: date
+              - column:
+                  name: date_fin
+                  type: date
+              - column:
+                  name: motif
+                  type: varchar(255)
+
+  - changeSet:
+      id: 002-2-fk-fermeture-site-site
+      author: fanoa
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: fermeture_site
+            baseColumnNames: site_id
+            referencedTableName: site
+            referencedColumnNames: id
+            constraintName: fk_fermeture_site_site
+
+  - changeSet:
+      id: 002-3-index-fermeture-site
+      author: fanoa
+      changes:
+        - createIndex:
+            tableName: fermeture_site
+            indexName: idx_fermeture_site_site
+            columns:
+              - column:
+                  name: site_id
+        - createIndex:
+            tableName: fermeture_site
+            indexName: idx_fermeture_site_date
+            columns:
+              - column:
+                  name: date_fermeture

--- a/backend/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,3 +1,5 @@
 databaseChangeLog:
   - include:
       file: db/changelog/001-init-schema.yaml
+  - include:
+      file: db/changelog/002-fermeture-site.yaml

--- a/backend/backend/src/test/java/be/ephec/padel/backend/integration/MatchCreationIntegrationIT.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/integration/MatchCreationIntegrationIT.java
@@ -1,11 +1,20 @@
 package be.ephec.padel.backend.integration;
 
 import be.ephec.padel.backend.model.entities.FermetureGlobale;
+import be.ephec.padel.backend.model.entities.FermetureSite;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.Site;
 import be.ephec.padel.backend.model.entities.Terrain;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
-import be.ephec.padel.backend.repository.*;
+import be.ephec.padel.backend.repository.FermetureGlobaleRepository;
+import be.ephec.padel.backend.repository.FermetureSiteRepository;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.MouvementSoldeRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
 import be.ephec.padel.backend.support.SqlServerTestContainerConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,7 +25,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
-import java.time.*;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Set;
 
@@ -31,6 +43,7 @@ class MatchCreationIntegrationIT extends SqlServerTestContainerConfig {
     @Autowired MockMvc mvc;
 
     @Autowired SiteRepository siteRepository;
+    @Autowired FermetureSiteRepository fermetureSiteRepository;
     @Autowired TerrainRepository terrainRepository;
     @Autowired JoueurRepository joueurRepository;
     @Autowired FermetureGlobaleRepository fermetureGlobaleRepository;
@@ -46,31 +59,31 @@ class MatchCreationIntegrationIT extends SqlServerTestContainerConfig {
 
     @BeforeEach
     void cleanAndSeed() {
-        // Nettoyage (ordre important à cause des FK)
+        // Nettoyage : toujours supprimer les enfants avant les parents
         paiementRepository.deleteAll();
         participationRepository.deleteAll();
         matchPadelRepository.deleteAll();
         mouvementSoldeRepository.deleteAll();
-        fermetureGlobaleRepository.deleteAll();
+        fermetureSiteRepository.deleteAll();
         terrainRepository.deleteAll();
+        fermetureGlobaleRepository.deleteAll();
         joueurRepository.deleteAll();
         siteRepository.deleteAll();
 
         // Seed minimal
         site = new Site("Site IT", "Bruxelles", LocalTime.of(8, 0), LocalTime.of(22, 0));
-        site.setJoursFermeture(Set.of()); // ouvert tous les jours par défaut
+        site.setJoursFermeture(Set.of());
         site = siteRepository.save(site);
 
         terrain = new Terrain("Terrain IT", site);
         terrain = terrainRepository.save(terrain);
 
         orga = new Joueur("G0001", "Orga Test", TypeJoueur.GLOBAL);
-        orga.setSolde(BigDecimal.ZERO); // sécurité si jamais
+        orga.setSolde(BigDecimal.ZERO);
         orga = joueurRepository.save(orga);
     }
 
     private String jsonCreateMatch(LocalDateTime dateDebut) {
-        // LocalDateTime -> format ISO "yyyy-MM-ddTHH:mm:ss" accepté par Jackson
         return """
                 {
                   "terrainId": %d,
@@ -104,7 +117,7 @@ class MatchCreationIntegrationIT extends SqlServerTestContainerConfig {
         LocalDateTime date = nextDay(DayOfWeek.SUNDAY, 10, 0);
 
         site.setJoursFermeture(Set.of(DayOfWeek.SUNDAY));
-        siteRepository.save(site);
+        site = siteRepository.save(site);
 
         mvc.perform(post("/api/v1/matchs")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -116,7 +129,6 @@ class MatchCreationIntegrationIT extends SqlServerTestContainerConfig {
 
     @Test
     void postMatch_refuse_si_hors_horaires_fin_depasse_fermeture() throws Exception {
-        // 21:30 + 105 minutes => dépasse 22:00 => refus
         LocalDateTime date = nextDay(DayOfWeek.WEDNESDAY, 21, 30);
 
         mvc.perform(post("/api/v1/matchs")
@@ -138,5 +150,45 @@ class MatchCreationIntegrationIT extends SqlServerTestContainerConfig {
                 .andExpect(header().string("Location", containsString("/api/v1/matchs/")))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").isNumber());
+    }
+
+    @Test
+    void postMatch_refuse_si_fermeture_site_exceptionnelle_date_unique() throws Exception {
+        LocalDateTime date = nextDay(DayOfWeek.TUESDAY, 10, 0);
+
+        fermetureSiteRepository.save(new FermetureSite(
+                site,
+                date.toLocalDate(),
+                null,
+                null,
+                "Congé exceptionnel"
+        ));
+
+        mvc.perform(post("/api/v1/matchs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonCreateMatch(date)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("site fermé à cette date")));
+    }
+
+    @Test
+    void postMatch_refuse_si_fermeture_site_exceptionnelle_periode() throws Exception {
+        LocalDateTime date = nextDay(DayOfWeek.WEDNESDAY, 10, 0);
+
+        fermetureSiteRepository.save(new FermetureSite(
+                site,
+                null,
+                date.toLocalDate().minusDays(1),
+                date.toLocalDate().plusDays(1),
+                "Travaux"
+        ));
+
+        mvc.perform(post("/api/v1/matchs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonCreateMatch(date)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("site fermé à cette date")));
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/repository/FermetureSiteRepositoryTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/repository/FermetureSiteRepositoryTest.java
@@ -1,0 +1,89 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.FermetureSite;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.support.SqlServerTestContainerConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class FermetureSiteRepositoryTest extends SqlServerTestContainerConfig {
+
+    @Autowired SiteRepository siteRepository;
+    @Autowired FermetureSiteRepository fermetureSiteRepository;
+
+    @Test
+    void existsBySiteIdAndDate_retourne_true_si_date_unique_existe() {
+        Site site = siteRepository.save(new Site("Site A", "Bruxelles"));
+        fermetureSiteRepository.save(new FermetureSite(
+                site,
+                LocalDate.of(2030, 1, 15),
+                null,
+                null,
+                "Jour férié local"
+        ));
+
+        assertThat(
+                fermetureSiteRepository.existsBySiteIdAndDate(site.getId(), LocalDate.of(2030, 1, 15))
+        ).isTrue();
+
+        assertThat(
+                fermetureSiteRepository.existsBySiteIdAndDate(site.getId(), LocalDate.of(2030, 1, 16))
+        ).isFalse();
+    }
+
+    @Test
+    void existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual_retourne_true_si_date_dans_periode() {
+        Site site = siteRepository.save(new Site("Site A", "Bruxelles"));
+        fermetureSiteRepository.save(new FermetureSite(
+                site,
+                null,
+                LocalDate.of(2030, 2, 10),
+                LocalDate.of(2030, 2, 15),
+                "Travaux"
+        ));
+
+        assertThat(
+                fermetureSiteRepository.existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(
+                        site.getId(),
+                        LocalDate.of(2030, 2, 12),
+                        LocalDate.of(2030, 2, 12)
+                )
+        ).isTrue();
+
+        assertThat(
+                fermetureSiteRepository.existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(
+                        site.getId(),
+                        LocalDate.of(2030, 2, 20),
+                        LocalDate.of(2030, 2, 20)
+                )
+        ).isFalse();
+    }
+
+    @Test
+    void findBySiteIdOrderByDateAscDateDebutAsc_retourne_les_fermetures_du_site() {
+        Site siteA = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Site siteB = siteRepository.save(new Site("Site B", "Liège"));
+
+        fermetureSiteRepository.save(new FermetureSite(
+                siteA, LocalDate.of(2030, 1, 10), null, null, "F1"
+        ));
+        fermetureSiteRepository.save(new FermetureSite(
+                siteA, null, LocalDate.of(2030, 2, 1), LocalDate.of(2030, 2, 3), "F2"
+        ));
+        fermetureSiteRepository.save(new FermetureSite(
+                siteB, LocalDate.of(2030, 3, 1), null, null, "F3"
+        ));
+
+        List<FermetureSite> result = fermetureSiteRepository.findBySiteIdOrderByDateAscDateDebutAsc(siteA.getId());
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(f -> f.getSite().getId().equals(siteA.getId()));
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/FermetureSiteServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/FermetureSiteServiceTest.java
@@ -1,0 +1,878 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.dto.request.CreateFermetureSiteDateRequest;
+import be.ephec.padel.backend.dto.request.CreateFermetureSitePeriodeRequest;
+import be.ephec.padel.backend.dto.request.UpdateFermetureSiteDateRequest;
+import be.ephec.padel.backend.dto.request.UpdateFermetureSitePeriodeRequest;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.ForbiddenException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.FermetureSite;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.repository.FermetureSiteRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.security.ServiceAutorisationAdmin;
+import be.ephec.padel.backend.service.FermetureSiteService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class FermetureSiteServiceTest {
+
+    private FermetureSiteRepository fermetureSiteRepository;
+    private SiteRepository siteRepository;
+    private ServiceAutorisationAdmin serviceAutorisationAdmin;
+    private FermetureSiteService service;
+
+    @BeforeEach
+    void setup() {
+        fermetureSiteRepository = mock(FermetureSiteRepository.class);
+        siteRepository = mock(SiteRepository.class);
+        serviceAutorisationAdmin = mock(ServiceAutorisationAdmin.class);
+
+        service = new FermetureSiteService(
+                fermetureSiteRepository,
+                siteRepository,
+                serviceAutorisationAdmin
+        );
+
+        doNothing().when(serviceAutorisationAdmin).verifierAccesAuSite(anyLong());
+    }
+
+    // --------
+    // listerParSite
+    // --------
+
+    @Test
+    void listerParSite_idNull_refuse() {
+        assertThrows(BusinessException.class, () -> service.listerParSite(null));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(null);
+        verifyNoInteractions(fermetureSiteRepository);
+        verifyNoMoreInteractions(siteRepository);
+    }
+
+    @Test
+    void listerParSite_refuse_si_admin_hors_perimetre() {
+        doThrow(new ForbiddenException("Accès refusé à ce site"))
+                .when(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+
+        assertThrows(ForbiddenException.class, () -> service.listerParSite(2L));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+        verifyNoInteractions(siteRepository, fermetureSiteRepository);
+    }
+
+    @Test
+    void listerParSite_siteIntrouvable_notFound() {
+        when(siteRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> service.listerParSite(1L));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verifyNoInteractions(fermetureSiteRepository);
+    }
+
+    @Test
+    void listerParSite_ok() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite f1 = new FermetureSite();
+        f1.setSite(site);
+        f1.setDate(LocalDate.of(2030, 1, 10));
+
+        FermetureSite f2 = new FermetureSite();
+        f2.setSite(site);
+        f2.setDateDebut(LocalDate.of(2030, 2, 1));
+        f2.setDateFin(LocalDate.of(2030, 2, 3));
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findBySiteIdOrderByDateAscDateDebutAsc(1L))
+                .thenReturn(List.of(f1, f2));
+
+        List<FermetureSite> res = service.listerParSite(1L);
+
+        assertEquals(2, res.size());
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).findBySiteIdOrderByDateAscDateDebutAsc(1L);
+    }
+
+    // --------
+    // getById
+    // --------
+
+    @Test
+    void getById_refuse_si_admin_hors_perimetre() {
+        doThrow(new ForbiddenException("Accès refusé à ce site"))
+                .when(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+
+        assertThrows(ForbiddenException.class, () -> service.getById(2L, 10L));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+        verifyNoInteractions(siteRepository, fermetureSiteRepository);
+    }
+
+    @Test
+    void getById_refuse_si_fermetureId_null() {
+        assertThrows(BusinessException.class, () -> service.getById(1L, null));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verifyNoInteractions(fermetureSiteRepository);
+    }
+
+    @Test
+    void getById_siteIntrouvable_notFound() {
+        when(siteRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> service.getById(1L, 10L));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verifyNoInteractions(fermetureSiteRepository);
+    }
+
+    @Test
+    void getById_fermetureIntrouvable_notFound() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> service.getById(1L, 10L));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).findByIdAndSiteId(10L, 1L);
+    }
+
+    @Test
+    void getById_ok() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+        fermeture.setDate(LocalDate.of(2030, 1, 15));
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.of(fermeture));
+
+        FermetureSite res = service.getById(1L, 10L);
+
+        assertSame(fermeture, res);
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).findByIdAndSiteId(10L, 1L);
+    }
+
+    // --------
+    // creerDate
+    // --------
+
+    @Test
+    void creerDate_siteIdNull_refuse() {
+        CreateFermetureSiteDateRequest req = new CreateFermetureSiteDateRequest();
+        req.setDate(LocalDate.of(2030, 1, 15));
+
+        assertThrows(BusinessException.class, () -> service.creerDate(null, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(null);
+        verifyNoInteractions(siteRepository, fermetureSiteRepository);
+    }
+
+    @Test
+    void creerDate_refuse_si_admin_hors_perimetre() {
+        CreateFermetureSiteDateRequest req = new CreateFermetureSiteDateRequest();
+        req.setDate(LocalDate.of(2030, 1, 15));
+
+        doThrow(new ForbiddenException("Accès refusé à ce site"))
+                .when(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+
+        assertThrows(ForbiddenException.class, () -> service.creerDate(2L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+        verifyNoInteractions(siteRepository, fermetureSiteRepository);
+    }
+
+    @Test
+    void creerDate_siteIntrouvable_notFound() {
+        CreateFermetureSiteDateRequest req = new CreateFermetureSiteDateRequest();
+        req.setDate(LocalDate.of(2030, 1, 15));
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> service.creerDate(1L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verifyNoInteractions(fermetureSiteRepository);
+    }
+
+    @Test
+    void creerDate_requestNull_refuse() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+
+        assertThrows(BusinessException.class, () -> service.creerDate(1L, null));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verifyNoInteractions(fermetureSiteRepository);
+    }
+
+    @Test
+    void creerDate_refuse_si_date_absente() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+
+        CreateFermetureSiteDateRequest req = new CreateFermetureSiteDateRequest();
+
+        assertThrows(BusinessException.class, () -> service.creerDate(1L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verifyNoInteractions(fermetureSiteRepository);
+    }
+
+    @Test
+    void creerDate_refuse_si_date_deja_existante() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.existsBySiteIdAndDate(1L, LocalDate.of(2030, 1, 15)))
+                .thenReturn(true);
+
+        CreateFermetureSiteDateRequest req = new CreateFermetureSiteDateRequest();
+        req.setDate(LocalDate.of(2030, 1, 15));
+        req.setMotif("Jour férié");
+
+        assertThrows(BusinessException.class, () -> service.creerDate(1L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).existsBySiteIdAndDate(1L, LocalDate.of(2030, 1, 15));
+        verify(fermetureSiteRepository, never()).save(any(FermetureSite.class));
+    }
+
+    @Test
+    void creerDate_ok() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.existsBySiteIdAndDate(1L, LocalDate.of(2030, 1, 15)))
+                .thenReturn(false);
+        when(fermetureSiteRepository.save(any(FermetureSite.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CreateFermetureSiteDateRequest req = new CreateFermetureSiteDateRequest();
+        req.setDate(LocalDate.of(2030, 1, 15));
+        req.setMotif("Jour férié");
+
+        FermetureSite res = service.creerDate(1L, req);
+
+        assertNotNull(res);
+        assertSame(site, res.getSite());
+        assertEquals(LocalDate.of(2030, 1, 15), res.getDate());
+        assertNull(res.getDateDebut());
+        assertNull(res.getDateFin());
+        assertEquals("Jour férié", res.getMotif());
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).existsBySiteIdAndDate(1L, LocalDate.of(2030, 1, 15));
+        verify(fermetureSiteRepository).save(any(FermetureSite.class));
+    }
+
+    // --------
+    // creerPeriode
+    // --------
+
+    @Test
+    void creerPeriode_refuse_si_admin_hors_perimetre() {
+        CreateFermetureSitePeriodeRequest req = new CreateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 10));
+        req.setDateFin(LocalDate.of(2030, 2, 15));
+
+        doThrow(new ForbiddenException("Accès refusé à ce site"))
+                .when(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+
+        assertThrows(ForbiddenException.class, () -> service.creerPeriode(2L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+        verifyNoInteractions(siteRepository, fermetureSiteRepository);
+    }
+
+    @Test
+    void creerPeriode_requestNull_refuse() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+
+        assertThrows(BusinessException.class, () -> service.creerPeriode(1L, null));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verifyNoInteractions(fermetureSiteRepository);
+    }
+
+    @Test
+    void creerPeriode_refuse_si_dates_absentes() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+
+        CreateFermetureSitePeriodeRequest req = new CreateFermetureSitePeriodeRequest();
+
+        assertThrows(BusinessException.class, () -> service.creerPeriode(1L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verifyNoInteractions(fermetureSiteRepository);
+    }
+
+    @Test
+    void creerPeriode_refuse_si_dateFin_avant_dateDebut() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+
+        CreateFermetureSitePeriodeRequest req = new CreateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 15));
+        req.setDateFin(LocalDate.of(2030, 2, 10));
+
+        assertThrows(BusinessException.class, () -> service.creerPeriode(1L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verifyNoInteractions(fermetureSiteRepository);
+    }
+
+    @Test
+    void creerPeriode_ok() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.save(any(FermetureSite.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CreateFermetureSitePeriodeRequest req = new CreateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 10));
+        req.setDateFin(LocalDate.of(2030, 2, 15));
+        req.setMotif("Travaux");
+
+        FermetureSite res = service.creerPeriode(1L, req);
+
+        assertNotNull(res);
+        assertSame(site, res.getSite());
+        assertNull(res.getDate());
+        assertEquals(LocalDate.of(2030, 2, 10), res.getDateDebut());
+        assertEquals(LocalDate.of(2030, 2, 15), res.getDateFin());
+        assertEquals("Travaux", res.getMotif());
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).save(any(FermetureSite.class));
+    }
+
+    // --------
+    // updateDate
+    // --------
+
+    @Test
+    void updateDate_refuse_si_admin_hors_perimetre() {
+        doThrow(new ForbiddenException("Accès refusé à ce site"))
+                .when(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+
+        UpdateFermetureSiteDateRequest req = new UpdateFermetureSiteDateRequest();
+        req.setDate(LocalDate.of(2030, 3, 10));
+
+        assertThrows(ForbiddenException.class, () -> service.updateDate(2L, 10L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+        verifyNoInteractions(siteRepository, fermetureSiteRepository);
+    }
+
+    @Test
+    void updateDate_refuse_si_request_null() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+        fermeture.setDate(LocalDate.of(2030, 1, 15));
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.of(fermeture));
+
+        assertThrows(BusinessException.class, () -> service.updateDate(1L, 10L, null));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).findByIdAndSiteId(10L, 1L);
+        verify(fermetureSiteRepository, never()).save(any());
+    }
+
+    @Test
+    void updateDate_refuse_doublon_sur_autre_fermeture() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+        fermeture.setDate(LocalDate.of(2030, 1, 15));
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.of(fermeture));
+        when(fermetureSiteRepository.existsBySiteIdAndDate(1L, LocalDate.of(2030, 1, 20))).thenReturn(true);
+
+        UpdateFermetureSiteDateRequest req = new UpdateFermetureSiteDateRequest();
+        req.setDate(LocalDate.of(2030, 1, 20));
+
+        assertThrows(BusinessException.class, () -> service.updateDate(1L, 10L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(fermetureSiteRepository, never()).save(any());
+    }
+
+    @Test
+    void updateDate_ok() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+        fermeture.setDate(LocalDate.of(2030, 1, 15));
+        fermeture.setMotif("Ancien");
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.of(fermeture));
+        when(fermetureSiteRepository.existsBySiteIdAndDate(1L, LocalDate.of(2030, 1, 20))).thenReturn(false);
+        when(fermetureSiteRepository.save(any(FermetureSite.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateFermetureSiteDateRequest req = new UpdateFermetureSiteDateRequest();
+        req.setDate(LocalDate.of(2030, 1, 20));
+        req.setMotif("Nouveau");
+
+        FermetureSite res = service.updateDate(1L, 10L, req);
+
+        assertEquals(LocalDate.of(2030, 1, 20), res.getDate());
+        assertNull(res.getDateDebut());
+        assertNull(res.getDateFin());
+        assertEquals("Nouveau", res.getMotif());
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(fermetureSiteRepository).save(fermeture);
+    }
+
+    // --------
+    // updatePeriode
+    // --------
+
+    @Test
+    void updatePeriode_refuse_si_admin_hors_perimetre() {
+        doThrow(new ForbiddenException("Accès refusé à ce site"))
+                .when(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+
+        UpdateFermetureSitePeriodeRequest req = new UpdateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 10));
+        req.setDateFin(LocalDate.of(2030, 2, 15));
+
+        assertThrows(ForbiddenException.class, () -> service.updatePeriode(2L, 10L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+        verifyNoInteractions(siteRepository, fermetureSiteRepository);
+    }
+
+    @Test
+    void updatePeriode_refuse_si_request_null() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.of(fermeture));
+
+        assertThrows(BusinessException.class, () -> service.updatePeriode(1L, 10L, null));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).findByIdAndSiteId(10L, 1L);
+        verify(fermetureSiteRepository, never()).save(any());
+    }
+
+    @Test
+    void updatePeriode_refuse_si_dates_absentes() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.of(fermeture));
+
+        UpdateFermetureSitePeriodeRequest req = new UpdateFermetureSitePeriodeRequest();
+
+        assertThrows(BusinessException.class, () -> service.updatePeriode(1L, 10L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(fermetureSiteRepository, never()).save(any());
+    }
+
+    @Test
+    void updatePeriode_refuse_si_dateFin_avant_dateDebut() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.of(fermeture));
+
+        UpdateFermetureSitePeriodeRequest req = new UpdateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 15));
+        req.setDateFin(LocalDate.of(2030, 2, 10));
+
+        assertThrows(BusinessException.class, () -> service.updatePeriode(1L, 10L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(fermetureSiteRepository, never()).save(any());
+    }
+
+    @Test
+    void updatePeriode_ok() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+        fermeture.setDate(LocalDate.of(2030, 1, 15));
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.of(fermeture));
+        when(fermetureSiteRepository.save(any(FermetureSite.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateFermetureSitePeriodeRequest req = new UpdateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 10));
+        req.setDateFin(LocalDate.of(2030, 2, 15));
+        req.setMotif("Travaux");
+
+        FermetureSite res = service.updatePeriode(1L, 10L, req);
+
+        assertNull(res.getDate());
+        assertEquals(LocalDate.of(2030, 2, 10), res.getDateDebut());
+        assertEquals(LocalDate.of(2030, 2, 15), res.getDateFin());
+        assertEquals("Travaux", res.getMotif());
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(fermetureSiteRepository).save(fermeture);
+    }
+
+    // --------
+    // delete
+    // --------
+
+    @Test
+    void delete_refuse_si_admin_hors_perimetre() {
+        doThrow(new ForbiddenException("Accès refusé à ce site"))
+                .when(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+
+        assertThrows(ForbiddenException.class, () -> service.delete(2L, 10L));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+        verifyNoInteractions(siteRepository, fermetureSiteRepository);
+    }
+
+    @Test
+    void delete_ok() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.of(fermeture));
+
+        service.delete(1L, 10L);
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).findByIdAndSiteId(10L, 1L);
+        verify(fermetureSiteRepository).delete(fermeture);
+    }
+
+    // --------
+    // isDateFermeePourSite
+    // --------
+
+    @Test
+    void isDateFermeePourSite_siteIdNull_refuse() {
+        assertThrows(BusinessException.class,
+                () -> service.isDateFermeePourSite(null, LocalDate.of(2030, 1, 15)));
+
+        verifyNoInteractions(serviceAutorisationAdmin, siteRepository, fermetureSiteRepository);
+    }
+
+    @Test
+    void isDateFermeePourSite_dateNull_refuse() {
+        assertThrows(BusinessException.class,
+                () -> service.isDateFermeePourSite(1L, null));
+
+        verifyNoInteractions(serviceAutorisationAdmin, siteRepository, fermetureSiteRepository);
+    }
+
+    @Test
+    void isDateFermeePourSite_true_si_dateUnique() {
+        LocalDate date = LocalDate.of(2030, 1, 15);
+
+        when(fermetureSiteRepository.existsBySiteIdAndDate(1L, date)).thenReturn(true);
+
+        boolean res = service.isDateFermeePourSite(1L, date);
+
+        assertTrue(res);
+        verify(fermetureSiteRepository).existsBySiteIdAndDate(1L, date);
+        verify(fermetureSiteRepository, never())
+                .existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(anyLong(), any(), any());
+        verifyNoInteractions(serviceAutorisationAdmin, siteRepository);
+    }
+
+    @Test
+    void isDateFermeePourSite_true_si_date_dans_periode() {
+        LocalDate date = LocalDate.of(2030, 2, 12);
+
+        when(fermetureSiteRepository.existsBySiteIdAndDate(1L, date)).thenReturn(false);
+        when(fermetureSiteRepository.existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(1L, date, date))
+                .thenReturn(true);
+
+        boolean res = service.isDateFermeePourSite(1L, date);
+
+        assertTrue(res);
+        verify(fermetureSiteRepository).existsBySiteIdAndDate(1L, date);
+        verify(fermetureSiteRepository)
+                .existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(1L, date, date);
+        verifyNoInteractions(serviceAutorisationAdmin, siteRepository);
+    }
+
+    @Test
+    void isDateFermeePourSite_false_si_hors_fermeture() {
+        LocalDate date = LocalDate.of(2030, 3, 5);
+
+        when(fermetureSiteRepository.existsBySiteIdAndDate(1L, date)).thenReturn(false);
+        when(fermetureSiteRepository.existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(1L, date, date))
+                .thenReturn(false);
+
+        boolean res = service.isDateFermeePourSite(1L, date);
+
+        assertFalse(res);
+        verify(fermetureSiteRepository).existsBySiteIdAndDate(1L, date);
+        verify(fermetureSiteRepository)
+                .existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(1L, date, date);
+        verifyNoInteractions(serviceAutorisationAdmin, siteRepository);
+    }
+    @Test
+    void creerPeriode_refuse_si_periode_deja_existante() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.existsBySiteIdAndDateDebutAndDateFin(
+                1L,
+                LocalDate.of(2030, 2, 10),
+                LocalDate.of(2030, 2, 15)
+        )).thenReturn(true);
+
+        CreateFermetureSitePeriodeRequest req = new CreateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 10));
+        req.setDateFin(LocalDate.of(2030, 2, 15));
+        req.setMotif("Travaux");
+
+        assertThrows(BusinessException.class, () -> service.creerPeriode(1L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).existsBySiteIdAndDateDebutAndDateFin(
+                1L,
+                LocalDate.of(2030, 2, 10),
+                LocalDate.of(2030, 2, 15)
+        );
+        verify(fermetureSiteRepository, never()).save(any(FermetureSite.class));
+    }
+    @Test
+    void updatePeriode_refuse_doublon_exact_sur_autre_fermeture() {
+        Site site = new Site("Site A", "Bruxelles");
+        FermetureSite fermeture = new FermetureSite();
+        fermeture.setSite(site);
+        fermeture.setDateDebut(LocalDate.of(2030, 2, 1));
+        fermeture.setDateFin(LocalDate.of(2030, 2, 3));
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L)).thenReturn(Optional.of(fermeture));
+        when(fermetureSiteRepository.existsBySiteIdAndDateDebutAndDateFin(
+                1L,
+                LocalDate.of(2030, 2, 10),
+                LocalDate.of(2030, 2, 15)
+        )).thenReturn(true);
+
+        UpdateFermetureSitePeriodeRequest req = new UpdateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 10));
+        req.setDateFin(LocalDate.of(2030, 2, 15));
+        req.setMotif("Travaux");
+
+        assertThrows(BusinessException.class, () -> service.updatePeriode(1L, 10L, req));
+
+        verify(serviceAutorisationAdmin, times(1)).verifierAccesAuSite(1L);
+        verify(fermetureSiteRepository, never()).save(any(FermetureSite.class));
+    }
+    @Test
+    void creerDate_refuse_si_date_dans_periode_existante() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.existsBySiteIdAndDate(1L, LocalDate.of(2030, 2, 12)))
+                .thenReturn(false);
+        when(fermetureSiteRepository.existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(
+                1L,
+                LocalDate.of(2030, 2, 12),
+                LocalDate.of(2030, 2, 12)
+        )).thenReturn(true);
+
+        CreateFermetureSiteDateRequest req = new CreateFermetureSiteDateRequest();
+        req.setDate(LocalDate.of(2030, 2, 12));
+        req.setMotif("Jour férié");
+
+        assertThrows(BusinessException.class, () -> service.creerDate(1L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).existsBySiteIdAndDate(1L, LocalDate.of(2030, 2, 12));
+        verify(fermetureSiteRepository)
+                .existsBySiteIdAndDateDebutLessThanEqualAndDateFinGreaterThanEqual(
+                        1L,
+                        LocalDate.of(2030, 2, 12),
+                        LocalDate.of(2030, 2, 12)
+                );
+        verify(fermetureSiteRepository, never()).save(any(FermetureSite.class));
+    }
+    @Test
+    void creerPeriode_refuse_si_chevauche_une_periode_existante() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+
+        when(fermetureSiteRepository.existsBySiteIdAndDateDebutAndDateFin(
+                1L,
+                LocalDate.of(2030, 2, 12),
+                LocalDate.of(2030, 2, 20)
+        )).thenReturn(false);
+
+        when(fermetureSiteRepository.existsPeriodeChevauchante(
+                1L,
+                LocalDate.of(2030, 2, 12),
+                LocalDate.of(2030, 2, 20)
+        )).thenReturn(true);
+
+        CreateFermetureSitePeriodeRequest req = new CreateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 12));
+        req.setDateFin(LocalDate.of(2030, 2, 20));
+        req.setMotif("Travaux");
+
+        assertThrows(BusinessException.class, () -> service.creerPeriode(1L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).existsBySiteIdAndDateDebutAndDateFin(
+                1L,
+                LocalDate.of(2030, 2, 12),
+                LocalDate.of(2030, 2, 20)
+        );
+        verify(fermetureSiteRepository).existsPeriodeChevauchante(
+                1L,
+                LocalDate.of(2030, 2, 12),
+                LocalDate.of(2030, 2, 20)
+        );
+        verify(fermetureSiteRepository, never()).save(any(FermetureSite.class));
+    }
+    @Test
+    void creerPeriode_refuse_si_contient_date_unique_existante() {
+        Site site = new Site("Site A", "Bruxelles");
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+
+        when(fermetureSiteRepository.existsBySiteIdAndDateDebutAndDateFin(
+                1L,
+                LocalDate.of(2030, 2, 10),
+                LocalDate.of(2030, 2, 15)
+        )).thenReturn(false);
+
+        when(fermetureSiteRepository.existsPeriodeChevauchante(
+                1L,
+                LocalDate.of(2030, 2, 10),
+                LocalDate.of(2030, 2, 15)
+        )).thenReturn(false);
+
+        when(fermetureSiteRepository.existsBySiteIdAndDateBetween(
+                1L,
+                LocalDate.of(2030, 2, 10),
+                LocalDate.of(2030, 2, 15)
+        )).thenReturn(true);
+
+        CreateFermetureSitePeriodeRequest req = new CreateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 10));
+        req.setDateFin(LocalDate.of(2030, 2, 15));
+        req.setMotif("Travaux");
+
+        assertThrows(BusinessException.class, () -> service.creerPeriode(1L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).existsBySiteIdAndDateDebutAndDateFin(
+                1L,
+                LocalDate.of(2030, 2, 10),
+                LocalDate.of(2030, 2, 15)
+        );
+        verify(fermetureSiteRepository).existsPeriodeChevauchante(
+                1L,
+                LocalDate.of(2030, 2, 10),
+                LocalDate.of(2030, 2, 15)
+        );
+        verify(fermetureSiteRepository).existsBySiteIdAndDateBetween(
+                1L,
+                LocalDate.of(2030, 2, 10),
+                LocalDate.of(2030, 2, 15)
+        );
+        verify(fermetureSiteRepository, never()).save(any(FermetureSite.class));
+    }
+    @Test
+    void updatePeriode_refuse_si_chevauche_une_autre_periode() {
+        Site site = new Site("Site A", "Bruxelles");
+
+        FermetureSite fermetureCourante = mock(FermetureSite.class);
+        when(fermetureCourante.getId()).thenReturn(10L);
+        when(fermetureCourante.getSite()).thenReturn(site);
+        when(fermetureCourante.getDateDebut()).thenReturn(LocalDate.of(2030, 2, 1));
+        when(fermetureCourante.getDateFin()).thenReturn(LocalDate.of(2030, 2, 3));
+        when(fermetureCourante.getDate()).thenReturn(null);
+
+        FermetureSite autreFermeture = mock(FermetureSite.class);
+        when(autreFermeture.getId()).thenReturn(20L);
+        when(autreFermeture.getSite()).thenReturn(site);
+        when(autreFermeture.getDateDebut()).thenReturn(LocalDate.of(2030, 2, 12));
+        when(autreFermeture.getDateFin()).thenReturn(LocalDate.of(2030, 2, 20));
+        when(autreFermeture.getDate()).thenReturn(null);
+
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site));
+        when(fermetureSiteRepository.findByIdAndSiteId(10L, 1L))
+                .thenReturn(Optional.of(fermetureCourante));
+
+        when(fermetureSiteRepository.existsBySiteIdAndDateDebutAndDateFin(
+                1L,
+                LocalDate.of(2030, 2, 15),
+                LocalDate.of(2030, 2, 25)
+        )).thenReturn(false);
+
+        when(fermetureSiteRepository.findBySiteIdOrderByDateAscDateDebutAsc(1L))
+                .thenReturn(List.of(fermetureCourante, autreFermeture));
+
+        UpdateFermetureSitePeriodeRequest req = new UpdateFermetureSitePeriodeRequest();
+        req.setDateDebut(LocalDate.of(2030, 2, 15));
+        req.setDateFin(LocalDate.of(2030, 2, 25));
+        req.setMotif("Nouvelle période");
+
+        assertThrows(BusinessException.class, () -> service.updatePeriode(1L, 10L, req));
+
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
+        verify(siteRepository).findById(1L);
+        verify(fermetureSiteRepository).findByIdAndSiteId(10L, 1L);
+        verify(fermetureSiteRepository).existsBySiteIdAndDateDebutAndDateFin(
+                1L,
+                LocalDate.of(2030, 2, 15),
+                LocalDate.of(2030, 2, 25)
+        );
+        verify(fermetureSiteRepository).findBySiteIdOrderByDateAscDateDebutAsc(1L);
+        verify(fermetureSiteRepository, never()).save(any(FermetureSite.class));
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
@@ -3,20 +3,30 @@ package be.ephec.padel.backend.unit.service;
 import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.dto.response.MatchDetailDto;
 import be.ephec.padel.backend.dto.response.MatchDto;
+import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.ForbiddenException;
 import be.ephec.padel.backend.exception.NotFoundException;
-import be.ephec.padel.backend.model.entities.*;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
-import be.ephec.padel.backend.repository.*;
+import be.ephec.padel.backend.repository.FermetureGlobaleRepository;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.repository.projection.PublicMatchSummaryProjection;
+import be.ephec.padel.backend.service.FermetureSiteService;
 import be.ephec.padel.backend.service.MatchPadelService;
 import be.ephec.padel.backend.service.PaiementService;
 import be.ephec.padel.backend.service.SoldeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
-import be.ephec.padel.backend.repository.projection.PublicMatchSummaryProjection;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -40,6 +50,7 @@ class MatchPadelServiceTest {
     private PaiementService paiementService;
     private PaiementRepository paiementRepo;
     private FermetureGlobaleRepository fermetureGlobaleRepo;
+    private FermetureSiteService fermetureSiteService;
 
     private MatchPadelService service;
 
@@ -53,13 +64,19 @@ class MatchPadelServiceTest {
         paiementService = mock(PaiementService.class);
         paiementRepo = mock(PaiementRepository.class);
         fermetureGlobaleRepo = mock(FermetureGlobaleRepository.class);
+        fermetureSiteService = mock(FermetureSiteService.class);
 
         service = new MatchPadelService(
-                matchRepo, terrainRepo, joueurRepo,
-                soldeService, participationRepo,
-                paiementService, paiementRepo,
+                        matchRepo,
+                        terrainRepo,
+                        joueurRepo,
+                        soldeService,
+                        participationRepo,
+                        paiementService,
+                fermetureSiteService,
+                paiementRepo,
                 fermetureGlobaleRepo
-        );
+                );
     }
 
     // ----------------
@@ -76,6 +93,7 @@ class MatchPadelServiceTest {
         Site site = mock(Site.class);
         when(t.getSite()).thenReturn(site);
 
+        when(site.getId()).thenReturn(1L);
         when(site.getHeureOuverture()).thenReturn(LocalTime.of(8, 0));
         when(site.getHeureFermeture()).thenReturn(LocalTime.of(22, 0));
         when(site.getJoursFermeture()).thenReturn(Set.of());
@@ -463,6 +481,7 @@ class MatchPadelServiceTest {
         when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
 
         Site site = mock(Site.class);
+        when(site.getId()).thenReturn(1L);
         when(t.getSite()).thenReturn(site);
 
         LocalDateTime date = dateValide();
@@ -483,6 +502,7 @@ class MatchPadelServiceTest {
         when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
 
         Site site = mock(Site.class);
+        when(site.getId()).thenReturn(1L);
         when(t.getSite()).thenReturn(site);
 
         LocalDateTime date = LocalDateTime.now()
@@ -524,6 +544,7 @@ class MatchPadelServiceTest {
         MatchPadel res = service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC);
         assertSame(savedMatch, res);
     }
+
     @Test
     void getPublicMatchSummaries_calcule_placesRestantes_et_complet() {
         PublicMatchSummaryProjection row = mock(PublicMatchSummaryProjection.class);
@@ -557,6 +578,7 @@ class MatchPadelServiceTest {
         assertFalse(dto.isComplet());
         assertEquals(0, Tarifs.PART_PAR_JOUEUR.compareTo(dto.getMontantParJoueur()));
     }
+
     @Test
     void getPublicMatchSummaries_match_complet_si_4_participants() {
         PublicMatchSummaryProjection row = mock(PublicMatchSummaryProjection.class);
@@ -583,6 +605,7 @@ class MatchPadelServiceTest {
         assertEquals(0, dto.getPlacesRestantes());
         assertTrue(dto.isComplet());
     }
+
     @Test
     void getPublicMatchSummaries_throw_businessException_si_from_apres_to() {
         LocalDate from = LocalDate.of(2030, 2, 1);
@@ -593,6 +616,7 @@ class MatchPadelServiceTest {
 
         verify(matchRepo, never()).findPublicMatchSummaries(any(), any(), any(), any());
     }
+
     @Test
     void getMatchDetailDto_public_sansMatricule_ok() {
         MatchPadel match = mock(MatchPadel.class);
@@ -631,6 +655,7 @@ class MatchPadelServiceTest {
         assertEquals(4, dto.getPlacesRestantes());
         assertFalse(dto.isComplet());
     }
+
     @Test
     void getMatchDetailDto_prive_sansMatricule_refuse() {
         MatchPadel match = mock(MatchPadel.class);
@@ -643,6 +668,7 @@ class MatchPadelServiceTest {
 
         verify(paiementRepo, never()).sumMontantByMatchId(anyLong());
     }
+
     @Test
     void getMatchDetailDto_prive_organisateur_ok() {
         MatchPadel match = mock(MatchPadel.class);
@@ -676,6 +702,7 @@ class MatchPadelServiceTest {
         assertEquals(1L, dto.getId());
         assertEquals("G0001", dto.getOrganisateurMatricule());
     }
+
     @Test
     void getMatchDetailDto_prive_participant_ok() {
         MatchPadel match = mock(MatchPadel.class);
@@ -716,6 +743,7 @@ class MatchPadelServiceTest {
         assertEquals(1, dto.getParticipants().size());
         assertEquals("J0001", dto.getParticipants().get(0).getMatricule());
     }
+
     @Test
     void getMatchDetailDto_prive_autreJoueur_refuse() {
         MatchPadel match = mock(MatchPadel.class);
@@ -739,11 +767,39 @@ class MatchPadelServiceTest {
 
         verify(paiementRepo, never()).sumMontantByMatchId(anyLong());
     }
+
     @Test
     void getMatchDetailDto_introuvable_notFound() {
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
                 () -> service.getMatchDetailDto(1L, null));
+    }
+
+    @Test
+    void creerMatch_refuse_si_fermeture_site_exceptionnelle() {
+        Terrain t = mock(Terrain.class);
+        when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
+
+        Site site = mock(Site.class);
+        when(site.getId()).thenReturn(99L);
+        when(t.getSite()).thenReturn(site);
+
+        LocalDateTime date = dateValide();
+
+        when(site.getHeureOuverture()).thenReturn(LocalTime.of(8, 0));
+        when(site.getHeureFermeture()).thenReturn(LocalTime.of(22, 0));
+        when(site.getJoursFermeture()).thenReturn(Set.of());
+
+        stubOrgaGlobalSansDette("G0001");
+        when(fermetureGlobaleRepo.existsByDate(date.toLocalDate())).thenReturn(false);
+        when(fermetureSiteService.isDateFermeePourSite(99L, date.toLocalDate())).thenReturn(true);
+
+        BusinessException ex = assertThrows(BusinessException.class, () ->
+                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+
+        assertTrue(ex.getMessage().contains("site fermé à cette date"));
+        verify(fermetureSiteService).isDateFermeePourSite(99L, date.toLocalDate());
+        verifyNoInteractions(matchRepo, participationRepo, soldeService, paiementService);
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/FermetureSiteAdminControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/FermetureSiteAdminControllerTest.java
@@ -1,0 +1,510 @@
+package be.ephec.padel.backend.web.controller;
+
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.repository.FermetureSiteRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.MouvementSoldeRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.support.SqlServerTestContainerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalTime;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "app.security.admin.site.users=adminSite1:1,adminSite2:2"
+})
+class FermetureSiteAdminControllerTest extends SqlServerTestContainerConfig {
+
+    @Autowired MockMvc mvc;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @Autowired SiteRepository siteRepository;
+    @Autowired FermetureSiteRepository fermetureSiteRepository;
+
+    @Autowired TerrainRepository terrainRepository;
+    @Autowired MatchPadelRepository matchPadelRepository;
+    @Autowired ParticipationRepository participationRepository;
+    @Autowired PaiementRepository paiementRepository;
+    @Autowired MouvementSoldeRepository mouvementSoldeRepository;
+
+    private Site site;
+
+    @BeforeEach
+    void cleanAndSeed() {
+        paiementRepository.deleteAll();
+        participationRepository.deleteAll();
+        matchPadelRepository.deleteAll();
+        mouvementSoldeRepository.deleteAll();
+        fermetureSiteRepository.deleteAll();
+        terrainRepository.deleteAll();
+        siteRepository.deleteAll();
+
+        try {
+            jdbcTemplate.execute("DBCC CHECKIDENT ('fermeture_site', RESEED, 0)");
+        } catch (Exception ignored) {
+        }
+        try {
+            jdbcTemplate.execute("DBCC CHECKIDENT ('site', RESEED, 0)");
+        } catch (Exception ignored) {
+        }
+
+        site = new Site("Site Admin Test", "Bruxelles", LocalTime.of(8, 0), LocalTime.of(22, 0));
+        site.setJoursFermeture(Set.of());
+        site = siteRepository.save(site);
+    }
+
+    // ===== Sécurité =====
+
+    @Test
+    void public_ne_peut_pas_lister_401() throws Exception {
+        mvc.perform(get("/api/v1/admin/sites/" + site.getId() + "/fermetures"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void public_ne_peut_pas_creer_date_401() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-04-10",
+                                  "motif": "Congé exceptionnel"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void public_ne_peut_pas_creer_periode_401() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "dateDebut": "2026-05-01",
+                                  "dateFin": "2026-05-03",
+                                  "motif": "Travaux"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ===== CRUD =====
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void post_cree_fermeture_date_unique_201() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-04-10",
+                                  "motif": "Congé exceptionnel"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location",
+                        containsString("/api/v1/admin/sites/" + site.getId() + "/fermetures/")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").isNumber())
+                .andExpect(jsonPath("$.siteId").value(site.getId()))
+                .andExpect(jsonPath("$.date").value("2026-04-10"))
+                .andExpect(jsonPath("$.dateDebut").doesNotExist())
+                .andExpect(jsonPath("$.dateFin").doesNotExist())
+                .andExpect(jsonPath("$.motif").value("Congé exceptionnel"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_SITE", username = "adminSite1")
+    void post_cree_fermeture_periode_201() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "dateDebut": "2026-05-01",
+                                  "dateFin": "2026-05-03",
+                                  "motif": "Travaux"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.siteId").value(site.getId()))
+                .andExpect(jsonPath("$.date").doesNotExist())
+                .andExpect(jsonPath("$.dateDebut").value("2026-05-01"))
+                .andExpect(jsonPath("$.dateFin").value("2026-05-03"))
+                .andExpect(jsonPath("$.motif").value("Travaux"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void get_list_retourne_les_fermetures_du_site() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-04-10",
+                                  "motif": "Congé exceptionnel"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "dateDebut": "2026-05-01",
+                                  "dateFin": "2026-05-03",
+                                  "motif": "Travaux"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        mvc.perform(get("/api/v1/admin/sites/" + site.getId() + "/fermetures"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void get_one_retourne_la_fermeture() throws Exception {
+        String location = mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-04-10",
+                                  "motif": "Congé exceptionnel"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getHeader("Location");
+
+        mvc.perform(get(location))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.siteId").value(site.getId()))
+                .andExpect(jsonPath("$.date").value("2026-04-10"))
+                .andExpect(jsonPath("$.motif").value("Congé exceptionnel"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void put_modifie_la_fermeture_en_periode_200() throws Exception {
+        String location = mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-04-10",
+                                  "motif": "Congé exceptionnel"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getHeader("Location");
+
+        mvc.perform(put(location + "/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "dateDebut": "2026-06-10",
+                                  "dateFin": "2026-06-12",
+                                  "motif": "Travaux prolongés"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.date").doesNotExist())
+                .andExpect(jsonPath("$.dateDebut").value("2026-06-10"))
+                .andExpect(jsonPath("$.dateFin").value("2026-06-12"))
+                .andExpect(jsonPath("$.motif").value("Travaux prolongés"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void put_modifie_la_fermeture_en_date_200() throws Exception {
+        String location = mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "dateDebut": "2026-05-01",
+                                  "dateFin": "2026-05-03",
+                                  "motif": "Travaux"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getHeader("Location");
+
+        mvc.perform(put(location + "/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-07-15",
+                                  "motif": "Jour unique"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.date").value("2026-07-15"))
+                .andExpect(jsonPath("$.dateDebut").doesNotExist())
+                .andExpect(jsonPath("$.dateFin").doesNotExist())
+                .andExpect(jsonPath("$.motif").value("Jour unique"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void delete_supprime_la_fermeture_204() throws Exception {
+        String location = mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-04-10",
+                                  "motif": "Congé exceptionnel"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getHeader("Location");
+
+        mvc.perform(delete(location))
+                .andExpect(status().isNoContent());
+
+        mvc.perform(get("/api/v1/admin/sites/" + site.getId() + "/fermetures"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // ===== Validation métier =====
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void post_date_refuse_si_date_absente() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "motif": "Invalide"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("Date obligatoire")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void post_periode_refuse_si_dates_absentes() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "motif": "Invalide"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("date de début et une date de fin")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void post_periode_refuse_si_date_fin_avant_date_debut() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "dateDebut": "2026-05-10",
+                                  "dateFin": "2026-05-01",
+                                  "motif": "Invalide"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("date de fin doit être après ou égale")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void post_date_refuse_doublon_date_unique() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-04-10",
+                                  "motif": "A"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-04-10",
+                                  "motif": "B"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("existe déjà")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void get_one_404_si_introuvable() throws Exception {
+        mvc.perform(get("/api/v1/admin/sites/" + site.getId() + "/fermetures/999999"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("introuvable")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_SITE", username = "adminSite1")
+    void admin_site_hors_perimetre_refuse_403() throws Exception {
+        Site autreSite = new Site("Autre site", "Liège", LocalTime.of(8, 0), LocalTime.of(22, 0));
+        autreSite.setJoursFermeture(Set.of());
+        autreSite = siteRepository.save(autreSite);
+
+        mvc.perform(post("/api/v1/admin/sites/" + autreSite.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2026-08-01",
+                                  "motif": "Interdit"
+                                }
+                                """))
+                .andExpect(status().isForbidden());
+    }
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void post_periode_refuse_doublon_exact() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "dateDebut": "2026-05-01",
+                              "dateFin": "2026-05-03",
+                              "motif": "Travaux"
+                            }
+                            """))
+                .andExpect(status().isCreated());
+
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "dateDebut": "2026-05-01",
+                              "dateFin": "2026-05-03",
+                              "motif": "Travaux bis"
+                            }
+                            """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("existe déjà pour cette période")));
+    }
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void post_date_refuse_si_date_couverte_par_periode() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "dateDebut": "2026-05-01",
+                              "dateFin": "2026-05-03",
+                              "motif": "Travaux"
+                            }
+                            """))
+                .andExpect(status().isCreated());
+
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "date": "2026-05-02",
+                              "motif": "Jour isolé"
+                            }
+                            """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("déjà couverte par une période")));
+    }
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void post_periode_refuse_si_chevauche_une_autre_periode() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "dateDebut": "2026-05-01",
+                              "dateFin": "2026-05-05",
+                              "motif": "Travaux 1"
+                            }
+                            """))
+                .andExpect(status().isCreated());
+
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "dateDebut": "2026-05-04",
+                              "dateFin": "2026-05-08",
+                              "motif": "Travaux 2"
+                            }
+                            """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("chevauche une autre fermeture")));
+    }
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void post_periode_refuse_si_contient_date_unique_existante() throws Exception {
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "date": "2026-05-02",
+                              "motif": "Jour unique"
+                            }
+                            """))
+                .andExpect(status().isCreated());
+
+        mvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/periode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "dateDebut": "2026-05-01",
+                              "dateFin": "2026-05-03",
+                              "motif": "Travaux"
+                            }
+                            """))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(containsString("contient déjà une date de fermeture")));
+    }
+}


### PR DESCRIPTION
- Ajout des fermetures par date et par période
- Blocage des doublons (date et période)
- Blocage des chevauchements de périodes
- Blocage des dates incluses dans une période existante
- Blocage des périodes contenant une date unique existante
- Gestion des updates avec exclusion de l'entité courante (id)

- Ajout des tests service (validation métier)
- Ajout des tests controller (validation API)

- Validation complète testée (tests OK + Swagger OK)