### PR TITLE
78# test: sécuriser les filtres nullables sur les matchs publics

### DIFF
--- a/backend/backend/src/test/java/be/ephec/padel/backend/repository/MatchPadelRepositoryTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/repository/MatchPadelRepositoryTest.java
@@ -212,6 +212,159 @@ class MatchPadelRepositoryTest extends SqlServerTestContainerConfig {
     }
 
     @Test
+    void findPublicMatchSummaries_filtre_par_site_quand_siteId_est_renseigne() {
+        Site siteA = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Site siteB = siteRepository.save(new Site("Site B", "Namur"));
+        Terrain terrainA = terrainRepository.save(new Terrain("T1", siteA));
+        Terrain terrainB = terrainRepository.save(new Terrain("T2", siteB));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        MatchPadel matchSiteA = matchPadelRepository.save(
+                new MatchPadel(terrainA, orga, LocalDateTime.of(2030, 1, 2, 10, 0), MatchVisibilite.PUBLIC)
+        );
+        matchPadelRepository.save(
+                new MatchPadel(terrainB, orga, LocalDateTime.of(2030, 1, 2, 11, 0), MatchVisibilite.PUBLIC)
+        );
+
+        em.flush();
+        em.clear();
+
+        var rows = matchPadelRepository.findPublicMatchSummaries(
+                MatchVisibilite.PUBLIC,
+                null,
+                null,
+                siteA.getId()
+        );
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getId()).isEqualTo(matchSiteA.getId());
+        assertThat(rows.get(0).getSiteId()).isEqualTo(siteA.getId());
+    }
+
+    @Test
+    void findPublicMatchSummaries_filtre_avec_from_seul() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        LocalDateTime from = LocalDateTime.of(2030, 1, 2, 10, 0);
+        matchPadelRepository.save(
+                new MatchPadel(t, orga, from.minusMinutes(1), MatchVisibilite.PUBLIC)
+        );
+        MatchPadel matchAtFrom = matchPadelRepository.save(
+                new MatchPadel(t, orga, from, MatchVisibilite.PUBLIC)
+        );
+
+        em.flush();
+        em.clear();
+
+        var rows = matchPadelRepository.findPublicMatchSummaries(
+                MatchVisibilite.PUBLIC,
+                from,
+                null,
+                null
+        );
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getId()).isEqualTo(matchAtFrom.getId());
+    }
+
+    @Test
+    void findPublicMatchSummaries_filtre_avec_to_seul() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        LocalDateTime to = LocalDateTime.of(2030, 1, 2, 10, 0);
+        MatchPadel matchBeforeTo = matchPadelRepository.save(
+                new MatchPadel(t, orga, to.minusMinutes(1), MatchVisibilite.PUBLIC)
+        );
+        matchPadelRepository.save(
+                new MatchPadel(t, orga, to.plusMinutes(1), MatchVisibilite.PUBLIC)
+        );
+
+        em.flush();
+        em.clear();
+
+        var rows = matchPadelRepository.findPublicMatchSummaries(
+                MatchVisibilite.PUBLIC,
+                null,
+                to,
+                null
+        );
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getId()).isEqualTo(matchBeforeTo.getId());
+    }
+
+    @Test
+    void findPublicMatchSummaries_inclut_la_borne_exacte_to() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        LocalDateTime to = LocalDateTime.of(2030, 1, 2, 10, 0);
+        MatchPadel matchAtTo = matchPadelRepository.save(
+                new MatchPadel(t, orga, to, MatchVisibilite.PUBLIC)
+        );
+        matchPadelRepository.save(
+                new MatchPadel(t, orga, to.plusSeconds(1), MatchVisibilite.PUBLIC)
+        );
+
+        em.flush();
+        em.clear();
+
+        var rows = matchPadelRepository.findPublicMatchSummaries(
+                MatchVisibilite.PUBLIC,
+                null,
+                to,
+                null
+        );
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getId()).isEqualTo(matchAtTo.getId());
+    }
+
+    @Test
+    void findPublicMatchSummaries_filtre_par_from_to_et_siteId() {
+        Site siteA = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Site siteB = siteRepository.save(new Site("Site B", "Namur"));
+        Terrain terrainA = terrainRepository.save(new Terrain("T1", siteA));
+        Terrain terrainB = terrainRepository.save(new Terrain("T2", siteB));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        LocalDateTime from = LocalDateTime.of(2030, 1, 2, 0, 0);
+        LocalDateTime to = LocalDateTime.of(2030, 1, 2, 23, 59, 59);
+
+        matchPadelRepository.save(
+                new MatchPadel(terrainA, orga, from.minusMinutes(1), MatchVisibilite.PUBLIC)
+        );
+        MatchPadel inScope = matchPadelRepository.save(
+                new MatchPadel(terrainA, orga, LocalDateTime.of(2030, 1, 2, 10, 0), MatchVisibilite.PUBLIC)
+        );
+        matchPadelRepository.save(
+                new MatchPadel(terrainA, orga, to.plusSeconds(1), MatchVisibilite.PUBLIC)
+        );
+        matchPadelRepository.save(
+                new MatchPadel(terrainB, orga, LocalDateTime.of(2030, 1, 2, 11, 0), MatchVisibilite.PUBLIC)
+        );
+
+        em.flush();
+        em.clear();
+
+        var rows = matchPadelRepository.findPublicMatchSummaries(
+                MatchVisibilite.PUBLIC,
+                from,
+                to,
+                siteA.getId()
+        );
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getId()).isEqualTo(inScope.getId());
+        assertThat(rows.get(0).getSiteId()).isEqualTo(siteA.getId());
+    }
+
+    @Test
     void countByDateDebutBetween_exclut_les_matchs_annules() {
         Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
         Terrain t = terrainRepository.save(new Terrain("T1", s));

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
@@ -744,6 +744,96 @@ class MatchPadelServiceTest {
     }
 
     @Test
+    void getPublicMatchSummaries_transmet_siteId_null_au_repository() {
+        when(matchRepo.findPublicMatchSummaries(any(), any(), any(), any())).thenReturn(List.of());
+
+        service.getPublicMatchSummaries(
+                LocalDate.of(2030, 1, 1),
+                LocalDate.of(2030, 1, 2),
+                null
+        );
+
+        verify(matchRepo).findPublicMatchSummaries(
+                eq(MatchVisibilite.PUBLIC),
+                any(LocalDateTime.class),
+                any(LocalDateTime.class),
+                isNull()
+        );
+    }
+
+    @Test
+    void getPublicMatchSummaries_transmet_siteId_renseigne_au_repository() {
+        when(matchRepo.findPublicMatchSummaries(any(), any(), any(), any())).thenReturn(List.of());
+
+        service.getPublicMatchSummaries(
+                LocalDate.of(2030, 1, 1),
+                LocalDate.of(2030, 1, 2),
+                5L
+        );
+
+        verify(matchRepo).findPublicMatchSummaries(
+                eq(MatchVisibilite.PUBLIC),
+                any(LocalDateTime.class),
+                any(LocalDateTime.class),
+                eq(5L)
+        );
+    }
+
+    @Test
+    void getPublicMatchSummaries_normalise_from_null_en_debut_de_jour_courant() {
+        when(matchRepo.findPublicMatchSummaries(any(), any(), any(), any())).thenReturn(List.of());
+
+        service.getPublicMatchSummaries(
+                null,
+                LocalDate.of(2030, 1, 2),
+                null
+        );
+
+        verify(matchRepo).findPublicMatchSummaries(
+                eq(MatchVisibilite.PUBLIC),
+                eq(LocalDate.of(2026, 3, 24).atStartOfDay()),
+                any(LocalDateTime.class),
+                isNull()
+        );
+    }
+
+    @Test
+    void getPublicMatchSummaries_normalise_to_en_fin_de_jour() {
+        when(matchRepo.findPublicMatchSummaries(any(), any(), any(), any())).thenReturn(List.of());
+
+        service.getPublicMatchSummaries(
+                LocalDate.of(2030, 1, 1),
+                LocalDate.of(2030, 1, 2),
+                null
+        );
+
+        verify(matchRepo).findPublicMatchSummaries(
+                eq(MatchVisibilite.PUBLIC),
+                eq(LocalDate.of(2030, 1, 1).atStartOfDay()),
+                eq(LocalDate.of(2030, 1, 2).atTime(LocalTime.MAX)),
+                isNull()
+        );
+    }
+
+    @Test
+    void getPublicMatchSummaries_conserve_to_null() {
+        when(matchRepo.findPublicMatchSummaries(any(), any(), any(), any())).thenReturn(List.of());
+
+        service.getPublicMatchSummaries(
+                LocalDate.of(2030, 1, 1),
+                null,
+                null
+        );
+
+        verify(matchRepo).findPublicMatchSummaries(
+                eq(MatchVisibilite.PUBLIC),
+                eq(LocalDate.of(2030, 1, 1).atStartOfDay()),
+                isNull(),
+                isNull()
+        );
+    }
+
+    @Test
     void getMatchDetailDto_public_sansMatricule_ok() {
         MatchPadel match = mock(MatchPadel.class);
         when(match.getId()).thenReturn(1L);


### PR DESCRIPTION
Issue analysée sans modification du code métier.

Conclusion :
- pas de bug concret reproduit sur la requête actuelle ;
- le comportement nullable existant a été conservé ;
- couverture de tests renforcée sur :
  - filtre siteId,
  - filtre from seul,
  - filtre to seul,
  - borne exacte sur to,
  - normalisation service de from/to.

L’issue est considérée comme traitée par sécurisation via les tests.