### PR TITLE
feat(auth): implémentation du socle d’authentification utilisateur (#83)

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
@@ -1,62 +1,25 @@
 package be.ephec.padel.backend.config;
 
-import jakarta.annotation.PostConstruct;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.ObjectProvider;
 
+import be.ephec.padel.backend.security.PersistentUserDetailsService;
+import be.ephec.padel.backend.repository.UserRepository;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
-
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.http.HttpMethod;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Configuration
 public class SecurityConfig {
-
-    @Value("${app.security.admin.global.username:adminGlobal}")
-    private String adminGlobalUsername;
-
-    // Pas de mot de passe par défaut (doit venir d'une env var / secret)
-    @Value("${app.security.admin.global.password:}")
-    private String adminGlobalPassword;
-
-    /**
-     * Admins site sous forme:
-     *   app.security.admin.site.users=adminSite1:1,adminSite2:2
-     * Le ":siteId" est utilisé ailleurs (périmètre). Ici on ne garde que le username.
-     */
-    @Value("${app.security.admin.site.users:adminSite1:1,adminSite2:2}")
-    private String adminSiteUsers;
-
-    // Pas de mot de passe par défaut (doit venir d'une env var / secret)
-    @Value("${app.security.admin.site.password:}")
-    private String adminSitePassword;
-
-    @PostConstruct
-    void validateSecrets() {
-        if (adminGlobalPassword == null || adminGlobalPassword.isBlank()) {
-            throw new IllegalStateException(
-                    "Missing secret: app.security.admin.global.password (env: APP_SECURITY_ADMIN_GLOBAL_PASSWORD)"
-            );
-        }
-        if (adminSitePassword == null || adminSitePassword.isBlank()) {
-            throw new IllegalStateException(
-                    "Missing secret: app.security.admin.site.password (env: APP_SECURITY_ADMIN_SITE_PASSWORD)"
-            );
-        }
-    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -67,6 +30,9 @@ public class SecurityConfig {
 
                         // Swagger / OpenAPI
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
+
+                        // Login
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
 
                         // ===== ADMIN =====
 
@@ -107,38 +73,23 @@ public class SecurityConfig {
     }
 
     @Bean
-    public UserDetailsService users(PasswordEncoder encoder) {
-        List<org.springframework.security.core.userdetails.UserDetails> users = new ArrayList<>();
-
-        // Admin global
-        users.add(User.builder()
-                .username(adminGlobalUsername)
-                .password(encoder.encode(adminGlobalPassword))
-                .roles("ADMIN_GLOBAL")
-                .build());
-
-        // Admins site (on ignore le :siteId ici)
-        for (String entry : adminSiteUsers.split(",")) {
-            String trimmed = entry.trim();
-            if (trimmed.isEmpty()) continue;
-
-            String[] parts = trimmed.split(":");
-            String username = parts[0].trim();
-
-            if (username.isEmpty()) continue;
-
-            users.add(User.builder()
-                    .username(username)
-                    .password(encoder.encode(adminSitePassword))
-                    .roles("ADMIN_SITE")
-                    .build());
+    public UserDetailsService userDetailsService(ObjectProvider<UserRepository> provider) {
+        UserRepository repository = provider.getIfAvailable();
+        if (repository != null) {
+            return new PersistentUserDetailsService(repository);
         }
-
-        return new InMemoryUserDetailsManager(users);
+        return username -> {
+            throw new UsernameNotFoundException("UserDetailsService unavailable in this context");
+        };
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AuthController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AuthController.java
@@ -1,0 +1,24 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.request.LoginRequest;
+import be.ephec.padel.backend.dto.response.LoginResponse;
+import be.ephec.padel.backend.service.AuthenticationService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthenticationService authenticationService;
+
+    public AuthController(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authenticationService.login(request));
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/LoginRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/LoginRequest.java
@@ -1,0 +1,28 @@
+package be.ephec.padel.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/LoginResponse.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/LoginResponse.java
@@ -1,0 +1,31 @@
+package be.ephec.padel.backend.dto.response;
+
+public class LoginResponse {
+
+    private String token;
+    private String type;
+
+    public LoginResponse() {
+    }
+
+    public LoginResponse(String token, String type) {
+        this.token = token;
+        this.type = type;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Joueur.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Joueur.java
@@ -2,6 +2,8 @@ package be.ephec.padel.backend.model.entities;
 
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import jakarta.persistence.*;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GenerationTime;
 
 import java.time.LocalDateTime;
 import java.math.BigDecimal;
@@ -11,6 +13,13 @@ import java.util.List;
 @Entity
 @Table(name = "joueur")
 public class Joueur {
+
+    // `matricule` remains the JPA identifier and business key.
+    // `id` is a separate technical database identifier introduced for security-side relations,
+    // especially the optional `User -> Joueur` link.
+    @Generated(GenerationTime.INSERT)
+    @Column(name = "id", nullable = false, unique = true, insertable = false, updatable = false)
+    private Long id;
 
     @Id
     @Column(length = 10)
@@ -59,6 +68,10 @@ public class Joueur {
 
     public String getMatricule() {
         return matricule;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getNom() {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/User.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/User.java
@@ -1,0 +1,88 @@
+package be.ephec.padel.backend.model.entities;
+
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import jakarta.persistence.*;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "app_user")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String login;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(nullable = false)
+    private boolean active = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "joueur_id", referencedColumnName = "id")
+    private Joueur joueur;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "app_user_role", joinColumns = @JoinColumn(name = "user_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 50)
+    private Set<SecurityRole> roles = new LinkedHashSet<>();
+
+    public User() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public Joueur getJoueur() {
+        return joueur;
+    }
+
+    public void setJoueur(Joueur joueur) {
+        this.joueur = joueur;
+    }
+
+    public Set<SecurityRole> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<SecurityRole> roles) {
+        this.roles = (roles == null) ? new LinkedHashSet<>() : new LinkedHashSet<>(roles);
+    }
+
+    public void addRole(SecurityRole role) {
+        if (role != null) {
+            roles.add(role);
+        }
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/SecurityRole.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/SecurityRole.java
@@ -1,0 +1,7 @@
+package be.ephec.padel.backend.model.enums;
+
+public enum SecurityRole {
+    ROLE_JOUEUR,
+    ROLE_ADMIN_SITE,
+    ROLE_ADMIN_GLOBAL
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/UserRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package be.ephec.padel.backend.repository;
+
+import be.ephec.padel.backend.model.entities.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByLogin(String login);
+
+    boolean existsByLogin(String login);
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/security/PersistentUserDetailsService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/security/PersistentUserDetailsService.java
@@ -1,0 +1,35 @@
+package be.ephec.padel.backend.security;
+
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+public class PersistentUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public PersistentUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByLogin(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        String[] authorities = user.getRoles().stream()
+                .map(Enum::name)
+                .toArray(String[]::new);
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getLogin())
+                .password(user.getPasswordHash())
+                .authorities(authorities)
+                .disabled(!user.isActive())
+                .build();
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AuthenticationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AuthenticationService.java
@@ -1,0 +1,28 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.dto.request.LoginRequest;
+import be.ephec.padel.backend.dto.response.LoginResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthenticationService {
+
+    private final AuthenticationManager authenticationManager;
+
+    public AuthenticationService(AuthenticationManager authenticationManager) {
+        this.authenticationManager = authenticationManager;
+    }
+
+    public LoginResponse login(LoginRequest request) {
+        authenticationManager.authenticate(
+                UsernamePasswordAuthenticationToken.unauthenticated(
+                        request.getUsername(),
+                        request.getPassword()
+                )
+        );
+
+        return new LoginResponse(null, "Bearer");
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/UserBootstrapService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/UserBootstrapService.java
@@ -1,0 +1,90 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserBootstrapService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${app.security.admin.global.username:adminGlobal}")
+    private String adminGlobalUsername;
+
+    @Value("${app.security.admin.global.password:}")
+    private String adminGlobalPassword;
+
+    @Value("${app.security.admin.site.users:}")
+    private String adminSiteUsers;
+
+    @Value("${app.security.admin.site.password:}")
+    private String adminSitePassword;
+
+    public UserBootstrapService(UserRepository userRepository,
+                                PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @PostConstruct
+    public void bootstrapAdmins() {
+        validateBootstrapConfiguration();
+
+        upsertAdmin(adminGlobalUsername, adminGlobalPassword, SecurityRole.ROLE_ADMIN_GLOBAL);
+
+        if (adminSiteUsers == null || adminSiteUsers.isBlank()) {
+            return;
+        }
+
+        for (String entry : adminSiteUsers.split(",")) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+
+            String[] parts = trimmed.split(":");
+            String username = parts[0].trim();
+            if (username.isEmpty()) {
+                continue;
+            }
+
+            upsertAdmin(username, adminSitePassword, SecurityRole.ROLE_ADMIN_SITE);
+        }
+    }
+
+    private void validateBootstrapConfiguration() {
+        if (adminGlobalUsername == null || adminGlobalUsername.isBlank()) {
+            throw new IllegalStateException(
+                    "Missing value: app.security.admin.global.username"
+            );
+        }
+
+        if (adminGlobalPassword == null || adminGlobalPassword.isBlank()) {
+            throw new IllegalStateException(
+                    "Missing secret: app.security.admin.global.password (env: APP_SECURITY_ADMIN_GLOBAL_PASSWORD)"
+            );
+        }
+
+        if (adminSiteUsers != null && !adminSiteUsers.isBlank()
+                && (adminSitePassword == null || adminSitePassword.isBlank())) {
+            throw new IllegalStateException(
+                    "Missing secret: app.security.admin.site.password (env: APP_SECURITY_ADMIN_SITE_PASSWORD)"
+            );
+        }
+    }
+
+    private void upsertAdmin(String login, String rawPassword, SecurityRole role) {
+        User user = userRepository.findByLogin(login).orElseGet(User::new);
+        user.setLogin(login);
+        user.setPasswordHash(passwordEncoder.encode(rawPassword));
+        user.setActive(true);
+        user.addRole(role);
+        userRepository.save(user);
+    }
+}

--- a/backend/backend/src/main/resources/db/changelog/007-auth-user.yaml
+++ b/backend/backend/src/main/resources/db/changelog/007-auth-user.yaml
@@ -1,0 +1,96 @@
+databaseChangeLog:
+  - changeSet:
+      id: 007-1-add-joueur-technical-id
+      author: codex
+      changes:
+        - addColumn:
+            tableName: joueur
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+        - addNotNullConstraint:
+            tableName: joueur
+            columnName: id
+            columnDataType: bigint
+        - addUniqueConstraint:
+            tableName: joueur
+            columnNames: id
+            constraintName: uk_joueur_id
+
+  - changeSet:
+      id: 007-2-create-app-user
+      author: codex
+      changes:
+        - createTable:
+            tableName: app_user
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_app_user
+                    nullable: false
+              - column:
+                  name: login
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: password_hash
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: active
+                  type: bit
+                  constraints:
+                    nullable: false
+              - column:
+                  name: joueur_id
+                  type: bigint
+        - addUniqueConstraint:
+            tableName: app_user
+            columnNames: login
+            constraintName: uk_app_user_login
+        - addForeignKeyConstraint:
+            baseTableName: app_user
+            baseColumnNames: joueur_id
+            referencedTableName: joueur
+            referencedColumnNames: id
+            constraintName: fk_app_user_joueur_id
+            onDelete: NO ACTION
+            onUpdate: NO ACTION
+
+  - changeSet:
+      id: 007-3-create-app-user-role
+      author: codex
+      changes:
+        - createTable:
+            tableName: app_user_role
+            columns:
+              - column:
+                  name: user_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: role
+                  type: varchar(50)
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: app_user_role
+            columnNames: user_id, role
+            constraintName: pk_app_user_role
+        - addForeignKeyConstraint:
+            baseTableName: app_user_role
+            baseColumnNames: user_id
+            referencedTableName: app_user
+            referencedColumnNames: id
+            constraintName: fk_app_user_role_user_id
+            onDelete: CASCADE
+            onUpdate: NO ACTION

--- a/backend/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -11,4 +11,6 @@ databaseChangeLog:
       file: db/changelog/005-match-statut.yaml
   - include:
       file: db/changelog/006-type-paiement.yaml
+  - include:
+      file: db/changelog/007-auth-user.yaml
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AuthenticationServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AuthenticationServiceTest.java
@@ -1,0 +1,45 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.dto.request.LoginRequest;
+import be.ephec.padel.backend.dto.response.LoginResponse;
+import be.ephec.padel.backend.service.AuthenticationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationServiceTest {
+
+    @Mock
+    AuthenticationManager authenticationManager;
+
+    @InjectMocks
+    AuthenticationService authenticationService;
+
+    @Test
+    void login_utilise_authenticationManager_et_renvoie_contrat_compatible_jwt() {
+        LoginRequest request = new LoginRequest();
+        request.setUsername("adminGlobal");
+        request.setPassword("test123");
+
+        LoginResponse response = authenticationService.login(request);
+
+        ArgumentCaptor<UsernamePasswordAuthenticationToken> captor =
+                ArgumentCaptor.forClass(UsernamePasswordAuthenticationToken.class);
+        verify(authenticationManager).authenticate(captor.capture());
+
+        UsernamePasswordAuthenticationToken token = captor.getValue();
+        assertThat(token.getPrincipal()).isEqualTo("adminGlobal");
+        assertThat(token.getCredentials()).isEqualTo("test123");
+        assertThat(response.getToken()).isNull();
+        assertThat(response.getType()).isEqualTo("Bearer");
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/PersistentUserDetailsServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/PersistentUserDetailsServiceTest.java
@@ -1,0 +1,59 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.repository.UserRepository;
+import be.ephec.padel.backend.security.PersistentUserDetailsService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PersistentUserDetailsServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    PersistentUserDetailsService persistentUserDetailsService;
+
+    @Test
+    void loadUserByUsername_mappe_login_hash_roles_et_active() {
+        User user = new User();
+        user.setLogin("player1");
+        user.setPasswordHash("hash");
+        user.setActive(true);
+        user.setRoles(Set.of(SecurityRole.ROLE_JOUEUR, SecurityRole.ROLE_ADMIN_SITE));
+
+        when(userRepository.findByLogin("player1")).thenReturn(Optional.of(user));
+
+        UserDetails details = persistentUserDetailsService.loadUserByUsername("player1");
+
+        assertThat(details.getUsername()).isEqualTo("player1");
+        assertThat(details.getPassword()).isEqualTo("hash");
+        assertThat(details.isEnabled()).isTrue();
+        assertThat(details.getAuthorities())
+                .extracting("authority")
+                .containsExactlyInAnyOrder("ROLE_JOUEUR", "ROLE_ADMIN_SITE");
+    }
+
+    @Test
+    void loadUserByUsername_404_logique_si_login_inconnu() {
+        when(userRepository.findByLogin("ghost")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> persistentUserDetailsService.loadUserByUsername("ghost"))
+                .isInstanceOf(UsernameNotFoundException.class)
+                .hasMessage("User not found");
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/UserBootstrapServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/UserBootstrapServiceTest.java
@@ -1,0 +1,67 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.repository.UserRepository;
+import be.ephec.padel.backend.service.UserBootstrapService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserBootstrapServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    UserBootstrapService userBootstrapService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(userBootstrapService, "adminGlobalUsername", "adminGlobal");
+        ReflectionTestUtils.setField(userBootstrapService, "adminGlobalPassword", "globalRaw");
+        ReflectionTestUtils.setField(userBootstrapService, "adminSiteUsers", "adminSite1:1,adminSite2:2");
+        ReflectionTestUtils.setField(userBootstrapService, "adminSitePassword", "siteRaw");
+    }
+
+    @Test
+    void bootstrap_cree_les_admins_attendus() {
+        when(userRepository.findByLogin(any())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(eq("globalRaw"))).thenReturn("hash-global");
+        when(passwordEncoder.encode(eq("siteRaw"))).thenReturn("hash-site");
+
+        userBootstrapService.bootstrapAdmins();
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository, org.mockito.Mockito.times(3)).save(captor.capture());
+
+        assertThat(captor.getAllValues())
+                .extracting(User::getLogin)
+                .containsExactly("adminGlobal", "adminSite1", "adminSite2");
+
+        assertThat(captor.getAllValues().get(0).getRoles())
+                .containsExactly(SecurityRole.ROLE_ADMIN_GLOBAL);
+        assertThat(captor.getAllValues().get(1).getRoles())
+                .containsExactly(SecurityRole.ROLE_ADMIN_SITE);
+        assertThat(captor.getAllValues().get(2).getRoles())
+                .containsExactly(SecurityRole.ROLE_ADMIN_SITE);
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AuthControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AuthControllerTest.java
@@ -1,0 +1,78 @@
+package be.ephec.padel.backend.web.controller;
+
+import be.ephec.padel.backend.config.SecurityConfig;
+import be.ephec.padel.backend.controller.AuthController;
+import be.ephec.padel.backend.dto.response.LoginResponse;
+import be.ephec.padel.backend.error.ApiExceptionHandler;
+import be.ephec.padel.backend.service.AuthenticationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class)
+@Import({SecurityConfig.class, ApiExceptionHandler.class})
+class AuthControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockitoBean
+    AuthenticationService authenticationService;
+
+    @Test
+    void login_ok_200_et_json() throws Exception {
+        when(authenticationService.login(any()))
+                .thenReturn(new LoginResponse(null, "Bearer"));
+
+        mvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "adminGlobal",
+                                  "password": "test123"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.token").value(nullValue()))
+                .andExpect(jsonPath("$.type").value("Bearer"));
+    }
+
+    @Test
+    void login_validation_400_si_body_invalide() throws Exception {
+        mvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void login_401_si_credentials_invalides() throws Exception {
+        when(authenticationService.login(any()))
+                .thenThrow(new BadCredentialsException("Bad credentials"));
+
+        mvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "adminGlobal",
+                                  "password": "wrong"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Authentication required"));
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminSiteControllerSecurityTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminSiteControllerSecurityTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -41,16 +42,16 @@ class AdminSiteControllerSecurityTest {
     }
 
     @Test
+    @WithMockUser(username = "adminSite1", roles = {"ADMIN_SITE"})
     void adminSite_auth_200_mapping_ok() throws Exception {
-        mockMvc.perform(get("/api/v1/admin/sites/1/joueurs")
-                        .with(org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic("adminSite1", "test123")))
+        mockMvc.perform(get("/api/v1/admin/sites/1/joueurs"))
                 .andExpect(status().isOk());
     }
 
     @Test
+    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
     void adminGlobal_auth_200() throws Exception {
-        mockMvc.perform(get("/api/v1/admin/sites/2/joueurs")
-                        .with(org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic("adminGlobal", "test123")))
+        mockMvc.perform(get("/api/v1/admin/sites/2/joueurs"))
                 .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
- Ajout du modèle persistant User avec rôles (ROLE_JOUEUR, ROLE_ADMIN_SITE, ROLE_ADMIN_GLOBAL)
- Ajout du lien optionnel User -> Joueur via joueur.id (id technique)
- Introduction d’un identifiant technique sur Joueur sans casser le matricule existant
- Mise en place du UserDetailsService basé sur la base de données
- Ajout de l’AuthenticationService utilisant AuthenticationManager
- Implémentation du endpoint POST /api/v1/auth/login (réponse JSON compatible JWT)
- Ajout du bootstrap des comptes admin au démarrage
- Migration de la configuration sécurité (suppression in-memory, conservation httpBasic temporaire)
- Ajout des entités, repository, services et DTO nécessaires
- Ajout des tests unitaires et web liés à l’authentification
- Ajout du changelog Liquibase pour User, rôles et joueur.id