### PR TITLE
feat76#: gestion des matchs ANNULE suite à fermeture site imprévue

### DIFF
--- a/backend/backend/.gitignore
+++ b/backend/backend/.gitignore
@@ -20,6 +20,7 @@ target/
 *.ipr
 .env
 .run/
+run.log
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDetailDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDetailDto.java
@@ -1,5 +1,6 @@
 package be.ephec.padel.backend.dto.response;
 
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 
 import java.math.BigDecimal;
@@ -24,6 +25,7 @@ public class MatchDetailDto {
     private String organisateurNom;
 
     private MatchVisibilite visibilite;
+    private MatchStatut statut;
 
     private int nbParticipants;
     private int placesRestantes;
@@ -32,6 +34,7 @@ public class MatchDetailDto {
     private BigDecimal montantTotal;
     private BigDecimal montantPaye;
     private BigDecimal resteAPayer;
+    private BigDecimal montantRembourse;
 
     private List<ParticipantDto> participants;
 
@@ -45,12 +48,14 @@ public class MatchDetailDto {
                           String organisateurMatricule,
                           String organisateurNom,
                           MatchVisibilite visibilite,
+                          MatchStatut statut,
                           int nbParticipants,
                           int placesRestantes,
                           boolean complet,
                           BigDecimal montantTotal,
                           BigDecimal montantPaye,
                           BigDecimal resteAPayer,
+                          BigDecimal montantRembourse,
                           List<ParticipantDto> participants) {
         this.id = id;
         this.dateDebut = dateDebut;
@@ -62,12 +67,14 @@ public class MatchDetailDto {
         this.organisateurMatricule = organisateurMatricule;
         this.organisateurNom = organisateurNom;
         this.visibilite = visibilite;
+        this.statut = statut;
         this.nbParticipants = nbParticipants;
         this.placesRestantes = placesRestantes;
         this.complet = complet;
         this.montantTotal = montantTotal;
         this.montantPaye = montantPaye;
         this.resteAPayer = resteAPayer;
+        this.montantRembourse = montantRembourse;
         this.participants = participants;
     }
 
@@ -111,6 +118,10 @@ public class MatchDetailDto {
         return visibilite;
     }
 
+    public MatchStatut getStatut() {
+        return statut;
+    }
+
     public int getNbParticipants() {
         return nbParticipants;
     }
@@ -133,6 +144,10 @@ public class MatchDetailDto {
 
     public BigDecimal getResteAPayer() {
         return resteAPayer;
+    }
+
+    public BigDecimal getMontantRembourse() {
+        return montantRembourse;
     }
 
     public List<ParticipantDto> getParticipants() {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDto.java
@@ -1,5 +1,6 @@
 package be.ephec.padel.backend.dto.response;
 
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 
 import java.math.BigDecimal;
@@ -15,6 +16,7 @@ public class MatchDto {
     private String organisateurMatricule;
     private LocalDateTime dateDebut;
     private MatchVisibilite visibilite;
+    private MatchStatut statut;
 
     private int nbParticipants;
 
@@ -30,6 +32,7 @@ public class MatchDto {
                     String organisateurMatricule,
                     LocalDateTime dateDebut,
                     MatchVisibilite visibilite,
+                    MatchStatut statut,
                     int nbParticipants,
                     BigDecimal montantTotal,
                     BigDecimal montantPaye,
@@ -42,6 +45,7 @@ public class MatchDto {
         this.organisateurMatricule = organisateurMatricule;
         this.dateDebut = dateDebut;
         this.visibilite = visibilite;
+        this.statut = statut;
         this.nbParticipants = nbParticipants;
 
         this.montantTotal = montantTotal;
@@ -56,6 +60,7 @@ public class MatchDto {
     public String getOrganisateurMatricule() { return organisateurMatricule; }
     public LocalDateTime getDateDebut() { return dateDebut; }
     public MatchVisibilite getVisibilite() { return visibilite; }
+    public MatchStatut getStatut() { return statut; }
     public int getNbParticipants() { return nbParticipants; }
 
     public BigDecimal getMontantTotal() { return montantTotal; }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/OrganizerMatchSummaryDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/OrganizerMatchSummaryDto.java
@@ -1,6 +1,7 @@
 package be.ephec.padel.backend.dto.response;
 
 import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 
 import java.time.LocalDateTime;
@@ -13,6 +14,7 @@ public record OrganizerMatchSummaryDto(
         Long terrainId,
         String terrainNom,
         MatchVisibilite visibilite,
+        MatchStatut statut,
         int nbParticipants,
         int placesRestantes,
         boolean complet,

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PlayerMatchSummaryDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PlayerMatchSummaryDto.java
@@ -2,6 +2,7 @@ package be.ephec.padel.backend.dto.response;
 
 import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
 import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ public record PlayerMatchSummaryDto(
         Long terrainId,
         String terrainNom,
         MatchVisibilite visibilite,
+        MatchStatut statut,
         PlayerMatchRoleDto roleJoueur,
         MatchTemporalStatusDto statutTemporel,
         Integer joursAvantMatch,

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchDetailMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchDetailMapper.java
@@ -18,7 +18,8 @@ public final class MatchDetailMapper {
     public static MatchDetailDto toDto(MatchPadel m,
                                        BigDecimal montantTotal,
                                        BigDecimal montantPaye,
-                                       BigDecimal resteAPayer) {
+                                       BigDecimal resteAPayer,
+                                       BigDecimal montantRembourse) {
 
         int nbParticipants = (m.getParticipations() != null) ? m.getParticipations().size() : 0;
         int placesRestantes = Math.max(0, CAPACITE_MATCH - nbParticipants);
@@ -41,12 +42,14 @@ public final class MatchDetailMapper {
                 m.getOrganisateur().getMatricule(),
                 m.getOrganisateur().getNom(),
                 m.getVisibilite(),
+                m.getStatut(),
                 nbParticipants,
                 placesRestantes,
                 complet,
                 montantTotal,
                 montantPaye,
                 resteAPayer,
+                montantRembourse,
                 participants
         );
     }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchMapper.java
@@ -44,6 +44,7 @@ public final class MatchMapper {
                 organisateurMatricule,
                 match.getDateDebut(),
                 match.getVisibilite(),
+                match.getStatut(),
                 nbParticipants,
                 montantTotal,
                 montantPaye,

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/MatchPadel.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/MatchPadel.java
@@ -1,5 +1,6 @@
 package be.ephec.padel.backend.model.entities;
 
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import jakarta.persistence.*;
 
@@ -34,6 +35,10 @@ public class MatchPadel {
     @Column(nullable = false)
     private MatchVisibilite visibilite;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "statut", nullable = false)
+    private MatchStatut statut = MatchStatut.PLANIFIE;
+
     @Column(name = "solde_traite_le")
     private LocalDateTime soldeTraiteLe;
 
@@ -54,6 +59,7 @@ public class MatchPadel {
         this.organisateur = organisateur;
         this.dateDebut = dateDebut;
         this.visibilite = visibilite;
+        this.statut = MatchStatut.PLANIFIE;
     }
 
     public Long getId() {
@@ -74,6 +80,10 @@ public class MatchPadel {
 
     public MatchVisibilite getVisibilite() {
         return visibilite;
+    }
+
+    public MatchStatut getStatut() {
+        return statut;
     }
 
     public List<Participation> getParticipations() {
@@ -101,6 +111,10 @@ public class MatchPadel {
 
     public void setVisibilite(MatchVisibilite visibilite) {
         this.visibilite = visibilite;
+    }
+
+    public void setStatut(MatchStatut statut) {
+        this.statut = statut;
     }
 
     public LocalDateTime getSoldeTraiteLe() {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Paiement.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Paiement.java
@@ -1,5 +1,6 @@
 package be.ephec.padel.backend.model.entities;
 
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import jakarta.persistence.*;
 
 import java.math.BigDecimal;
@@ -21,6 +22,10 @@ public class Paiement {
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal montant;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private TypePaiement type = TypePaiement.ENCAISSEMENT;
+
     @Column(name = "date_paiement", nullable = false)
     private LocalDateTime datePaiement;
 
@@ -28,8 +33,16 @@ public class Paiement {
     }
 
     public Paiement(Participation participation, BigDecimal montant, LocalDateTime datePaiement) {
+        this(participation, montant, TypePaiement.ENCAISSEMENT, datePaiement);
+    }
+
+    public Paiement(Participation participation,
+                    BigDecimal montant,
+                    TypePaiement type,
+                    LocalDateTime datePaiement) {
         this.participation = participation;
         this.montant = montant;
+        this.type = type;
         this.datePaiement = datePaiement;
     }
 
@@ -49,12 +62,20 @@ public class Paiement {
         return datePaiement;
     }
 
+    public TypePaiement getType() {
+        return type;
+    }
+
     public void setParticipation(Participation participation) {
         this.participation = participation;
     }
 
     public void setMontant(BigDecimal montant) {
         this.montant = montant;
+    }
+
+    public void setType(TypePaiement type) {
+        this.type = type;
     }
 
     public void setDatePaiement(LocalDateTime datePaiement) {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/MatchStatut.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/MatchStatut.java
@@ -1,0 +1,6 @@
+package be.ephec.padel.backend.model.enums;
+
+public enum MatchStatut {
+    PLANIFIE,
+    ANNULE
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/TypePaiement.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/TypePaiement.java
@@ -1,0 +1,6 @@
+package be.ephec.padel.backend.model.enums;
+
+public enum TypePaiement {
+    ENCAISSEMENT,
+    REMBOURSEMENT
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -1,13 +1,14 @@
 package be.ephec.padel.backend.repository;
 
 import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.repository.projection.PublicMatchSummaryProjection;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import be.ephec.padel.backend.model.enums.MatchVisibilite;
-import be.ephec.padel.backend.repository.projection.PublicMatchSummaryProjection;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -66,6 +67,7 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
     left join fetch m.participations p
     left join fetch p.joueur pj
     where m.j1TraiteLe is null
+      and m.statut = be.ephec.padel.backend.model.enums.MatchStatut.PLANIFIE
       and m.dateDebut >= :from
       and m.dateDebut < :to
 """)
@@ -79,6 +81,7 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
     left join fetch m.participations p
     left join fetch p.joueur pj
     where m.soldeTraiteLe is null
+      and m.statut = be.ephec.padel.backend.model.enums.MatchStatut.PLANIFIE
       and m.dateDebut >= :from
       and m.dateDebut < :to
 """)
@@ -90,6 +93,7 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
     from MatchPadel m
     where m.dateDebut >= :from
       and m.dateDebut < :to
+      and m.statut = be.ephec.padel.backend.model.enums.MatchStatut.PLANIFIE
 """)
     long countByDateDebutBetween(LocalDateTime from, LocalDateTime to);
 
@@ -99,8 +103,26 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
         where m.dateDebut >= :from
           and m.dateDebut < :to
           and m.terrain.site.id = :siteId
+          and m.statut = be.ephec.padel.backend.model.enums.MatchStatut.PLANIFIE
     """)
     long countByDateDebutBetweenAndSiteId(LocalDateTime from, LocalDateTime to, Long siteId);
+
+    @Query("""
+    select m
+    from MatchPadel m
+    where m.terrain.site.id = :siteId
+      and m.statut = :statut
+      and m.dateDebut > :now
+      and m.dateDebut >= :from
+      and m.dateDebut < :to
+""")
+    List<MatchPadel> findPlannedFutureMatchesBySiteIdAndDateDebutBetween(
+            @Param("siteId") Long siteId,
+            @Param("statut") MatchStatut statut,
+            @Param("now") LocalDateTime now,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to
+    );
 
     @Query("""
     select
@@ -118,6 +140,7 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
     join m.organisateur o
     left join m.participations p
     where m.visibilite = :visibilite
+      and m.statut = be.ephec.padel.backend.model.enums.MatchStatut.PLANIFIE
       and (:from is null or m.dateDebut >= :from)
       and (:to is null or m.dateDebut <= :to)
       and (:siteId is null or s.id = :siteId)

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
@@ -1,6 +1,7 @@
 package be.ephec.padel.backend.repository;
 
 import be.ephec.padel.backend.model.entities.Paiement;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -27,11 +28,31 @@ public interface PaiementRepository extends JpaRepository<Paiement, Long> {
     @Query("""
         select coalesce(sum(p.montant), 0)
         from Paiement p
+        where p.participation.id = :participationId
+          and p.type = :typePaiement
+    """)
+    BigDecimal sumMontantByParticipationIdAndType(@Param("participationId") Long participationId,
+                                                  @Param("typePaiement") TypePaiement typePaiement);
+
+    @Query("""
+        select coalesce(sum(p.montant), 0)
+        from Paiement p
         join p.participation pa
         join pa.match m
         where m.id = :matchId
     """)
     BigDecimal sumMontantByMatchId(@Param("matchId") Long matchId);
+
+    @Query("""
+        select coalesce(sum(p.montant), 0)
+        from Paiement p
+        join p.participation pa
+        join pa.match m
+        where m.id = :matchId
+          and p.type = :typePaiement
+    """)
+    BigDecimal sumMontantByMatchIdAndType(@Param("matchId") Long matchId,
+                                          @Param("typePaiement") TypePaiement typePaiement);
 
     @Query("""
         select coalesce(sum(p.montant), 0)

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AnnulationMatchService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AnnulationMatchService.java
@@ -1,0 +1,116 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.common.Tarifs;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+public class AnnulationMatchService {
+
+    private static final BigDecimal PART_JOUEUR = Tarifs.PART_PAR_JOUEUR;
+
+    private final MatchPadelRepository matchPadelRepository;
+    private final PaiementRepository paiementRepository;
+    private final PaiementService paiementService;
+    private final SoldeService soldeService;
+    private final Clock clock;
+
+    public AnnulationMatchService(MatchPadelRepository matchPadelRepository,
+                                  PaiementRepository paiementRepository,
+                                  PaiementService paiementService,
+                                  SoldeService soldeService,
+                                  Clock clock) {
+        this.matchPadelRepository = matchPadelRepository;
+        this.paiementRepository = paiementRepository;
+        this.paiementService = paiementService;
+        this.soldeService = soldeService;
+        this.clock = clock;
+    }
+
+    public int annulerMatchsFutursPlanifiesSite(Long siteId,
+                                                LocalDateTime from,
+                                                LocalDateTime to) {
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        List<Long> matchIds = matchPadelRepository
+                .findPlannedFutureMatchesBySiteIdAndDateDebutBetween(
+                        siteId,
+                        MatchStatut.PLANIFIE,
+                        now,
+                        from,
+                        to
+                ).stream()
+                .map(MatchPadel::getId)
+                .toList();
+
+        int nbAnnules = 0;
+        for (Long matchId : matchIds) {
+            if (annulerMatchSiPlanifie(matchId)) {
+                nbAnnules++;
+            }
+        }
+
+        return nbAnnules;
+    }
+
+    public boolean annulerMatchSiPlanifie(Long matchId) {
+        MatchPadel match = matchPadelRepository.findByIdForUpdateWithParticipations(matchId)
+                .orElseThrow(() -> new NotFoundException("Match introuvable"));
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        if (match.getStatut() != MatchStatut.PLANIFIE) {
+            return false;
+        }
+        if (match.getDateDebut() == null || !match.getDateDebut().isAfter(now)) {
+            return false;
+        }
+
+        match.setStatut(MatchStatut.ANNULE);
+
+        for (Participation participation : match.getParticipations()) {
+            compenserParticipation(participation);
+        }
+
+        matchPadelRepository.save(match);
+        return true;
+    }
+
+    private void compenserParticipation(Participation participation) {
+        BigDecimal montantPaye = nullSafe(paiementRepository.sumMontantByParticipationId(participation.getId()));
+        BigDecimal montantRembourse = montantPaye.min(PART_JOUEUR).max(BigDecimal.ZERO).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal detteAAnnuler = PART_JOUEUR.subtract(montantRembourse).setScale(2, RoundingMode.HALF_UP);
+
+        Joueur joueur = participation.getJoueur();
+        BigDecimal detteActuelle = nullSafe(joueur.getSolde());
+        BigDecimal montantACrediter = detteAAnnuler.min(detteActuelle).setScale(2, RoundingMode.HALF_UP);
+
+        if (montantACrediter.signum() > 0) {
+            soldeService.crediter(joueur.getMatricule(), montantACrediter);
+        }
+
+        if (montantRembourse.signum() > 0) {
+            paiementService.enregistrerRemboursementAnnulation(participation, montantRembourse);
+        }
+    }
+
+    private BigDecimal nullSafe(BigDecimal montant) {
+        if (montant == null) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+        return montant.setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/FermetureSiteService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/FermetureSiteService.java
@@ -24,13 +24,16 @@ public class FermetureSiteService {
     private final FermetureSiteRepository fermetureSiteRepository;
     private final SiteRepository siteRepository;
     private final ServiceAutorisationAdmin serviceAutorisationAdmin;
+    private final AnnulationMatchService annulationMatchService;
 
     public FermetureSiteService(FermetureSiteRepository fermetureSiteRepository,
                                 SiteRepository siteRepository,
-                                ServiceAutorisationAdmin serviceAutorisationAdmin) {
+                                ServiceAutorisationAdmin serviceAutorisationAdmin,
+                                AnnulationMatchService annulationMatchService) {
         this.fermetureSiteRepository = fermetureSiteRepository;
         this.siteRepository = siteRepository;
         this.serviceAutorisationAdmin = serviceAutorisationAdmin;
+        this.annulationMatchService = annulationMatchService;
     }
 
     @Transactional(readOnly = true)
@@ -76,7 +79,9 @@ public class FermetureSiteService {
         fermeture.setDateFin(null);
         fermeture.setMotif(req.getMotif());
 
-        return fermetureSiteRepository.save(fermeture);
+        FermetureSite saved = fermetureSiteRepository.save(fermeture);
+        annulerMatchsImpactesPourDate(siteId, req.getDate());
+        return saved;
     }
 
     public FermetureSite creerPeriode(Long siteId, CreateFermetureSitePeriodeRequest req) {
@@ -107,7 +112,9 @@ public class FermetureSiteService {
         fermeture.setDateFin(req.getDateFin());
         fermeture.setMotif(req.getMotif());
 
-        return fermetureSiteRepository.save(fermeture);
+        FermetureSite saved = fermetureSiteRepository.save(fermeture);
+        annulerMatchsImpactesPourPeriode(siteId, req.getDateDebut(), req.getDateFin());
+        return saved;
     }
 
     public FermetureSite updateDate(Long siteId, Long fermetureId, UpdateFermetureSiteDateRequest req) {
@@ -133,7 +140,9 @@ public class FermetureSiteService {
         fermeture.setDateFin(null);
         fermeture.setMotif(req.getMotif());
 
-        return fermetureSiteRepository.save(fermeture);
+        FermetureSite saved = fermetureSiteRepository.save(fermeture);
+        annulerMatchsImpactesPourDate(siteId, req.getDate());
+        return saved;
     }
 
     public FermetureSite updatePeriode(Long siteId, Long fermetureId, UpdateFermetureSitePeriodeRequest req) {
@@ -158,7 +167,9 @@ public class FermetureSiteService {
         fermeture.setDateFin(req.getDateFin());
         fermeture.setMotif(req.getMotif());
 
-        return fermetureSiteRepository.save(fermeture);
+        FermetureSite saved = fermetureSiteRepository.save(fermeture);
+        annulerMatchsImpactesPourPeriode(siteId, req.getDateDebut(), req.getDateFin());
+        return saved;
     }
 
     public void delete(Long siteId, Long fermetureId) {
@@ -255,5 +266,21 @@ public class FermetureSiteService {
                 }
             }
         }
+    }
+
+    private void annulerMatchsImpactesPourDate(Long siteId, LocalDate date) {
+        annulationMatchService.annulerMatchsFutursPlanifiesSite(
+                siteId,
+                date.atStartOfDay(),
+                date.plusDays(1).atStartOfDay()
+        );
+    }
+
+    private void annulerMatchsImpactesPourPeriode(Long siteId, LocalDate dateDebut, LocalDate dateFin) {
+        annulationMatchService.annulerMatchsFutursPlanifiesSite(
+                siteId,
+                dateDebut.atStartOfDay(),
+                dateFin.plusDays(1).atStartOfDay()
+        );
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
@@ -10,6 +10,7 @@ import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
@@ -140,6 +141,7 @@ public class JoueurService {
                 match.getTerrain().getId(),
                 match.getTerrain().getNom(),
                 match.getVisibilite(),
+                match.getStatut(),
                 roleJoueur,
                 statutTemporel,
                 joursAvantMatch,
@@ -180,7 +182,8 @@ public class JoueurService {
         boolean complet = nbParticipants >= CAPACITE_MATCH;
 
         boolean risquePenaliteJ1 =
-                match.getVisibilite() == MatchVisibilite.PRIVE
+                match.getStatut() != MatchStatut.ANNULE
+                        && match.getVisibilite() == MatchVisibilite.PRIVE
                         && !complet
                         && statutTemporel == MatchTemporalStatusDto.FUTUR
                         && joursAvantMatch != null
@@ -194,6 +197,7 @@ public class JoueurService {
                 match.getTerrain().getId(),
                 match.getTerrain().getNom(),
                 match.getVisibilite(),
+                match.getStatut(),
                 nbParticipants,
                 placesRestantes,
                 complet,

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -16,7 +16,9 @@ import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.entities.Site;
 import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.FermetureGlobaleRepository;
 import be.ephec.padel.backend.repository.JoueurRepository;
@@ -29,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -44,6 +47,7 @@ public class MatchPadelService {
     private static final long DUREE_MATCH_MIN = 90;
     private static final long BUFFER_MIN = 15;
     private static final long SLOT_MIN = DUREE_MATCH_MIN + BUFFER_MIN; // 105
+    private static final BigDecimal PART_JOUEUR = Tarifs.PART_PAR_JOUEUR;
 
     private final MatchPadelRepository matchPadelRepository;
     private final TerrainRepository terrainRepository;
@@ -92,15 +96,8 @@ public class MatchPadelService {
         MatchPadel match = getMatch(id);
 
         BigDecimal montantTotal = Tarifs.PRIX_MATCH;
-        BigDecimal montantPaye = paiementRepository.sumMontantByMatchId(id);
-        if (montantPaye == null) {
-            montantPaye = BigDecimal.ZERO;
-        }
-
-        BigDecimal resteAPayer = montantTotal.subtract(montantPaye);
-        if (resteAPayer.signum() < 0) {
-            resteAPayer = BigDecimal.ZERO;
-        }
+        BigDecimal montantPaye = getMontantEncaisseParMatch(match);
+        BigDecimal resteAPayer = calculerResteAPayer(match, montantTotal, montantPaye);
 
         return MatchMapper.toDtoComplet(match, montantTotal, montantPaye, resteAPayer);
     }
@@ -347,16 +344,80 @@ public class MatchPadelService {
         }
 
         BigDecimal montantTotal = Tarifs.PRIX_MATCH;
-        BigDecimal montantPaye = paiementRepository.sumMontantByMatchId(id);
-        if (montantPaye == null) {
-            montantPaye = BigDecimal.ZERO;
+        BigDecimal montantPaye = getMontantEncaisseParMatch(match);
+        BigDecimal montantRembourse = getMontantRembourseParMatch(match);
+        BigDecimal resteAPayer = calculerResteAPayer(match, montantTotal, montantPaye);
+
+        return MatchDetailMapper.toDto(match, montantTotal, montantPaye, resteAPayer, montantRembourse);
+    }
+
+    private BigDecimal getMontantEncaisseParMatch(MatchPadel match) {
+        BigDecimal montantPaye = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        if (match.getParticipations() == null) {
+            return montantPaye;
+        }
+
+        for (Participation participation : match.getParticipations()) {
+            montantPaye = montantPaye.add(getMontantEncaisseAffecteParticipation(participation));
+        }
+
+        return montantPaye;
+    }
+
+    private BigDecimal getMontantRembourseParMatch(MatchPadel match) {
+        BigDecimal totalRembourse = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        if (match.getParticipations() == null) {
+            return totalRembourse;
+        }
+
+        for (Participation participation : match.getParticipations()) {
+            totalRembourse = totalRembourse.add(getMontantRembourseAffecteParticipation(participation));
+        }
+
+        return totalRembourse;
+    }
+
+    private BigDecimal getMontantEncaisseAffecteParticipation(Participation participation) {
+        if (participation == null || participation.getId() == null) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        BigDecimal encaisseParticipation = nullSafeAmount(
+                paiementRepository.sumMontantByParticipationIdAndType(participation.getId(), TypePaiement.ENCAISSEMENT)
+        );
+
+        return encaisseParticipation.min(PART_JOUEUR).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal getMontantRembourseAffecteParticipation(Participation participation) {
+        if (participation == null || participation.getId() == null) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        BigDecimal encaisseAffecteParticipation = getMontantEncaisseAffecteParticipation(participation);
+        BigDecimal rembourseParticipation = nullSafeAmount(
+                paiementRepository.sumMontantByParticipationIdAndType(participation.getId(), TypePaiement.REMBOURSEMENT)
+        ).abs();
+
+        return rembourseParticipation.min(encaisseAffecteParticipation).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal nullSafeAmount(BigDecimal montant) {
+        if (montant == null) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+        return montant.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal calculerResteAPayer(MatchPadel match, BigDecimal montantTotal, BigDecimal montantPaye) {
+        if (match.getStatut() == MatchStatut.ANNULE) {
+            return BigDecimal.ZERO;
         }
 
         BigDecimal resteAPayer = montantTotal.subtract(montantPaye);
         if (resteAPayer.signum() < 0) {
             resteAPayer = BigDecimal.ZERO;
         }
-
-        return MatchDetailMapper.toDto(match, montantTotal, montantPaye, resteAPayer);
+        return resteAPayer;
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/PaiementService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/PaiementService.java
@@ -5,6 +5,8 @@ import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Paiement;
 import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
 import org.springframework.stereotype.Service;
@@ -12,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 @Service
@@ -23,17 +26,20 @@ public class PaiementService {
     private final PaiementRepository paiementRepository;
     private final ParticipationRepository participationRepository;
     private final SoldeService soldeService;
+    private final Clock clock;
 
     public PaiementService(PaiementRepository paiementRepository,
                            ParticipationRepository participationRepository,
-                           SoldeService soldeService) {
+                           SoldeService soldeService,
+                           Clock clock) {
         this.paiementRepository = paiementRepository;
         this.participationRepository = participationRepository;
         this.soldeService = soldeService;
+        this.clock = clock;
     }
 
     public Paiement payerParticipation(Long participationId, BigDecimal montant) {
-        return payerParticipationInterne(participationId, montant, false);
+        return payerParticipationInterne(participationId, montant, TypePaiement.ENCAISSEMENT, false);
     }
 
     public Paiement payerPourMatch(Long matchId, String joueurMatricule, BigDecimal montant) {
@@ -42,7 +48,7 @@ public class PaiementService {
     }
 
     public Paiement payerParticipationAvecRattrapageDette(Long participationId, BigDecimal montant) {
-        return payerParticipationInterne(participationId, montant, true);
+        return payerParticipationInterne(participationId, montant, TypePaiement.ENCAISSEMENT, true);
     }
 
     public Paiement payerPourMatchAvecRattrapageDette(Long matchId, String joueurMatricule, BigDecimal montant) {
@@ -50,14 +56,40 @@ public class PaiementService {
         return payerParticipationAvecRattrapageDette(participation.getId(), montant);
     }
 
+    Paiement enregistrerRemboursementAnnulation(Participation participation, BigDecimal montantRembourse) {
+        if (participation == null) {
+            throw new BusinessException("Participation obligatoire");
+        }
+        if (participation.getMatch() == null || participation.getMatch().getStatut() != MatchStatut.ANNULE) {
+            throw new BusinessException("Remboursement impossible : le match doit être annulé");
+        }
+
+        BigDecimal montant = validerMontant(
+                montantRembourse == null ? null : montantRembourse.negate(),
+                TypePaiement.REMBOURSEMENT
+        );
+
+        return paiementRepository.save(new Paiement(
+                participation,
+                montant,
+                TypePaiement.REMBOURSEMENT,
+                LocalDateTime.now(clock)
+        ));
+    }
+
     private Paiement payerParticipationInterne(Long participationId,
                                                BigDecimal montant,
+                                               TypePaiement typePaiement,
                                                boolean autoriserRattrapageDette) {
 
         Participation participation = participationRepository.findById(participationId)
                 .orElseThrow(() -> new NotFoundException("Participation introuvable"));
 
-        BigDecimal m = validerMontant(montant);
+        if (participation.getMatch() != null && participation.getMatch().getStatut() == MatchStatut.ANNULE) {
+            throw new BusinessException("Match annulé : aucun paiement n'est possible.");
+        }
+
+        BigDecimal m = validerMontant(montant, typePaiement);
 
         BigDecimal dejaPaye = getDejaPaye(participationId);
         BigDecimal restePart = PART_JOUEUR.subtract(dejaPaye).setScale(2, RoundingMode.HALF_UP);
@@ -84,7 +116,7 @@ public class PaiementService {
             );
         }
 
-        Paiement saved = paiementRepository.save(new Paiement(participation, m, LocalDateTime.now()));
+        Paiement saved = paiementRepository.save(new Paiement(participation, m, typePaiement, LocalDateTime.now(clock)));
 
         String matricule = participation.getJoueur().getMatricule();
         soldeService.crediter(matricule, m);
@@ -114,12 +146,18 @@ public class PaiementService {
         return dette.setScale(2, RoundingMode.HALF_UP);
     }
 
-    private BigDecimal validerMontant(BigDecimal montant) {
+    private BigDecimal validerMontant(BigDecimal montant, TypePaiement typePaiement) {
         if (montant == null) {
             throw new BusinessException("Montant obligatoire");
         }
-        if (montant.signum() <= 0) {
+        if (typePaiement == null) {
+            throw new BusinessException("Type de paiement obligatoire");
+        }
+        if (typePaiement == TypePaiement.ENCAISSEMENT && montant.signum() <= 0) {
             throw new BusinessException("Montant invalide");
+        }
+        if (typePaiement == TypePaiement.REMBOURSEMENT && montant.signum() >= 0) {
+            throw new BusinessException("Montant de remboursement invalide");
         }
         return montant.setScale(2, RoundingMode.HALF_UP);
     }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java
@@ -6,6 +6,7 @@ import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
@@ -50,6 +51,7 @@ public class ParticipationService {
 
         MatchPadel match = matchPadelRepository.findByIdForUpdateWithParticipations(matchId)
                 .orElseThrow(() -> new NotFoundException("Match introuvable"));
+        verifierMatchNonAnnule(match);
 
         if (match.getVisibilite() != MatchVisibilite.PUBLIC) {
             throw new BusinessException("Match privé : seule l'organisation peut ajouter des joueurs.");
@@ -86,6 +88,7 @@ public class ParticipationService {
 
         MatchPadel match = matchPadelRepository.findById(matchId)
                 .orElseThrow(() -> new NotFoundException("Match introuvable"));
+        verifierMatchNonAnnule(match);
 
         if (match.getVisibilite() != MatchVisibilite.PUBLIC) {
             throw new BusinessException("Match privé : ce calcul n'est valable que pour un match public.");
@@ -101,6 +104,7 @@ public class ParticipationService {
                                                       String organisateurMatricule,
                                                       String joueurMatriculeAAjouter) {
         MatchPadel match = getMatchOrThrow(matchId);
+        verifierMatchNonAnnule(match);
 
         if (match.getVisibilite() == MatchVisibilite.PUBLIC) {
             throw new BusinessException("Match public : l'organisateur ne peut pas ajouter des joueurs.");
@@ -127,6 +131,12 @@ public class ParticipationService {
     private MatchPadel getMatchOrThrow(Long matchId) {
         return matchPadelRepository.findById(matchId)
                 .orElseThrow(() -> new NotFoundException("Match introuvable"));
+    }
+
+    private void verifierMatchNonAnnule(MatchPadel match) {
+        if (match.getStatut() == MatchStatut.ANNULE) {
+            throw new BusinessException("Match annulé : aucune nouvelle participation n'est possible.");
+        }
     }
 
     private Joueur getJoueurOrThrow(String matricule) {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/TraitementDebutMatchService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/TraitementDebutMatchService.java
@@ -2,6 +2,9 @@ package be.ephec.padel.backend.service;
 
 import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,7 @@ import java.util.List;
 public class TraitementDebutMatchService {
 
     private static final BigDecimal PRIX_MATCH = Tarifs.PRIX_MATCH;
+    private static final BigDecimal PART_JOUEUR = Tarifs.PART_PAR_JOUEUR;
 
     private final MatchPadelRepository matchPadelRepository;
     private final PaiementRepository paiementRepository;
@@ -41,23 +45,44 @@ public class TraitementDebutMatchService {
         LocalDateTime to = now.plusSeconds(1);
 
         List<MatchPadel> matchs = matchPadelRepository.findAtraiterDebutMatchAvecDetails(from, to);
+        int traites = 0;
 
         for (MatchPadel match : matchs) {
+            if (match.getStatut() != MatchStatut.PLANIFIE) {
+                continue;
+            }
             appliquerSoldeSiIncomplet(match);
             match.setSoldeTraiteLe(now);
             matchPadelRepository.save(match);
+            traites++;
         }
 
-        return matchs.size();
+        return traites;
     }
 
     private void appliquerSoldeSiIncomplet(MatchPadel match) {
         // Si déjà complet => solde = 0 (normalement total payé = 60)
         // Si incomplet => solde = 60 - total payé, débité à l'organisateur (dette)
-        BigDecimal totalPayeMatch = paiementRepository.sumMontantByMatchId(match.getId());
-        if (totalPayeMatch == null) totalPayeMatch = BigDecimal.ZERO;
+        BigDecimal totalPayeMatch = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        for (Participation participation : match.getParticipations()) {
+            if (participation == null || participation.getId() == null) {
+                continue;
+            }
 
-        totalPayeMatch = totalPayeMatch.setScale(2, RoundingMode.HALF_UP);
+            BigDecimal encaisseParticipation = paiementRepository.sumMontantByParticipationIdAndType(
+                    participation.getId(),
+                    TypePaiement.ENCAISSEMENT
+            );
+            if (encaisseParticipation == null) {
+                encaisseParticipation = BigDecimal.ZERO;
+            }
+
+            totalPayeMatch = totalPayeMatch.add(
+                    encaisseParticipation
+                            .setScale(2, RoundingMode.HALF_UP)
+                            .min(PART_JOUEUR)
+            );
+        }
 
         BigDecimal solde = PRIX_MATCH.subtract(totalPayeMatch).setScale(2, RoundingMode.HALF_UP);
 

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/TraitementJ1Service.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/TraitementJ1Service.java
@@ -4,6 +4,7 @@ import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
@@ -51,14 +52,19 @@ public class TraitementJ1Service {
         LocalDateTime to = from.plusMinutes(windowMinutes);
 
         List<MatchPadel> matchs = matchPadelRepository.findAtraiterJ1AvecDetails(from, to);
+        int traites = 0;
 
         for (MatchPadel match : matchs) {
+            if (match.getStatut() != MatchStatut.PLANIFIE) {
+                continue;
+            }
             appliquerReglesJ1(match, now);
             match.setJ1TraiteLe(now);
             matchPadelRepository.save(match);
+            traites++;
         }
 
-        return matchs.size();
+        return traites;
     }
 
     private void appliquerReglesJ1(MatchPadel match, LocalDateTime now) {

--- a/backend/backend/src/main/resources/db/changelog/005-match-statut.yaml
+++ b/backend/backend/src/main/resources/db/changelog/005-match-statut.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  - changeSet:
+      id: 005-1-add-match-statut-column
+      author: fanoa
+      changes:
+        - addColumn:
+            tableName: match_padel
+            columns:
+              - column:
+                  name: statut
+                  type: varchar(20)
+
+  - changeSet:
+      id: 005-2-backfill-match-statut
+      author: fanoa
+      changes:
+        - update:
+            tableName: match_padel
+            columns:
+              - column:
+                  name: statut
+                  value: PLANIFIE
+
+  - changeSet:
+      id: 005-3-set-match-statut-not-null
+      author: fanoa
+      changes:
+        - addNotNullConstraint:
+            tableName: match_padel
+            columnName: statut
+            columnDataType: varchar(20)

--- a/backend/backend/src/main/resources/db/changelog/006-type-paiement.yaml
+++ b/backend/backend/src/main/resources/db/changelog/006-type-paiement.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  - changeSet:
+      id: 006-1-add-paiement-type-column
+      author: fanoa
+      changes:
+        - addColumn:
+            tableName: paiement
+            columns:
+              - column:
+                  name: type
+                  type: varchar(20)
+
+  - changeSet:
+      id: 006-2-backfill-paiement-type
+      author: fanoa
+      changes:
+        - update:
+            tableName: paiement
+            columns:
+              - column:
+                  name: type
+                  value: ENCAISSEMENT
+
+  - changeSet:
+      id: 006-3-set-paiement-type-not-null
+      author: fanoa
+      changes:
+        - addNotNullConstraint:
+            tableName: paiement
+            columnName: type
+            columnDataType: varchar(20)

--- a/backend/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -7,4 +7,8 @@ databaseChangeLog:
       file: db/changelog/003-horaire-site.yaml
   - include:
       file: db/changelog/004-drop-site-horaires.yaml
+  - include:
+      file: db/changelog/005-match-statut.yaml
+  - include:
+      file: db/changelog/006-type-paiement.yaml
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/integration/FermetureSiteAnnulationIntegrationIT.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/integration/FermetureSiteAnnulationIntegrationIT.java
@@ -1,0 +1,386 @@
+package be.ephec.padel.backend.integration;
+
+import be.ephec.padel.backend.dto.request.CreateFermetureSiteDateRequest;
+import be.ephec.padel.backend.model.entities.FermetureSite;
+import be.ephec.padel.backend.model.entities.HoraireSite;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Paiement;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.TypePaiement;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.repository.FermetureSiteRepository;
+import be.ephec.padel.backend.repository.HoraireSiteRepository;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.MouvementSoldeRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.service.MatchPadelService;
+import be.ephec.padel.backend.service.PaiementService;
+import be.ephec.padel.backend.service.ParticipationService;
+import be.ephec.padel.backend.service.TraitementDebutMatchService;
+import be.ephec.padel.backend.service.TraitementJ1Service;
+import be.ephec.padel.backend.support.SqlServerTestContainerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ContextConfiguration(classes = {
+        be.ephec.padel.backend.BackendApplication.class,
+        FermetureSiteAnnulationIntegrationIT.FixedClockConfig.class
+})
+@TestPropertySource(properties = {
+        "spring.main.allow-bean-definition-overriding=true",
+        "app.security.admin.global.password=test-global-password",
+        "app.security.admin.site.password=test-site-password",
+        "app.security.admin.site.users=adminSite1:1,adminSite2:2"
+})
+class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig {
+
+    @Autowired MockMvc mockMvc;
+
+    @Autowired SiteRepository siteRepository;
+    @Autowired TerrainRepository terrainRepository;
+    @Autowired HoraireSiteRepository horaireSiteRepository;
+    @Autowired JoueurRepository joueurRepository;
+    @Autowired MatchPadelRepository matchPadelRepository;
+    @Autowired ParticipationRepository participationRepository;
+    @Autowired PaiementRepository paiementRepository;
+    @Autowired MouvementSoldeRepository mouvementSoldeRepository;
+    @Autowired FermetureSiteRepository fermetureSiteRepository;
+
+    @Autowired MatchPadelService matchPadelService;
+    @Autowired ParticipationService participationService;
+    @Autowired PaiementService paiementService;
+    @Autowired TraitementJ1Service traitementJ1Service;
+    @Autowired TraitementDebutMatchService traitementDebutMatchService;
+    @Autowired MutableClock clock;
+
+    private Site site;
+    private Terrain terrain;
+    private Joueur orga;
+    private Joueur joueur2;
+    private Joueur joueur3;
+    private Joueur joueur4;
+    private Joueur joueur5;
+
+    @BeforeEach
+    void cleanAndSeed() {
+        clock.setInstant(LocalDateTime.of(2030, 1, 1, 9, 0)
+                .atZone(clock.getZone())
+                .toInstant());
+
+        paiementRepository.deleteAll();
+        participationRepository.deleteAll();
+        matchPadelRepository.deleteAll();
+        mouvementSoldeRepository.deleteAll();
+        fermetureSiteRepository.deleteAll();
+        horaireSiteRepository.deleteAll();
+        terrainRepository.deleteAll();
+        joueurRepository.deleteAll();
+        siteRepository.deleteAll();
+
+        site = new Site("Site Annulation IT", "Bruxelles");
+        site.setJoursFermeture(Set.of());
+        site = siteRepository.save(site);
+
+        terrain = new Terrain("Terrain Annulation IT", site);
+        terrain = terrainRepository.save(terrain);
+
+        horaireSiteRepository.save(new HoraireSite(
+                site,
+                LocalDate.now(clock).getYear(),
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0)
+        ));
+
+        orga = joueurRepository.save(joueur("G0001", "Orga"));
+        joueur2 = joueurRepository.save(joueur("G0002", "Joueur 2"));
+        joueur3 = joueurRepository.save(joueur("G0003", "Joueur 3"));
+        joueur4 = joueurRepository.save(joueur("G0004", "Joueur 4"));
+        joueur5 = joueurRepository.save(joueur("G0005", "Joueur 5"));
+    }
+
+    @Test
+    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
+    void fermeture_date_annule_match_prive_compense_et_bloque_les_ecritures() throws Exception {
+        LocalDateTime dateMatch = LocalDateTime.of(2030, 1, 2, 10, 0);
+
+        MatchPadel match = matchPadelService.creerMatch(
+                terrain.getId(),
+                orga.getMatricule(),
+                dateMatch,
+                MatchVisibilite.PRIVE
+        );
+
+        participationService.ajouterJoueurParOrganisateur(match.getId(), orga.getMatricule(), joueur2.getMatricule());
+        participationService.ajouterJoueurParOrganisateur(match.getId(), orga.getMatricule(), joueur3.getMatricule());
+
+        Participation participationJ3 = participationRepository
+                .findByMatch_IdAndJoueur_Matricule(match.getId(), joueur3.getMatricule())
+                .orElseThrow();
+        paiementService.payerParticipation(participationJ3.getId(), new BigDecimal("10.00"));
+
+        mockMvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2030-01-02",
+                                  "motif": "Incident technique"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", org.hamcrest.Matchers.containsString("/api/v1/admin/sites/" + site.getId() + "/fermetures/")));
+
+        MatchPadel cancelled = matchPadelRepository.findByIdWithDetails(match.getId()).orElseThrow();
+        assertThat(cancelled.getStatut()).isEqualTo(MatchStatut.ANNULE);
+        assertThat(cancelled.getParticipations()).hasSize(3);
+
+        Joueur orgaReloaded = joueurRepository.findById(orga.getMatricule()).orElseThrow();
+        Joueur joueur2Reloaded = joueurRepository.findById(joueur2.getMatricule()).orElseThrow();
+        Joueur joueur3Reloaded = joueurRepository.findById(joueur3.getMatricule()).orElseThrow();
+        assertThat(orgaReloaded.getSolde()).isEqualByComparingTo("0.00");
+        assertThat(joueur2Reloaded.getSolde()).isEqualByComparingTo("0.00");
+        assertThat(joueur3Reloaded.getSolde()).isEqualByComparingTo("0.00");
+
+        List<Paiement> paiements = paiementRepository.findByParticipation_Match_Id(match.getId());
+        assertThat(paiements).hasSize(4);
+        assertThat(paiements.stream()
+                .filter(p -> p.getType() == TypePaiement.REMBOURSEMENT)
+                .map(Paiement::getMontant))
+                .containsExactlyInAnyOrder(new BigDecimal("-15.00"), new BigDecimal("-10.00"));
+
+        mockMvc.perform(get("/api/v1/matchs/public")
+                        .param("from", "2030-01-01")
+                        .param("to", "2030-01-03")
+                        .param("siteId", site.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+
+        mockMvc.perform(get("/api/v1/matchs/" + match.getId())
+                        .param("matricule", orga.getMatricule()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statut").value("ANNULE"))
+                .andExpect(jsonPath("$.resteAPayer").value(0.00))
+                .andExpect(jsonPath("$.montantPaye").value(25.00))
+                .andExpect(jsonPath("$.montantRembourse").value(25.00));
+
+        mockMvc.perform(get("/api/v1/joueurs/" + joueur3.getMatricule() + "/matchs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].statut").value("ANNULE"));
+
+        mockMvc.perform(get("/api/v1/joueurs/" + orga.getMatricule() + "/matchs/organises"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].statut").value("ANNULE"))
+                .andExpect(jsonPath("$[0].risquePenaliteJ1").value(false));
+
+        mockMvc.perform(post("/api/v1/matchs/" + match.getId() + "/participants/prive")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "organisateurMatricule": "%s",
+                                  "joueurMatriculeAAjouter": "%s"
+                                }
+                                """.formatted(orga.getMatricule(), joueur4.getMatricule())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Match annul")));
+
+        mockMvc.perform(post("/api/v1/participations/" + participationJ3.getId() + "/paiements")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "montant": 5.00
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Match annul")));
+
+        FermetureSite fermeture = fermetureSiteRepository.findAll().get(0);
+        mockMvc.perform(delete("/api/v1/admin/sites/" + site.getId() + "/fermetures/" + fermeture.getId()))
+                .andExpect(status().isNoContent());
+
+        MatchPadel stillCancelled = matchPadelRepository.findByIdWithDetails(match.getId()).orElseThrow();
+        assertThat(stillCancelled.getStatut()).isEqualTo(MatchStatut.ANNULE);
+    }
+
+    @Test
+    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
+    void fermeture_date_annule_match_public_et_bloque_join_et_montant_attendu() throws Exception {
+        LocalDateTime dateMatch = LocalDateTime.of(2030, 1, 2, 11, 0);
+
+        MatchPadel match = matchPadelService.creerMatch(
+                terrain.getId(),
+                orga.getMatricule(),
+                dateMatch,
+                MatchVisibilite.PUBLIC
+        );
+
+        mockMvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2030-01-02",
+                                  "motif": "Incident technique"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/matchs/" + match.getId() + "/participants/public/montant-attendu")
+                        .param("joueurMatricule", joueur5.getMatricule()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Match annul")));
+
+        mockMvc.perform(post("/api/v1/matchs/" + match.getId() + "/participants/public")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "joueurMatricule": "%s"
+                                }
+                                """.formatted(joueur5.getMatricule())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Match annul")));
+    }
+
+    @Test
+    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
+    void match_annule_est_ignore_par_schedulers_et_exclu_des_stats() throws Exception {
+        LocalDateTime dateMatch = LocalDateTime.of(2030, 1, 2, 9, 1);
+
+        MatchPadel match = matchPadelService.creerMatch(
+                terrain.getId(),
+                orga.getMatricule(),
+                dateMatch,
+                MatchVisibilite.PRIVE
+        );
+
+        mockMvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "date": "2030-01-02",
+                                  "motif": "Incident technique"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        int traitesJ1 = traitementJ1Service.traiterJ1FenetreMinutes(5);
+        assertThat(traitesJ1).isZero();
+
+        MatchPadel afterJ1 = matchPadelRepository.findByIdWithDetails(match.getId()).orElseThrow();
+        assertThat(afterJ1.getJ1TraiteLe()).isNull();
+        assertThat(joueurRepository.findById(orga.getMatricule()).orElseThrow().getPenaliteJusqua()).isNull();
+
+        clock.setInstant(dateMatch.plusMinutes(1).atZone(clock.getZone()).toInstant());
+
+        int traitesDebut = traitementDebutMatchService.traiterDebutMatchFenetreMinutes(5);
+        assertThat(traitesDebut).isZero();
+
+        MatchPadel afterDebut = matchPadelRepository.findByIdWithDetails(match.getId()).orElseThrow();
+        assertThat(afterDebut.getSoldeTraiteLe()).isNull();
+        assertThat(joueurRepository.findById(orga.getMatricule()).orElseThrow().getSolde()).isEqualByComparingTo("0.00");
+
+        mockMvc.perform(get("/api/v1/admin/stats/matchs")
+                        .param("from", "2030-01-02")
+                        .param("to", "2030-01-02"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nbMatchs").value(0));
+
+        mockMvc.perform(get("/api/v1/admin/stats/ca")
+                        .param("from", "2030-01-01")
+                        .param("to", "2030-01-01"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.caTotal").value(0.00));
+
+        mockMvc.perform(get("/api/v1/admin/sites/" + site.getId() + "/stats/matchs")
+                        .param("from", "2030-01-02")
+                        .param("to", "2030-01-02"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nbMatchs").value(0));
+    }
+
+    private Joueur joueur(String matricule, String nom) {
+        Joueur joueur = new Joueur(matricule, nom, TypeJoueur.GLOBAL);
+        joueur.setSolde(BigDecimal.ZERO);
+        return joueur;
+    }
+
+    @TestConfiguration
+    static class FixedClockConfig {
+
+        @Bean
+        @Primary
+        MutableClock clock() {
+            return new MutableClock(
+                    Instant.parse("2030-01-01T08:00:00Z"),
+                    ZoneId.of("Europe/Brussels")
+            );
+        }
+    }
+
+    static final class MutableClock extends Clock {
+
+        private Instant instant;
+        private final ZoneId zone;
+
+        MutableClock(Instant instant, ZoneId zone) {
+            this.instant = instant;
+            this.zone = zone;
+        }
+
+        void setInstant(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return new MutableClock(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/repository/MatchPadelRepositoryTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/repository/MatchPadelRepositoryTest.java
@@ -1,6 +1,7 @@
 package be.ephec.padel.backend.repository;
 
 import be.ephec.padel.backend.model.entities.*;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.support.SqlServerTestContainerConfig;
@@ -177,5 +178,152 @@ class MatchPadelRepositoryTest extends SqlServerTestContainerConfig {
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).getId()).isEqualTo(publicMatch.getId());
         assertThat(rows.get(0).getNbParticipants()).isEqualTo(2L);
+    }
+
+    @Test
+    void findPublicMatchSummaries_exclut_les_matchs_annules() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        MatchPadel plannedMatch = new MatchPadel(
+                t, orga, LocalDateTime.of(2030, 1, 1, 10, 0), MatchVisibilite.PUBLIC
+        );
+        MatchPadel cancelledMatch = new MatchPadel(
+                t, orga, LocalDateTime.of(2030, 1, 2, 10, 0), MatchVisibilite.PUBLIC
+        );
+        cancelledMatch.setStatut(MatchStatut.ANNULE);
+
+        matchPadelRepository.save(plannedMatch);
+        matchPadelRepository.save(cancelledMatch);
+
+        em.flush();
+        em.clear();
+
+        var rows = matchPadelRepository.findPublicMatchSummaries(
+                MatchVisibilite.PUBLIC,
+                null,
+                null,
+                null
+        );
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getId()).isEqualTo(plannedMatch.getId());
+    }
+
+    @Test
+    void countByDateDebutBetween_exclut_les_matchs_annules() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        matchPadelRepository.save(new MatchPadel(
+                t, orga, LocalDateTime.of(2030, 1, 1, 10, 0), MatchVisibilite.PUBLIC
+        ));
+
+        MatchPadel cancelledMatch = new MatchPadel(
+                t, orga, LocalDateTime.of(2030, 1, 2, 10, 0), MatchVisibilite.PUBLIC
+        );
+        cancelledMatch.setStatut(MatchStatut.ANNULE);
+        matchPadelRepository.save(cancelledMatch);
+
+        long count = matchPadelRepository.countByDateDebutBetween(
+                LocalDateTime.of(2030, 1, 1, 0, 0),
+                LocalDateTime.of(2030, 1, 3, 0, 0)
+        );
+
+        assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    void findAtraiterJ1AvecDetails_exclut_les_matchs_annules() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        MatchPadel plannedMatch = new MatchPadel(
+                t, orga, LocalDateTime.of(2030, 1, 2, 10, 0), MatchVisibilite.PUBLIC
+        );
+        MatchPadel cancelledMatch = new MatchPadel(
+                t, orga, LocalDateTime.of(2030, 1, 2, 11, 0), MatchVisibilite.PUBLIC
+        );
+        cancelledMatch.setStatut(MatchStatut.ANNULE);
+
+        matchPadelRepository.save(plannedMatch);
+        matchPadelRepository.save(cancelledMatch);
+
+        List<MatchPadel> rows = matchPadelRepository.findAtraiterJ1AvecDetails(
+                LocalDateTime.of(2030, 1, 2, 0, 0),
+                LocalDateTime.of(2030, 1, 3, 0, 0)
+        );
+
+        assertThat(rows).extracting(MatchPadel::getId).containsExactly(plannedMatch.getId());
+    }
+
+    @Test
+    void findAtraiterDebutMatchAvecDetails_exclut_les_matchs_annules() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        MatchPadel plannedMatch = new MatchPadel(
+                t, orga, LocalDateTime.of(2030, 1, 2, 10, 0), MatchVisibilite.PUBLIC
+        );
+        MatchPadel cancelledMatch = new MatchPadel(
+                t, orga, LocalDateTime.of(2030, 1, 2, 11, 0), MatchVisibilite.PUBLIC
+        );
+        cancelledMatch.setStatut(MatchStatut.ANNULE);
+
+        matchPadelRepository.save(plannedMatch);
+        matchPadelRepository.save(cancelledMatch);
+
+        List<MatchPadel> rows = matchPadelRepository.findAtraiterDebutMatchAvecDetails(
+                LocalDateTime.of(2030, 1, 2, 0, 0),
+                LocalDateTime.of(2030, 1, 3, 0, 0)
+        );
+
+        assertThat(rows).extracting(MatchPadel::getId).containsExactly(plannedMatch.getId());
+    }
+
+    @Test
+    void findPlannedFutureMatchesBySiteIdAndDateDebutBetween_retourne_seulement_les_matchs_planifies_futurs_du_site() {
+        Site siteA = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Site siteB = siteRepository.save(new Site("Site B", "Namur"));
+        Terrain terrainA = terrainRepository.save(new Terrain("T1", siteA));
+        Terrain terrainB = terrainRepository.save(new Terrain("T2", siteB));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        LocalDateTime now = LocalDateTime.of(2030, 1, 1, 9, 0);
+        LocalDateTime from = LocalDateTime.of(2030, 1, 1, 0, 0);
+        LocalDateTime to = LocalDateTime.of(2030, 1, 3, 0, 0);
+
+        MatchPadel inScope = new MatchPadel(
+                terrainA, orga, LocalDateTime.of(2030, 1, 1, 10, 0), MatchVisibilite.PUBLIC
+        );
+        MatchPadel startedOrPast = new MatchPadel(
+                terrainA, orga, LocalDateTime.of(2030, 1, 1, 8, 0), MatchVisibilite.PUBLIC
+        );
+        MatchPadel cancelled = new MatchPadel(
+                terrainA, orga, LocalDateTime.of(2030, 1, 2, 10, 0), MatchVisibilite.PUBLIC
+        );
+        cancelled.setStatut(MatchStatut.ANNULE);
+        MatchPadel otherSite = new MatchPadel(
+                terrainB, orga, LocalDateTime.of(2030, 1, 1, 11, 0), MatchVisibilite.PUBLIC
+        );
+
+        matchPadelRepository.save(inScope);
+        matchPadelRepository.save(startedOrPast);
+        matchPadelRepository.save(cancelled);
+        matchPadelRepository.save(otherSite);
+
+        List<MatchPadel> rows = matchPadelRepository.findPlannedFutureMatchesBySiteIdAndDateDebutBetween(
+                siteA.getId(),
+                MatchStatut.PLANIFIE,
+                now,
+                from,
+                to
+        );
+
+        assertThat(rows).extracting(MatchPadel::getId).containsExactly(inScope.getId());
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/repository/PaiementRepositoryTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/repository/PaiementRepositoryTest.java
@@ -2,6 +2,7 @@ package be.ephec.padel.backend.repository;
 
 import be.ephec.padel.backend.model.entities.*;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.support.SqlServerTestContainerConfig;
 import org.junit.jupiter.api.Test;
@@ -44,5 +45,54 @@ class PaiementRepositoryTest extends SqlServerTestContainerConfig {
 
         assertThat(sum).isNotNull();
         assertThat(sum).isEqualByComparingTo(new BigDecimal("12.50"));
+    }
+
+    @Test
+    void sumMontantByMatchIdAndType_filtre_correctement_encaissements_et_remboursements() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+        Joueur j1 = joueurRepository.save(new Joueur("J001", "Alice", TypeJoueur.GLOBAL));
+
+        MatchPadel match = matchPadelRepository.save(
+                new MatchPadel(t, orga, LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC)
+        );
+
+        Participation part = participationRepository.save(new Participation(match, j1));
+
+        paiementRepository.save(new Paiement(part, new BigDecimal("15.00"), TypePaiement.ENCAISSEMENT, LocalDateTime.now()));
+        paiementRepository.save(new Paiement(part, new BigDecimal("-5.00"), TypePaiement.REMBOURSEMENT, LocalDateTime.now()));
+
+        BigDecimal encaissements = paiementRepository.sumMontantByMatchIdAndType(match.getId(), TypePaiement.ENCAISSEMENT);
+        BigDecimal remboursements = paiementRepository.sumMontantByMatchIdAndType(match.getId(), TypePaiement.REMBOURSEMENT);
+
+        assertThat(encaissements).isEqualByComparingTo(new BigDecimal("15.00"));
+        assertThat(remboursements).isEqualByComparingTo(new BigDecimal("-5.00"));
+    }
+
+    @Test
+    void sumMontantByParticipationIdAndType_filtre_correctement_par_type() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+        Joueur j1 = joueurRepository.save(new Joueur("J001", "Alice", TypeJoueur.GLOBAL));
+
+        MatchPadel match = matchPadelRepository.save(
+                new MatchPadel(t, orga, LocalDateTime.now().plusDays(1), MatchVisibilite.PUBLIC)
+        );
+
+        Participation part = participationRepository.save(new Participation(match, j1));
+
+        paiementRepository.save(new Paiement(part, new BigDecimal("10.00"), TypePaiement.ENCAISSEMENT, LocalDateTime.now()));
+        paiementRepository.save(new Paiement(part, new BigDecimal("5.00"), TypePaiement.ENCAISSEMENT, LocalDateTime.now()));
+        paiementRepository.save(new Paiement(part, new BigDecimal("-6.00"), TypePaiement.REMBOURSEMENT, LocalDateTime.now()));
+
+        BigDecimal encaissements = paiementRepository.sumMontantByParticipationIdAndType(part.getId(), TypePaiement.ENCAISSEMENT);
+        BigDecimal remboursements = paiementRepository.sumMontantByParticipationIdAndType(part.getId(), TypePaiement.REMBOURSEMENT);
+
+        assertThat(encaissements).isEqualByComparingTo(new BigDecimal("15.00"));
+        assertThat(remboursements).isEqualByComparingTo(new BigDecimal("-6.00"));
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminSiteStatsServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminSiteStatsServiceTest.java
@@ -1,0 +1,88 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
+import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.security.ServiceAutorisationAdmin;
+import be.ephec.padel.backend.service.AdminSiteStatsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminSiteStatsServiceTest {
+
+    @Mock
+    PaiementRepository paiementRepository;
+    @Mock
+    MatchPadelRepository matchPadelRepository;
+    @Mock
+    JoueurRepository joueurRepository;
+    @Mock
+    ServiceAutorisationAdmin serviceAutorisationAdmin;
+
+    private AdminSiteStatsService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminSiteStatsService(
+                paiementRepository,
+                matchPadelRepository,
+                joueurRepository,
+                serviceAutorisationAdmin
+        );
+    }
+
+    @Test
+    void getNbMatchs_utilise_le_compteur_filtre_par_site_et_statut() {
+        Long siteId = 3L;
+        LocalDate from = LocalDate.of(2026, 3, 1);
+        LocalDate to = LocalDate.of(2026, 3, 31);
+
+        when(matchPadelRepository.countByDateDebutBetweenAndSiteId(
+                eq(from.atStartOfDay()),
+                eq(to.plusDays(1).atStartOfDay()),
+                eq(siteId)
+        )).thenReturn(4L);
+
+        AdminMatchsStatsDto dto = service.getNbMatchs(siteId, from, to);
+
+        assertThat(dto.getNbMatchs()).isEqualTo(4L);
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(siteId);
+        verify(matchPadelRepository).countByDateDebutBetweenAndSiteId(
+                from.atStartOfDay(),
+                to.plusDays(1).atStartOfDay(),
+                siteId
+        );
+    }
+
+    @Test
+    void getCa_conserve_un_mode_cash_base_par_site() {
+        Long siteId = 3L;
+        LocalDate from = LocalDate.of(2026, 3, 1);
+        LocalDate to = LocalDate.of(2026, 3, 31);
+
+        when(paiementRepository.sumMontantByDatePaiementBetweenAndSiteId(
+                from.atStartOfDay(),
+                to.plusDays(1).atStartOfDay(),
+                siteId
+        )).thenReturn(new BigDecimal("18.00"));
+
+        AdminCaStatsDto dto = service.getCa(siteId, from, to);
+
+        assertThat(dto.getCaTotal()).isEqualByComparingTo("18.00");
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(siteId);
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminStatsServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminStatsServiceTest.java
@@ -1,0 +1,85 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
+import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.service.AdminStatsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminStatsServiceTest {
+
+    @Mock
+    PaiementRepository paiementRepository;
+    @Mock
+    MatchPadelRepository matchPadelRepository;
+    @Mock
+    JoueurRepository joueurRepository;
+
+    private AdminStatsService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminStatsService(paiementRepository, matchPadelRepository, joueurRepository);
+    }
+
+    @Test
+    void getNbMatchs_utilise_le_compteur_filtre_par_statut() {
+        LocalDate from = LocalDate.of(2026, 3, 1);
+        LocalDate to = LocalDate.of(2026, 3, 31);
+
+        when(matchPadelRepository.countByDateDebutBetween(
+                eq(from.atStartOfDay()),
+                eq(to.plusDays(1).atStartOfDay())
+        )).thenReturn(7L);
+
+        AdminMatchsStatsDto dto = service.getNbMatchs(from, to);
+
+        assertThat(dto.getNbMatchs()).isEqualTo(7L);
+        verify(matchPadelRepository).countByDateDebutBetween(
+                from.atStartOfDay(),
+                to.plusDays(1).atStartOfDay()
+        );
+    }
+
+    @Test
+    void getCa_conserve_un_mode_cash_base() {
+        LocalDate from = LocalDate.of(2026, 3, 1);
+        LocalDate to = LocalDate.of(2026, 3, 31);
+        LocalDateTime fromStart = from.atStartOfDay();
+        LocalDateTime toExclusive = to.plusDays(1).atStartOfDay();
+
+        when(paiementRepository.sumMontantByDatePaiementBetween(fromStart, toExclusive))
+                .thenReturn(new BigDecimal("42.50"));
+
+        AdminCaStatsDto dto = service.getCa(from, to);
+
+        assertThat(dto.getCaTotal()).isEqualByComparingTo("42.50");
+    }
+
+    @Test
+    void getNbMatchs_refuse_une_periode_invalide() {
+        LocalDate from = LocalDate.of(2026, 4, 2);
+        LocalDate to = LocalDate.of(2026, 4, 1);
+
+        assertThatThrownBy(() -> service.getNbMatchs(from, to))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AnnulationMatchServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AnnulationMatchServiceTest.java
@@ -1,0 +1,179 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class AnnulationMatchServiceTest {
+
+    private MatchPadelRepository matchPadelRepository;
+    private PaiementRepository paiementRepository;
+    private PaiementService paiementService;
+    private SoldeService soldeService;
+
+    private AnnulationMatchService service;
+
+    @BeforeEach
+    void setUp() {
+        matchPadelRepository = mock(MatchPadelRepository.class);
+        paiementRepository = mock(PaiementRepository.class);
+        paiementService = mock(PaiementService.class);
+        soldeService = mock(SoldeService.class);
+
+        Clock clock = Clock.fixed(Instant.parse("2030-01-01T09:00:00Z"), ZoneOffset.UTC);
+        service = new AnnulationMatchService(
+                matchPadelRepository,
+                paiementRepository,
+                paiementService,
+                soldeService,
+                clock
+        );
+    }
+
+    @Test
+    void annulerMatchSiPlanifie_matchIntrouvable_notFound() {
+        when(matchPadelRepository.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> service.annulerMatchSiPlanifie(1L));
+    }
+
+    @Test
+    void annulerMatchSiPlanifie_matchDejaAnnule_neFaitRien() {
+        MatchPadel match = createMatch(LocalDateTime.of(2030, 1, 1, 10, 0));
+        match.setStatut(MatchStatut.ANNULE);
+
+        when(matchPadelRepository.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
+
+        boolean result = service.annulerMatchSiPlanifie(1L);
+
+        assertFalse(result);
+        verifyNoInteractions(paiementRepository, paiementService, soldeService);
+        verify(matchPadelRepository, never()).save(any(MatchPadel.class));
+    }
+
+    @Test
+    void annulerMatchSiPlanifie_matchDejaCommence_neFaitRien() {
+        MatchPadel match = createMatch(LocalDateTime.of(2030, 1, 1, 9, 0));
+
+        when(matchPadelRepository.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
+
+        boolean result = service.annulerMatchSiPlanifie(1L);
+
+        assertFalse(result);
+        verifyNoInteractions(paiementRepository, paiementService, soldeService);
+        verify(matchPadelRepository, never()).save(any(MatchPadel.class));
+    }
+
+    @Test
+    void annulerMatchSiPlanifie_paiementPartiel_annuleDetteRestanteEtRembourseLePaye() {
+        MatchPadel match = createMatch(LocalDateTime.of(2030, 1, 1, 10, 0));
+        Joueur joueur = createJoueur("J001", new BigDecimal("5.00"));
+        Participation participation = new Participation(match, joueur);
+        ReflectionTestUtils.setField(participation, "id", 11L);
+        match.addParticipation(participation);
+
+        when(matchPadelRepository.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
+        when(paiementRepository.sumMontantByParticipationId(11L)).thenReturn(new BigDecimal("10.00"));
+
+        boolean result = service.annulerMatchSiPlanifie(1L);
+
+        assertTrue(result);
+        assertTrue(match.getStatut() == MatchStatut.ANNULE);
+        verify(soldeService).crediter("J001", new BigDecimal("5.00"));
+        verify(paiementService).enregistrerRemboursementAnnulation(participation, new BigDecimal("10.00"));
+        verify(matchPadelRepository).save(match);
+    }
+
+    @Test
+    void annulerMatchSiPlanifie_remboursementPlafonneAuCoutDuMatch() {
+        MatchPadel match = createMatch(LocalDateTime.of(2030, 1, 1, 10, 0));
+        Joueur joueur = createJoueur("J001", BigDecimal.ZERO);
+        Participation participation = new Participation(match, joueur);
+        ReflectionTestUtils.setField(participation, "id", 12L);
+        match.addParticipation(participation);
+
+        when(matchPadelRepository.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
+        when(paiementRepository.sumMontantByParticipationId(12L)).thenReturn(new BigDecimal("20.00"));
+
+        boolean result = service.annulerMatchSiPlanifie(1L);
+
+        assertTrue(result);
+        verifyNoInteractions(soldeService);
+        verify(paiementService).enregistrerRemboursementAnnulation(participation, new BigDecimal("15.00"));
+        verify(matchPadelRepository).save(match);
+    }
+
+    @Test
+    void annulerMatchsFutursPlanifiesSite_annuleTousLesMatchsRetournes() {
+        MatchPadel match1 = createMatch(LocalDateTime.of(2030, 1, 1, 10, 0));
+        MatchPadel match2 = createMatch(LocalDateTime.of(2030, 1, 1, 11, 0));
+        ReflectionTestUtils.setField(match1, "id", 101L);
+        ReflectionTestUtils.setField(match2, "id", 102L);
+
+        when(matchPadelRepository.findPlannedFutureMatchesBySiteIdAndDateDebutBetween(
+                55L,
+                MatchStatut.PLANIFIE,
+                LocalDateTime.of(2030, 1, 1, 9, 0),
+                LocalDateTime.of(2030, 1, 1, 0, 0),
+                LocalDateTime.of(2030, 1, 2, 0, 0)
+        )).thenReturn(List.of(match1, match2));
+
+        when(matchPadelRepository.findByIdForUpdateWithParticipations(101L)).thenReturn(Optional.of(match1));
+        when(matchPadelRepository.findByIdForUpdateWithParticipations(102L)).thenReturn(Optional.of(match2));
+
+        int result = service.annulerMatchsFutursPlanifiesSite(
+                55L,
+                LocalDateTime.of(2030, 1, 1, 0, 0),
+                LocalDateTime.of(2030, 1, 2, 0, 0)
+        );
+
+        assertEquals(2, result);
+        verify(matchPadelRepository).save(match1);
+        verify(matchPadelRepository).save(match2);
+    }
+
+    private MatchPadel createMatch(LocalDateTime dateDebut) {
+        Site site = new Site("Site A", "Bruxelles");
+        Terrain terrain = new Terrain("T1", site);
+        Joueur organisateur = createJoueur("ORG1", BigDecimal.ZERO);
+        MatchPadel match = new MatchPadel(terrain, organisateur, dateDebut, MatchVisibilite.PUBLIC);
+        ReflectionTestUtils.setField(match, "id", 1L);
+        return match;
+    }
+
+    private Joueur createJoueur(String matricule, BigDecimal solde) {
+        Joueur joueur = new Joueur(matricule, "Nom", TypeJoueur.GLOBAL);
+        joueur.setSolde(solde);
+        return joueur;
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/FermetureSiteServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/FermetureSiteServiceTest.java
@@ -11,6 +11,7 @@ import be.ephec.padel.backend.model.entities.FermetureSite;
 import be.ephec.padel.backend.model.entities.Site;
 import be.ephec.padel.backend.repository.FermetureSiteRepository;
 import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.service.AnnulationMatchService;
 import be.ephec.padel.backend.security.ServiceAutorisationAdmin;
 import be.ephec.padel.backend.service.FermetureSiteService;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +30,7 @@ class FermetureSiteServiceTest {
     private FermetureSiteRepository fermetureSiteRepository;
     private SiteRepository siteRepository;
     private ServiceAutorisationAdmin serviceAutorisationAdmin;
+    private AnnulationMatchService annulationMatchService;
     private FermetureSiteService service;
 
     @BeforeEach
@@ -36,11 +38,13 @@ class FermetureSiteServiceTest {
         fermetureSiteRepository = mock(FermetureSiteRepository.class);
         siteRepository = mock(SiteRepository.class);
         serviceAutorisationAdmin = mock(ServiceAutorisationAdmin.class);
+        annulationMatchService = mock(AnnulationMatchService.class);
 
         service = new FermetureSiteService(
                 fermetureSiteRepository,
                 siteRepository,
-                serviceAutorisationAdmin
+                serviceAutorisationAdmin,
+                annulationMatchService
         );
 
         doNothing().when(serviceAutorisationAdmin).verifierAccesAuSite(anyLong());
@@ -284,6 +288,11 @@ class FermetureSiteServiceTest {
         verify(siteRepository).findById(1L);
         verify(fermetureSiteRepository).existsBySiteIdAndDate(1L, LocalDate.of(2030, 1, 15));
         verify(fermetureSiteRepository).save(any(FermetureSite.class));
+        verify(annulationMatchService).annulerMatchsFutursPlanifiesSite(
+                1L,
+                LocalDate.of(2030, 1, 15).atStartOfDay(),
+                LocalDate.of(2030, 1, 16).atStartOfDay()
+        );
     }
 
     // --------
@@ -371,6 +380,11 @@ class FermetureSiteServiceTest {
         verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
         verify(siteRepository).findById(1L);
         verify(fermetureSiteRepository).save(any(FermetureSite.class));
+        verify(annulationMatchService).annulerMatchsFutursPlanifiesSite(
+                1L,
+                LocalDate.of(2030, 2, 10).atStartOfDay(),
+                LocalDate.of(2030, 2, 16).atStartOfDay()
+        );
     }
 
     // --------
@@ -456,6 +470,11 @@ class FermetureSiteServiceTest {
 
         verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
         verify(fermetureSiteRepository).save(fermeture);
+        verify(annulationMatchService).annulerMatchsFutursPlanifiesSite(
+                1L,
+                LocalDate.of(2030, 1, 20).atStartOfDay(),
+                LocalDate.of(2030, 1, 21).atStartOfDay()
+        );
     }
 
     // --------
@@ -556,6 +575,11 @@ class FermetureSiteServiceTest {
 
         verify(serviceAutorisationAdmin).verifierAccesAuSite(1L);
         verify(fermetureSiteRepository).save(fermeture);
+        verify(annulationMatchService).annulerMatchsFutursPlanifiesSite(
+                1L,
+                LocalDate.of(2030, 2, 10).atStartOfDay(),
+                LocalDate.of(2030, 2, 16).atStartOfDay()
+        );
     }
 
     // --------
@@ -588,6 +612,7 @@ class FermetureSiteServiceTest {
         verify(siteRepository).findById(1L);
         verify(fermetureSiteRepository).findByIdAndSiteId(10L, 1L);
         verify(fermetureSiteRepository).delete(fermeture);
+        verifyNoInteractions(annulationMatchService);
     }
 
     // --------

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/JoueurServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/JoueurServiceTest.java
@@ -7,6 +7,7 @@ import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.*;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
@@ -67,6 +68,7 @@ class JoueurServiceTest {
         when(match.getId()).thenReturn(999L);
         when(match.getDateDebut()).thenReturn(LocalDateTime.of(dateMatch, LocalTime.of(10, 0)));
         when(match.getVisibilite()).thenReturn(visibilite);
+        when(match.getStatut()).thenReturn(MatchStatut.PLANIFIE);
         when(match.getOrganisateur()).thenReturn(organisateur);
         when(match.getTerrain()).thenReturn(terrain);
 
@@ -104,6 +106,7 @@ class JoueurServiceTest {
         when(match.getId()).thenReturn(matchId);
         when(match.getDateDebut()).thenReturn(LocalDateTime.of(dateMatch, LocalTime.of(10, 0)));
         when(match.getVisibilite()).thenReturn(visibilite);
+        when(match.getStatut()).thenReturn(MatchStatut.PLANIFIE);
         when(match.getTerrain()).thenReturn(terrain);
         when(match.getOrganisateur()).thenReturn(organisateur);
 
@@ -381,6 +384,7 @@ class JoueurServiceTest {
         assertEquals(1, result.size());
 
         PlayerMatchSummaryDto dto = result.get(0);
+        assertEquals(MatchStatut.PLANIFIE, dto.statut());
         assertEquals(PlayerMatchRoleDto.PARTICIPANT, dto.roleJoueur());
         assertEquals(MatchTemporalStatusDto.FUTUR, dto.statutTemporel());
         assertEquals(5, dto.joursAvantMatch());
@@ -417,6 +421,7 @@ class JoueurServiceTest {
         assertEquals(1, result.size());
 
         PlayerMatchSummaryDto dto = result.get(0);
+        assertEquals(MatchStatut.PLANIFIE, dto.statut());
         assertEquals(PlayerMatchRoleDto.ORGANISATEUR, dto.roleJoueur());
         assertEquals(MatchTemporalStatusDto.FUTUR, dto.statutTemporel());
         assertEquals(3, dto.joursAvantMatch());
@@ -426,6 +431,33 @@ class JoueurServiceTest {
         assertEquals("Terrain Central", dto.terrainNom());
         assertEquals(2L, dto.siteId());
         assertEquals("Site Omega", dto.siteNom());
+    }
+
+    @Test
+    void getPlayerMatches_matchAnnule_exposeLeStatut() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        Participation participation = mockParticipation(
+                "G9999",
+                "G0001",
+                LocalDate.now().plusDays(3),
+                MatchVisibilite.PUBLIC,
+                true,
+                21L,
+                "Terrain Cancelled",
+                3L,
+                "Site Cancelled"
+        );
+        when(participation.getMatch().getStatut()).thenReturn(MatchStatut.ANNULE);
+
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of(participation));
+
+        List<PlayerMatchSummaryDto> result = service.getPlayerMatches("G0001");
+
+        assertEquals(1, result.size());
+        assertEquals(MatchStatut.ANNULE, result.get(0).statut());
     }
 
     @Test
@@ -589,6 +621,7 @@ class JoueurServiceTest {
         assertEquals(1, result.size());
 
         OrganizerMatchSummaryDto dto = result.get(0);
+        assertEquals(MatchStatut.PLANIFIE, dto.statut());
         assertEquals(1L, dto.id());
         assertEquals(10L, dto.terrainId());
         assertEquals("Terrain 1", dto.terrainNom());
@@ -601,6 +634,33 @@ class JoueurServiceTest {
         assertEquals(MatchTemporalStatusDto.FUTUR, dto.statutTemporel());
         assertEquals(1, dto.joursAvantMatch());
         assertTrue(dto.risquePenaliteJ1());
+    }
+
+    @Test
+    void getOrganizedMatches_matchAnnule_risquePenaliteFalse() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        MatchPadel match = mockOrganizedMatch(
+                LocalDate.now().plusDays(1),
+                MatchVisibilite.PRIVE,
+                2,
+                11L,
+                110L,
+                "Terrain Cancelled",
+                1110L,
+                "Site Cancelled"
+        );
+        when(match.getStatut()).thenReturn(MatchStatut.ANNULE);
+
+        when(matchPadelRepo.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of(match));
+
+        List<OrganizerMatchSummaryDto> result = service.getOrganizedMatches("G0001");
+
+        assertEquals(1, result.size());
+        assertEquals(MatchStatut.ANNULE, result.get(0).statut());
+        assertFalse(result.get(0).risquePenaliteJ1());
     }
 
     @Test
@@ -625,6 +685,7 @@ class JoueurServiceTest {
         List<OrganizerMatchSummaryDto> result = service.getOrganizedMatches("G0001");
 
         OrganizerMatchSummaryDto dto = result.get(0);
+        assertEquals(MatchStatut.PLANIFIE, dto.statut());
         assertEquals(MatchVisibilite.PUBLIC, dto.visibilite());
         assertEquals(2, dto.nbParticipants());
         assertEquals(2, dto.placesRestantes());

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
@@ -8,7 +8,9 @@ import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.ForbiddenException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.*;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.FermetureGlobaleRepository;
 import be.ephec.padel.backend.repository.JoueurRepository;
@@ -133,6 +135,7 @@ class MatchPadelServiceTest {
         when(m.getId()).thenReturn(1L);
         when(m.getDateDebut()).thenReturn(dateValide());
         when(m.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
+        when(m.getStatut()).thenReturn(MatchStatut.PLANIFIE);
 
         Terrain t = mock(Terrain.class);
         when(t.getId()).thenReturn(10L);
@@ -146,10 +149,17 @@ class MatchPadelServiceTest {
         when(orga.getMatricule()).thenReturn("G0001");
         when(m.getOrganisateur()).thenReturn(orga);
 
-        when(m.getParticipations()).thenReturn(List.of(mock(Participation.class), mock(Participation.class)));
+        Participation p1 = mock(Participation.class);
+        Participation p2 = mock(Participation.class);
+        when(p1.getId()).thenReturn(11L);
+        when(p2.getId()).thenReturn(12L);
+        when(m.getParticipations()).thenReturn(List.of(p1, p2));
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(m));
 
-        when(paiementRepo.sumMontantByMatchId(1L)).thenReturn(new BigDecimal("20.00"));
+        when(paiementRepo.sumMontantByParticipationIdAndType(11L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("15.00"));
+        when(paiementRepo.sumMontantByParticipationIdAndType(12L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("5.00"));
 
         MatchDto dto = service.getMatchDto(1L);
 
@@ -158,6 +168,7 @@ class MatchPadelServiceTest {
         assertEquals("T1", dto.getTerrainNom());
         assertEquals(5L, dto.getSiteId());
         assertEquals("G0001", dto.getOrganisateurMatricule());
+        assertEquals(MatchStatut.PLANIFIE, dto.getStatut());
         assertEquals(2, dto.getNbParticipants());
 
         assertEquals(Tarifs.PRIX_MATCH, dto.getMontantTotal());
@@ -171,14 +182,14 @@ class MatchPadelServiceTest {
         when(m.getId()).thenReturn(1L);
         when(m.getDateDebut()).thenReturn(dateValide());
         when(m.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
+        when(m.getStatut()).thenReturn(MatchStatut.PLANIFIE);
         when(m.getParticipations()).thenReturn(List.of());
 
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(m));
-        when(paiementRepo.sumMontantByMatchId(1L)).thenReturn(null);
 
         MatchDto dto = service.getMatchDto(1L);
 
-        assertEquals(BigDecimal.ZERO, dto.getMontantPaye());
+        assertEquals(0, BigDecimal.ZERO.compareTo(dto.getMontantPaye()));
         assertEquals(Tarifs.PRIX_MATCH, dto.getResteAPayer());
     }
 
@@ -188,14 +199,67 @@ class MatchPadelServiceTest {
         when(m.getId()).thenReturn(1L);
         when(m.getDateDebut()).thenReturn(dateValide());
         when(m.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
-        when(m.getParticipations()).thenReturn(List.of());
+        when(m.getStatut()).thenReturn(MatchStatut.PLANIFIE);
+        Participation p1 = mock(Participation.class);
+        when(p1.getId()).thenReturn(21L);
+        when(m.getParticipations()).thenReturn(List.of(p1));
 
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(m));
-        when(paiementRepo.sumMontantByMatchId(1L)).thenReturn(Tarifs.PRIX_MATCH.add(new BigDecimal("1.00")));
+        when(paiementRepo.sumMontantByParticipationIdAndType(21L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("25.00"));
 
         MatchDto dto = service.getMatchDto(1L);
 
+        assertEquals(new BigDecimal("15.00"), dto.getMontantPaye());
+        assertEquals(new BigDecimal("45.00"), dto.getResteAPayer());
+    }
+
+    @Test
+    void getMatchDto_matchAnnule_resteAPayerZero_et_statutVisible() {
+        MatchPadel m = mock(MatchPadel.class);
+        when(m.getId()).thenReturn(1L);
+        when(m.getDateDebut()).thenReturn(dateValide());
+        when(m.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
+        when(m.getStatut()).thenReturn(MatchStatut.ANNULE);
+        Participation p1 = mock(Participation.class);
+        when(p1.getId()).thenReturn(31L);
+        when(m.getParticipations()).thenReturn(List.of(p1));
+
+        when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(m));
+        when(paiementRepo.sumMontantByParticipationIdAndType(31L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("25.00"));
+
+        MatchDto dto = service.getMatchDto(1L);
+
+        assertEquals(MatchStatut.ANNULE, dto.getStatut());
+        assertEquals(new BigDecimal("15.00"), dto.getMontantPaye());
         assertEquals(BigDecimal.ZERO, dto.getResteAPayer());
+    }
+
+    @Test
+    void getMatchDto_paiementAvecRattrapageDette_estPlafonneA15ParParticipation() {
+        MatchPadel m = mock(MatchPadel.class);
+        when(m.getId()).thenReturn(1L);
+        when(m.getDateDebut()).thenReturn(dateValide());
+        when(m.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
+        when(m.getStatut()).thenReturn(MatchStatut.PLANIFIE);
+
+        Participation p1 = mock(Participation.class);
+        Participation p2 = mock(Participation.class);
+        when(p1.getId()).thenReturn(41L);
+        when(p2.getId()).thenReturn(42L);
+        when(m.getParticipations()).thenReturn(List.of(p1, p2));
+
+        when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(m));
+        when(paiementRepo.sumMontantByParticipationIdAndType(41L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("25.00"));
+        when(paiementRepo.sumMontantByParticipationIdAndType(42L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("10.00"));
+
+        MatchDto dto = service.getMatchDto(1L);
+
+        assertEquals(new BigDecimal("25.00"), dto.getMontantPaye());
+        assertEquals(new BigDecimal("35.00"), dto.getResteAPayer());
     }
 
     // ----------------
@@ -684,6 +748,7 @@ class MatchPadelServiceTest {
         MatchPadel match = mock(MatchPadel.class);
         when(match.getId()).thenReturn(1L);
         when(match.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
+        when(match.getStatut()).thenReturn(MatchStatut.PLANIFIE);
         when(match.getDateDebut()).thenReturn(LocalDateTime.of(2030, 1, 1, 10, 0));
 
         Terrain terrain = mock(Terrain.class);
@@ -705,7 +770,6 @@ class MatchPadelServiceTest {
         when(match.getParticipations()).thenReturn(List.of());
 
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
-        when(paiementRepo.sumMontantByMatchId(1L)).thenReturn(BigDecimal.ZERO);
 
         MatchDetailDto dto = service.getMatchDetailDto(1L, null);
 
@@ -713,9 +777,11 @@ class MatchPadelServiceTest {
         assertEquals("Site Delta", dto.getSiteNom());
         assertEquals("Terrain 1", dto.getTerrainNom());
         assertEquals("G0001", dto.getOrganisateurMatricule());
+        assertEquals(MatchStatut.PLANIFIE, dto.getStatut());
         assertEquals(0, dto.getNbParticipants());
         assertEquals(4, dto.getPlacesRestantes());
         assertFalse(dto.isComplet());
+        assertEquals(0, BigDecimal.ZERO.compareTo(dto.getMontantRembourse()));
     }
 
     @Test
@@ -728,7 +794,7 @@ class MatchPadelServiceTest {
         assertThrows(ForbiddenException.class,
                 () -> service.getMatchDetailDto(1L, null));
 
-        verify(paiementRepo, never()).sumMontantByMatchId(anyLong());
+        verify(paiementRepo, never()).sumMontantByParticipationIdAndType(anyLong(), any());
     }
 
     @Test
@@ -736,6 +802,7 @@ class MatchPadelServiceTest {
         MatchPadel match = mock(MatchPadel.class);
         when(match.getId()).thenReturn(1L);
         when(match.getVisibilite()).thenReturn(MatchVisibilite.PRIVE);
+        when(match.getStatut()).thenReturn(MatchStatut.PLANIFIE);
         when(match.getDateDebut()).thenReturn(LocalDateTime.of(2030, 1, 1, 10, 0));
 
         Terrain terrain = mock(Terrain.class);
@@ -757,7 +824,6 @@ class MatchPadelServiceTest {
         when(match.getParticipations()).thenReturn(List.of());
 
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
-        when(paiementRepo.sumMontantByMatchId(1L)).thenReturn(BigDecimal.ZERO);
 
         MatchDetailDto dto = service.getMatchDetailDto(1L, "G0001");
 
@@ -770,6 +836,7 @@ class MatchPadelServiceTest {
         MatchPadel match = mock(MatchPadel.class);
         when(match.getId()).thenReturn(1L);
         when(match.getVisibilite()).thenReturn(MatchVisibilite.PRIVE);
+        when(match.getStatut()).thenReturn(MatchStatut.PLANIFIE);
         when(match.getDateDebut()).thenReturn(LocalDateTime.of(2030, 1, 1, 10, 0));
 
         Terrain terrain = mock(Terrain.class);
@@ -792,13 +859,15 @@ class MatchPadelServiceTest {
         when(joueur.getNom()).thenReturn("Alice");
 
         when(participation.getJoueur()).thenReturn(joueur);
+        when(participation.getId()).thenReturn(51L);
 
         when(match.getTerrain()).thenReturn(terrain);
         when(match.getOrganisateur()).thenReturn(orga);
         when(match.getParticipations()).thenReturn(List.of(participation));
 
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
-        when(paiementRepo.sumMontantByMatchId(1L)).thenReturn(BigDecimal.ZERO);
+        when(paiementRepo.sumMontantByParticipationIdAndType(51L, TypePaiement.ENCAISSEMENT)).thenReturn(BigDecimal.ZERO);
+        when(paiementRepo.sumMontantByParticipationIdAndType(51L, TypePaiement.REMBOURSEMENT)).thenReturn(BigDecimal.ZERO);
 
         MatchDetailDto dto = service.getMatchDetailDto(1L, "J0001");
 
@@ -827,7 +896,51 @@ class MatchPadelServiceTest {
         assertThrows(ForbiddenException.class,
                 () -> service.getMatchDetailDto(1L, "X9999"));
 
-        verify(paiementRepo, never()).sumMontantByMatchId(anyLong());
+        verify(paiementRepo, never()).sumMontantByParticipationIdAndType(anyLong(), any());
+    }
+
+    @Test
+    void getMatchDetailDto_matchAnnule_exposeStatut_et_montantRembourse() {
+        MatchPadel match = mock(MatchPadel.class);
+        when(match.getId()).thenReturn(1L);
+        when(match.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
+        when(match.getStatut()).thenReturn(MatchStatut.ANNULE);
+        when(match.getDateDebut()).thenReturn(LocalDateTime.of(2030, 1, 1, 10, 0));
+
+        Terrain terrain = mock(Terrain.class);
+        Site site = mock(Site.class);
+        Joueur orga = mock(Joueur.class);
+
+        when(site.getId()).thenReturn(5L);
+        when(site.getNom()).thenReturn("Site Delta");
+        when(terrain.getId()).thenReturn(10L);
+        when(terrain.getNom()).thenReturn("Terrain 1");
+        when(terrain.getSite()).thenReturn(site);
+        when(orga.getMatricule()).thenReturn("G0001");
+        when(orga.getNom()).thenReturn("Orga");
+
+        when(match.getTerrain()).thenReturn(terrain);
+        when(match.getOrganisateur()).thenReturn(orga);
+        Participation participation = mock(Participation.class);
+        Joueur joueur = mock(Joueur.class);
+        when(participation.getId()).thenReturn(61L);
+        when(joueur.getMatricule()).thenReturn("J0002");
+        when(joueur.getNom()).thenReturn("Bob");
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(match.getParticipations()).thenReturn(List.of(participation));
+
+        when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
+        when(paiementRepo.sumMontantByParticipationIdAndType(61L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("25.00"));
+        when(paiementRepo.sumMontantByParticipationIdAndType(61L, TypePaiement.REMBOURSEMENT))
+                .thenReturn(new BigDecimal("-20.00"));
+
+        MatchDetailDto dto = service.getMatchDetailDto(1L, null);
+
+        assertEquals(MatchStatut.ANNULE, dto.getStatut());
+        assertEquals(new BigDecimal("15.00"), dto.getMontantPaye());
+        assertEquals(new BigDecimal("15.00"), dto.getMontantRembourse());
+        assertEquals(BigDecimal.ZERO, dto.getResteAPayer());
     }
 
     @Test

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/PaiementServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/PaiementServiceTest.java
@@ -3,16 +3,27 @@ package be.ephec.padel.backend.unit.service;
 import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Paiement;
 import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.TypePaiement;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.service.PaiementService;
 import be.ephec.padel.backend.service.SoldeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -24,6 +35,7 @@ class PaiementServiceTest {
     private PaiementRepository paiementRepo;
     private ParticipationRepository participationRepo;
     private SoldeService soldeService;
+    private Clock clock;
 
     private PaiementService service;
 
@@ -32,8 +44,9 @@ class PaiementServiceTest {
         paiementRepo = mock(PaiementRepository.class);
         participationRepo = mock(ParticipationRepository.class);
         soldeService = mock(SoldeService.class);
+        clock = Clock.fixed(Instant.parse("2030-01-01T09:00:00Z"), ZoneOffset.UTC);
 
-        service = new PaiementService(paiementRepo, participationRepo, soldeService);
+        service = new PaiementService(paiementRepo, participationRepo, soldeService, clock);
     }
 
     // ----------------
@@ -66,6 +79,19 @@ class PaiementServiceTest {
 
         assertThrows(BusinessException.class, () -> service.payerParticipation(1L, BigDecimal.ZERO));
         assertThrows(BusinessException.class, () -> service.payerParticipation(1L, new BigDecimal("-1.00")));
+
+        verifyNoInteractions(paiementRepo, soldeService);
+    }
+
+    @Test
+    void payerParticipation_matchAnnule_refuse() {
+        Participation p = mock(Participation.class);
+        MatchPadel match = mock(MatchPadel.class);
+        when(match.getStatut()).thenReturn(MatchStatut.ANNULE);
+        when(p.getMatch()).thenReturn(match);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(p));
+
+        assertThrows(BusinessException.class, () -> service.payerParticipation(1L, new BigDecimal("5.00")));
 
         verifyNoInteractions(paiementRepo, soldeService);
     }
@@ -115,7 +141,10 @@ class PaiementServiceTest {
         Paiement result = service.payerParticipation(1L, new BigDecimal("5.00"));
 
         assertSame(saved, result);
-        verify(paiementRepo).save(any(Paiement.class));
+        verify(paiementRepo).save(argThat(paiement ->
+                paiement.getType() == TypePaiement.ENCAISSEMENT
+                        && paiement.getMontant().compareTo(new BigDecimal("5.00")) == 0
+        ));
         verify(soldeService).crediter("G1", new BigDecimal("5.00").setScale(2));
     }
 
@@ -137,6 +166,10 @@ class PaiementServiceTest {
         Paiement result = service.payerParticipation(1L, new BigDecimal("7.50"));
 
         assertSame(saved, result);
+        verify(paiementRepo).save(argThat(paiement ->
+                paiement.getType() == TypePaiement.ENCAISSEMENT
+                        && paiement.getMontant().compareTo(new BigDecimal("7.50")) == 0
+        ));
         verify(soldeService).crediter("G1", new BigDecimal("7.50"));
     }
 
@@ -158,6 +191,10 @@ class PaiementServiceTest {
         Paiement result = service.payerParticipation(1L, new BigDecimal("5.1"));
 
         assertSame(saved, result);
+        verify(paiementRepo).save(argThat(paiement ->
+                paiement.getType() == TypePaiement.ENCAISSEMENT
+                        && paiement.getMontant().compareTo(new BigDecimal("5.10")) == 0
+        ));
         verify(soldeService).crediter("G1", new BigDecimal("5.10"));
     }
 
@@ -199,6 +236,89 @@ class PaiementServiceTest {
         Paiement result = service.payerPourMatch(10L, "G1", new BigDecimal("5.00"));
 
         assertSame(saved, result);
+        verify(paiementRepo).save(argThat(paiement ->
+                paiement.getType() == TypePaiement.ENCAISSEMENT
+                        && paiement.getMontant().compareTo(new BigDecimal("5.00")) == 0
+        ));
         verify(soldeService).crediter("G1", new BigDecimal("5.00"));
+    }
+
+    @Test
+    void validerMontant_remboursementPositifOuZero_refuse() {
+        assertThrows(BusinessException.class, () ->
+                ReflectionTestUtils.invokeMethod(
+                        service, "validerMontant", BigDecimal.ZERO, TypePaiement.REMBOURSEMENT
+                ));
+
+        assertThrows(BusinessException.class, () ->
+                ReflectionTestUtils.invokeMethod(
+                        service, "validerMontant", new BigDecimal("1.00"), TypePaiement.REMBOURSEMENT
+                ));
+    }
+
+    @Test
+    void validerMontant_remboursementNegatif_ok() {
+        BigDecimal montant = ReflectionTestUtils.invokeMethod(
+                service, "validerMontant", new BigDecimal("-5.1"), TypePaiement.REMBOURSEMENT
+        );
+
+        assertEquals(new BigDecimal("-5.10"), montant);
+    }
+
+    @Test
+    void enregistrerRemboursementAnnulation_matchNonAnnule_refuse() {
+        Site site = new Site("Site A", "Bruxelles");
+        Terrain terrain = new Terrain("T1", site);
+        Joueur organisateur = new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL);
+        MatchPadel match = new MatchPadel(
+                terrain,
+                organisateur,
+                java.time.LocalDateTime.of(2030, 1, 2, 10, 0),
+                MatchVisibilite.PUBLIC
+        );
+        Joueur joueur = new Joueur("J001", "Alice", TypeJoueur.GLOBAL);
+        Participation participation = new Participation(match, joueur);
+
+        assertThrows(BusinessException.class, () ->
+                ReflectionTestUtils.invokeMethod(
+                        service,
+                        "enregistrerRemboursementAnnulation",
+                        participation,
+                        new BigDecimal("5.00")
+                ));
+
+        verifyNoInteractions(paiementRepo);
+    }
+
+    @Test
+    void enregistrerRemboursementAnnulation_matchAnnule_enregistreUnRemboursementNegatif() {
+        Site site = new Site("Site A", "Bruxelles");
+        Terrain terrain = new Terrain("T1", site);
+        Joueur organisateur = new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL);
+        MatchPadel match = new MatchPadel(
+                terrain,
+                organisateur,
+                java.time.LocalDateTime.of(2030, 1, 2, 10, 0),
+                MatchVisibilite.PUBLIC
+        );
+        match.setStatut(MatchStatut.ANNULE);
+        Joueur joueur = new Joueur("J001", "Alice", TypeJoueur.GLOBAL);
+        Participation participation = new Participation(match, joueur);
+        Paiement saved = mock(Paiement.class);
+
+        when(paiementRepo.save(any(Paiement.class))).thenReturn(saved);
+
+        Paiement result = ReflectionTestUtils.invokeMethod(
+                service,
+                "enregistrerRemboursementAnnulation",
+                participation,
+                new BigDecimal("5.00")
+        );
+
+        assertSame(saved, result);
+        verify(paiementRepo).save(argThat(paiement ->
+                paiement.getType() == TypePaiement.REMBOURSEMENT
+                        && paiement.getMontant().compareTo(new BigDecimal("-5.00")) == 0
+        ));
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceTest.java
@@ -6,6 +6,7 @@ import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
@@ -75,6 +76,20 @@ class ParticipationServiceTest {
     }
 
     @Test
+    void calculerMontantAttendu_matchAnnule_refuse() {
+        MatchPadel match = new MatchPadel();
+        match.setVisibilite(MatchVisibilite.PUBLIC);
+        match.setStatut(MatchStatut.ANNULE);
+
+        when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
+
+        assertThrows(BusinessException.class,
+                () -> service.calculerMontantAttenduPourMatchPublic(1L, "G1"));
+
+        verifyNoInteractions(joueurRepo);
+    }
+
+    @Test
     void calculerMontantAttendu_public_sansDette_retourne15() {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
@@ -124,6 +139,20 @@ class ParticipationServiceTest {
     void rejoindreEtPayerMatchPublic_matchPrive_refuse() {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PRIVE);
+
+        when(matchRepo.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
+
+        assertThrows(BusinessException.class,
+                () -> service.rejoindreEtPayerMatchPublic(1L, "G1"));
+
+        verifyNoInteractions(joueurRepo, participationRepo, soldeService, paiementService);
+    }
+
+    @Test
+    void rejoindreEtPayerMatchPublic_matchAnnule_refuse() {
+        MatchPadel match = new MatchPadel();
+        match.setVisibilite(MatchVisibilite.PUBLIC);
+        match.setStatut(MatchStatut.ANNULE);
 
         when(matchRepo.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
 
@@ -260,6 +289,20 @@ class ParticipationServiceTest {
     void ajouterJoueurParOrganisateur_matchPublic_refuse() {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
+
+        when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
+
+        assertThrows(BusinessException.class,
+                () -> service.ajouterJoueurParOrganisateur(1L, "G1", "G2"));
+
+        verifyNoInteractions(joueurRepo, participationRepo, soldeService, paiementService);
+    }
+
+    @Test
+    void ajouterJoueurParOrganisateur_matchAnnule_refuse() {
+        MatchPadel match = new MatchPadel();
+        match.setVisibilite(MatchVisibilite.PRIVE);
+        match.setStatut(MatchStatut.ANNULE);
 
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/TraitementDebutMatchServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/TraitementDebutMatchServiceTest.java
@@ -2,7 +2,10 @@ package be.ephec.padel.backend.unit.service;
 
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
@@ -16,21 +19,26 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
-import java.time.*;
-
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TraitementDebutMatchServiceTest {
 
     @Mock MatchPadelRepository matchPadelRepository;
     @Mock PaiementRepository paiementRepository;
-    @Mock
-    SoldeService soldeService;
+    @Mock SoldeService soldeService;
 
     private Clock clock;
     private TraitementDebutMatchService service;
@@ -54,20 +62,80 @@ class TraitementDebutMatchServiceTest {
         Joueur orga = new Joueur("O1", "Orga", TypeJoueur.GLOBAL);
         match.setOrganisateur(orga);
 
+        Participation p1 = new Participation(match, orga);
+        Participation p2 = new Participation(match, new Joueur("J2", "Joueur 2", TypeJoueur.GLOBAL));
+        setId(p1, 100L);
+        setId(p2, 101L);
+        match.addParticipation(p1);
+        match.addParticipation(p2);
+
         when(matchPadelRepository.findAtraiterDebutMatchAvecDetails(any(), any()))
                 .thenReturn(List.of(match));
         when(matchPadelRepository.save(any(MatchPadel.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
-
-        // total payé = 30 => solde = 30
-        when(paiementRepository.sumMontantByMatchId(55L)).thenReturn(new BigDecimal("30.00"));
+        when(paiementRepository.sumMontantByParticipationIdAndType(100L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("15.00"));
+        when(paiementRepository.sumMontantByParticipationIdAndType(101L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("15.00"));
 
         int treated = service.traiterDebutMatchFenetreMinutes(5);
 
         assertThat(treated).isEqualTo(1);
         verify(soldeService).debiter(eq("O1"), eq(new BigDecimal("30.00")));
-
         assertThat(match.getSoldeTraiteLe()).isEqualTo(now);
+    }
+
+    @Test
+    void match_annule_ignore_meme_si_retourne_par_le_repository() {
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        MatchPadel match = new MatchPadel(null, null, now.minusMinutes(1), MatchVisibilite.PUBLIC);
+        setId(match, 56L);
+        match.setStatut(MatchStatut.ANNULE);
+
+        when(matchPadelRepository.findAtraiterDebutMatchAvecDetails(any(), any()))
+                .thenReturn(List.of(match));
+
+        int treated = service.traiterDebutMatchFenetreMinutes(5);
+
+        assertThat(treated).isZero();
+        assertThat(match.getSoldeTraiteLe()).isNull();
+
+        verifyNoInteractions(soldeService);
+        verify(matchPadelRepository, never()).save(any(MatchPadel.class));
+        verifyNoInteractions(paiementRepository);
+    }
+
+    @Test
+    void debut_match_ignore_le_rattrapage_de_dette_dans_le_total_paye_du_match() {
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        MatchPadel match = new MatchPadel(null, null, now.minusMinutes(1), MatchVisibilite.PUBLIC);
+        setId(match, 57L);
+
+        Joueur orga = new Joueur("O1", "Orga", TypeJoueur.GLOBAL);
+        match.setOrganisateur(orga);
+
+        Participation p1 = new Participation(match, orga);
+        Participation p2 = new Participation(match, new Joueur("J2", "Joueur 2", TypeJoueur.GLOBAL));
+        setId(p1, 110L);
+        setId(p2, 111L);
+        match.addParticipation(p1);
+        match.addParticipation(p2);
+
+        when(matchPadelRepository.findAtraiterDebutMatchAvecDetails(any(), any()))
+                .thenReturn(List.of(match));
+        when(matchPadelRepository.save(any(MatchPadel.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(paiementRepository.sumMontantByParticipationIdAndType(110L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("25.00"));
+        when(paiementRepository.sumMontantByParticipationIdAndType(111L, TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("10.00"));
+
+        int treated = service.traiterDebutMatchFenetreMinutes(5);
+
+        assertThat(treated).isEqualTo(1);
+        verify(soldeService).debiter(eq("O1"), eq(new BigDecimal("35.00")));
     }
 
     private static void setId(Object entity, Long id) {

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/TraitementJ1ServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/TraitementJ1ServiceTest.java
@@ -4,6 +4,7 @@ import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
@@ -162,6 +163,27 @@ class TraitementJ1ServiceTest {
 
         // flag idempotent
         assertThat(match.getJ1TraiteLe()).isEqualTo(now);
+    }
+
+    @Test
+    void match_annule_ignore_meme_si_retourne_par_le_repository() {
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        MatchPadel match = new MatchPadel(null, null, now.plusHours(24).plusMinutes(1), MatchVisibilite.PRIVE);
+        setId(match, 30L);
+        match.setStatut(MatchStatut.ANNULE);
+
+        when(matchPadelRepository.findAtraiterJ1AvecDetails(any(), any()))
+                .thenReturn(List.of(match));
+
+        int treated = service.traiterJ1FenetreMinutes(5);
+
+        assertThat(treated).isZero();
+        assertThat(match.getJ1TraiteLe()).isNull();
+
+        verifyNoInteractions(soldeService);
+        verify(matchPadelRepository, never()).save(any(MatchPadel.class));
+        verifyNoInteractions(paiementRepository);
     }
 
     // ---- helpers (IDs JPA) ----

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/JoueurControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/JoueurControllerTest.java
@@ -9,6 +9,7 @@ import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
 import be.ephec.padel.backend.error.ApiExceptionHandler;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.service.JoueurService;
@@ -187,6 +188,7 @@ class JoueurControllerTest {
                 200L,
                 "Terrain 1",
                 MatchVisibilite.PUBLIC,
+                MatchStatut.PLANIFIE,
                 PlayerMatchRoleDto.PARTICIPANT,
                 MatchTemporalStatusDto.FUTUR,
                 5,
@@ -243,6 +245,7 @@ class JoueurControllerTest {
                 200L,
                 "Terrain 1",
                 MatchVisibilite.PRIVE,
+                MatchStatut.PLANIFIE,
                 2,
                 2,
                 false,

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
@@ -11,6 +11,7 @@ import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.ForbiddenException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.service.MatchPadelService;
 import org.junit.jupiter.api.Test;
@@ -60,6 +61,7 @@ class MatchControllerTest {
                 "G0001",
                 LocalDateTime.now().plusDays(1),
                 MatchVisibilite.PUBLIC,
+                MatchStatut.PLANIFIE,
                 2,
                 new BigDecimal("60.00"),
                 new BigDecimal("15.00"),
@@ -95,12 +97,14 @@ class MatchControllerTest {
                 "G0001",
                 "Organisateur",
                 visibilite,
+                MatchStatut.PLANIFIE,
                 2,
                 2,
                 false,
                 new BigDecimal("60.00"),
                 new BigDecimal("15.00"),
                 new BigDecimal("45.00"),
+                BigDecimal.ZERO,
                 List.of(
                         new ParticipantDto("G0001", "Organisateur"),
                         new ParticipantDto("J0001", "Alice")


### PR DESCRIPTION
- ajout du statut métier ANNULE sur MatchPadel (Liquibase inclus)
- annulation automatique des matchs futurs via FermetureSiteService
- introduction de AnnulationMatchService (logique centralisée et idempotente)

- blocage des écritures sur match ANNULE (participation, paiement)
- conservation de l’historique (participations et paiements)

- gestion financière :
  - distinction ENCAISSEMENT / REMBOURSEMENT
  - remboursement interne plafonné à PART_JOUEUR
  - agrégation par participation (évite les biais liés aux dettes anciennes)
  - resteAPayer = 0 pour match ANNULE

- propagation du statut dans les lectures privées (DTO, mappers, services)
- exclusion des matchs ANNULE des listes publiques, schedulers et stats

- ajustement des schedulers (J-1, début match) pour ignorer ANNULE
- maintien d’un CA cash-based (pas de recalcul rétroactif)

- ajout et adaptation des tests (unitaires, repository, web, intégration)

- respect des invariants métier :
  - pas de suppression d’historique
  - pas de filtre global implicite
  - pas de réactivation automatique