### PR TITLE
feat(security): implémentation de l’authentification JWT et sécurisation API

### DIFF
--- a/backend/backend/pom.xml
+++ b/backend/backend/pom.xml
@@ -99,6 +99,26 @@
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
 

--- a/backend/backend/src/main/java/be/ephec/padel/backend/config/OpenApiConfig.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/config/OpenApiConfig.java
@@ -11,14 +11,15 @@ public class OpenApiConfig {
 
     @Bean
     public OpenAPI openAPI() {
-        final String schemeName = "basicAuth";
+        final String schemeName = "bearerAuth";
 
         return new OpenAPI()
                 .components(new Components().addSecuritySchemes(
                         schemeName,
                         new SecurityScheme()
                                 .type(SecurityScheme.Type.HTTP)
-                                .scheme("basic")
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
                 ));
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
@@ -1,75 +1,74 @@
 package be.ephec.padel.backend.config;
 
+import be.ephec.padel.backend.repository.UserRepository;
+import be.ephec.padel.backend.security.JwtAuthenticationFilter;
+import be.ephec.padel.backend.security.JwtService;
+import be.ephec.padel.backend.security.PersistentUserDetailsService;
+import be.ephec.padel.backend.security.RestAccessDeniedHandler;
+import be.ephec.padel.backend.security.RestAuthenticationEntryPoint;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.beans.factory.ObjectProvider;
-
-import be.ephec.padel.backend.security.PersistentUserDetailsService;
-import be.ephec.padel.backend.repository.UserRepository;
-import org.springframework.security.config.Customizer;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.http.HttpMethod;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
 
+    private final boolean swaggerPermitAll;
+
+    public SecurityConfig(@Value("${app.security.swagger.permit-all:true}") boolean swaggerPermitAll) {
+        this.swaggerPermitAll = swaggerPermitAll;
+    }
+
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           JwtAuthenticationFilter jwtAuthenticationFilter,
+                                           AuthenticationEntryPoint authenticationEntryPoint,
+                                           AccessDeniedHandler accessDeniedHandler) throws Exception {
+        http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-
-                        // Swagger / OpenAPI
-                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
-
-                        // Login
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
-
-                        // ===== ADMIN =====
-
-                        // Stats globales : ADMIN_GLOBAL uniquement
-                        .requestMatchers("/api/v1/admin/stats/**").hasRole("ADMIN_GLOBAL")
-
-                        // Endpoints admin par site : ADMIN_GLOBAL ou ADMIN_SITE
-                        .requestMatchers("/api/v1/admin/sites/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")
-
-                        // Autres endpoints admin : ADMIN_GLOBAL ou ADMIN_SITE
-                        .requestMatchers("/api/v1/admin/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")
-
-                        // ===== API publique mais avec exceptions sensibles (Issue 62) =====
-
-                        // Joueurs : listing + création réservés à l'admin global
-                        .requestMatchers(HttpMethod.GET, "/api/v1/joueurs").hasRole("ADMIN_GLOBAL")
-                        .requestMatchers(HttpMethod.POST, "/api/v1/joueurs").hasRole("ADMIN_GLOBAL")
-
-                        // Sites : création + update horaires réservés à l'admin global
-                        .requestMatchers(HttpMethod.POST, "/api/v1/sites").hasRole("ADMIN_GLOBAL")
-                        .requestMatchers(HttpMethod.PUT, "/api/v1/sites/*/horaires").hasRole("ADMIN_GLOBAL")
-
-                        // Terrains : création réservée à l'admin global
-                        .requestMatchers(HttpMethod.POST, "/api/v1/terrains").hasRole("ADMIN_GLOBAL")
-
-                        // Fermetures globales : création + suppression réservées à l'admin global
-                        .requestMatchers(HttpMethod.POST, "/api/v1/fermetures-globales").hasRole("ADMIN_GLOBAL")
-                        .requestMatchers(HttpMethod.DELETE, "/api/v1/fermetures-globales/*").hasRole("ADMIN_GLOBAL")
-
-                        // Tout le reste sous /api/v1 reste public (pour l’instant)
-                        .requestMatchers("/api/v1/**").permitAll()
-
-                        // Fallback
-                        .anyRequest().authenticated()
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
                 )
-                .httpBasic(Customizer.withDefaults())
-                .build();
+                .authorizeHttpRequests(auth -> {
+                    if (swaggerPermitAll) {
+                        auth.requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll();
+                    }
+
+                    auth
+                            .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
+                            .requestMatchers("/api/v1/admin/stats/**").hasRole("ADMIN_GLOBAL")
+                            .requestMatchers("/api/v1/admin/sites/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")
+                            .requestMatchers("/api/v1/admin/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")
+                            .requestMatchers(HttpMethod.GET, "/api/v1/joueurs").hasRole("ADMIN_GLOBAL")
+                            .requestMatchers(HttpMethod.POST, "/api/v1/joueurs").hasRole("ADMIN_GLOBAL")
+                            .requestMatchers(HttpMethod.POST, "/api/v1/sites").hasRole("ADMIN_GLOBAL")
+                            .requestMatchers(HttpMethod.PUT, "/api/v1/sites/*/horaires").hasRole("ADMIN_GLOBAL")
+                            .requestMatchers(HttpMethod.POST, "/api/v1/terrains").hasRole("ADMIN_GLOBAL")
+                            .requestMatchers(HttpMethod.POST, "/api/v1/fermetures-globales").hasRole("ADMIN_GLOBAL")
+                            .requestMatchers(HttpMethod.DELETE, "/api/v1/fermetures-globales/*").hasRole("ADMIN_GLOBAL")
+                            .requestMatchers("/api/v1/**").authenticated()
+                            .anyRequest().authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
     }
 
     @Bean
@@ -91,5 +90,28 @@ public class SecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtService jwtService(
+            @Value("${app.security.jwt.secret:cle-secrete-jwt-local-dev-ephec-padel-2026-123456789}") String secret,
+            @Value("${app.security.jwt.expiration-ms:3600000}") long expirationMs) {
+        return new JwtService(secret, expirationMs);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtService jwtService,
+                                                           UserDetailsService userDetailsService) {
+        return new JwtAuthenticationFilter(jwtService, userDetailsService);
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint(ObjectMapper objectMapper) {
+        return new RestAuthenticationEntryPoint(objectMapper);
+    }
+
+    @Bean
+    public AccessDeniedHandler accessDeniedHandler(ObjectMapper objectMapper) {
+        return new RestAccessDeniedHandler(objectMapper);
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminGlobalController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminGlobalController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.Map;
 
-@SecurityRequirement(name = "basicAuth")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/api/v1/admin")
 public class AdminGlobalController {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminSiteController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminSiteController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
-@SecurityRequirement(name = "basicAuth")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/api/v1/admin/sites")
 @Tag(name = "Admin Site")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AuthController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AuthController.java
@@ -3,6 +3,7 @@ package be.ephec.padel.backend.controller;
 import be.ephec.padel.backend.dto.request.LoginRequest;
 import be.ephec.padel.backend.dto.response.LoginResponse;
 import be.ephec.padel.backend.service.AuthenticationService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +18,7 @@ public class AuthController {
         this.authenticationService = authenticationService;
     }
 
+    @SecurityRequirements
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(authenticationService.login(request));

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/FermetureGlobaleController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/FermetureGlobaleController.java
@@ -30,7 +30,7 @@ public class FermetureGlobaleController {
         );
     }
 
-    @SecurityRequirement(name = "basicAuth")
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping
     public ResponseEntity<FermetureGlobaleDto> create(@Valid @RequestBody CreateFermetureGlobaleRequest req) {
         FermetureGlobale created = service.creer(req);
@@ -38,7 +38,7 @@ public class FermetureGlobaleController {
         return ResponseEntity.created(location).body(FermetureGlobaleMapper.toDto(created));
     }
 
-    @SecurityRequirement(name = "basicAuth")
+    @SecurityRequirement(name = "bearerAuth")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         service.supprimer(id);

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/FermetureSiteAdminController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/FermetureSiteAdminController.java
@@ -8,6 +8,7 @@ import be.ephec.padel.backend.dto.response.FermetureSiteDto;
 import be.ephec.padel.backend.mapper.FermetureSiteMapper;
 import be.ephec.padel.backend.model.entities.FermetureSite;
 import be.ephec.padel.backend.service.FermetureSiteService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -17,6 +18,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/admin/sites/{siteId}/fermetures")
+@SecurityRequirement(name = "bearerAuth")
 public class FermetureSiteAdminController {
 
     private final FermetureSiteService fermetureSiteService;

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/HoraireSiteController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/HoraireSiteController.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/admin/sites/{siteId}/horaires")
-@SecurityRequirement(name = "basicAuth")
+@SecurityRequirement(name = "bearerAuth")
 public class HoraireSiteController {
 
     private final HoraireSiteService horaireSiteService;

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/JoueurController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/JoueurController.java
@@ -26,7 +26,7 @@ public class JoueurController {
         this.joueurService = joueurService;
     }
 
-    @SecurityRequirement(name = "basicAuth")
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping
     public ResponseEntity<List<JoueurDto>> list() {
         List<JoueurDto> dtos = joueurService.lister().stream()
@@ -57,7 +57,7 @@ public class JoueurController {
         return ResponseEntity.ok(joueurService.getOrganizedMatches(matricule));
     }
 
-    @SecurityRequirement(name = "basicAuth")
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping
     public ResponseEntity<JoueurDto> create(@Valid @RequestBody JoueurCreateRequest req) {
         Joueur created = joueurService.creerJoueur(

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.net.URI;
 
 @Tag(name = "Matchs", description = "Gestion des matchs de padel")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/api/v1/matchs")
 public class MatchController {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/PaiementController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/PaiementController.java
@@ -5,6 +5,7 @@ import be.ephec.padel.backend.dto.response.PaiementDto;
 import be.ephec.padel.backend.mapper.PaiementMapper;
 import be.ephec.padel.backend.model.entities.Paiement;
 import be.ephec.padel.backend.service.PaiementService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +14,7 @@ import java.net.URI;
 
 @RestController
 @RequestMapping("/api/v1/participations")
+@SecurityRequirement(name = "bearerAuth")
 public class PaiementController {
 
     private final PaiementService paiementService;

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/ParticipationController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/ParticipationController.java
@@ -7,6 +7,7 @@ import be.ephec.padel.backend.dto.response.ParticipationDto;
 import be.ephec.padel.backend.mapper.ParticipationMapper;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.service.ParticipationService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ import java.net.URI;
 
 @RestController
 @RequestMapping("/api/v1/matchs")
+@SecurityRequirement(name = "bearerAuth")
 public class ParticipationController {
 
     private final ParticipationService participationService;

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/PingController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/PingController.java
@@ -1,11 +1,13 @@
 package be.ephec.padel.backend.controller;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
+@SecurityRequirement(name = "bearerAuth")
 public class PingController {
     @GetMapping("/ping")
     public String ping() { return "ok"; }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/SiteController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/SiteController.java
@@ -37,7 +37,7 @@ public class SiteController {
         return ResponseEntity.ok(SiteMapper.toDto(site));
     }
 
-    @SecurityRequirement(name = "basicAuth")
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping
     public ResponseEntity<SiteDto> create(@Valid @RequestBody CreateSiteRequest req) {
         Site created = siteService.creerSite(

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/TerrainController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/TerrainController.java
@@ -44,7 +44,7 @@ public class TerrainController {
         return ResponseEntity.ok(TerrainMapper.toDto(terrain));
     }
 
-    @SecurityRequirement(name = "basicAuth")
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping
     public ResponseEntity<TerrainDto> create(
             @Valid @RequestBody CreateTerrainRequest req) {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/security/JwtAuthenticationFilter.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/security/JwtAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package be.ephec.padel.backend.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtService jwtService, UserDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader == null || authorizationHeader.isBlank()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!authorizationHeader.startsWith(BEARER_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authorizationHeader.substring(BEARER_PREFIX.length()).trim();
+        if (token.isEmpty()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String username = jwtService.extractUsername(token);
+
+            if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                if (jwtService.isTokenValid(token)) {
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(
+                                    userDetails,
+                                    null,
+                                    userDetails.getAuthorities()
+                            );
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+        } catch (ExpiredJwtException ex) {
+            logger.warn("Token JWT expiré pour la requête {} {}", request.getMethod(), request.getRequestURI());
+        } catch (JwtException | IllegalArgumentException ex) {
+            logger.warn("Token JWT invalide pour la requête {} {}", request.getMethod(), request.getRequestURI());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/security/JwtService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/security/JwtService.java
@@ -1,0 +1,53 @@
+package be.ephec.padel.backend.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+public class JwtService {
+
+    private final SecretKey signingKey;
+    private final long expirationMs;
+
+    public JwtService(String secret, long expirationMs) {
+        this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+                .subject(userDetails.getUsername())
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(signingKey)
+                .compact();
+    }
+
+    public String extractUsername(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+    public boolean isTokenValid(String token) {
+        Claims claims = extractClaims(token);
+        Date expiration = claims.getExpiration();
+        return expiration != null && expiration.after(new Date());
+    }
+
+    private Claims extractClaims(String token) throws JwtException, ExpiredJwtException {
+        return Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/security/RestAccessDeniedHandler.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/security/RestAccessDeniedHandler.java
@@ -1,0 +1,42 @@
+package be.ephec.padel.backend.security;
+
+import be.ephec.padel.backend.dto.response.ApiErrorDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        ApiErrorDto error = new ApiErrorDto(
+                LocalDateTime.now(),
+                HttpStatus.FORBIDDEN.value(),
+                HttpStatus.FORBIDDEN.getReasonPhrase(),
+                "Accès refusé",
+                request.getRequestURI(),
+                null
+        );
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), error);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/security/RestAuthenticationEntryPoint.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package be.ephec.padel.backend.security;
+
+import be.ephec.padel.backend.dto.response.ApiErrorDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+
+        ApiErrorDto error = new ApiErrorDto(
+                LocalDateTime.now(),
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                "Authentification requise",
+                request.getRequestURI(),
+                null
+        );
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), error);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AuthenticationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AuthenticationService.java
@@ -2,7 +2,10 @@ package be.ephec.padel.backend.service;
 
 import be.ephec.padel.backend.dto.request.LoginRequest;
 import be.ephec.padel.backend.dto.response.LoginResponse;
+import be.ephec.padel.backend.security.JwtService;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Service;
 
@@ -10,19 +13,24 @@ import org.springframework.stereotype.Service;
 public class AuthenticationService {
 
     private final AuthenticationManager authenticationManager;
+    private final JwtService jwtService;
 
-    public AuthenticationService(AuthenticationManager authenticationManager) {
+    public AuthenticationService(AuthenticationManager authenticationManager,
+                                 JwtService jwtService) {
         this.authenticationManager = authenticationManager;
+        this.jwtService = jwtService;
     }
 
     public LoginResponse login(LoginRequest request) {
-        authenticationManager.authenticate(
+        Authentication authentication = authenticationManager.authenticate(
                 UsernamePasswordAuthenticationToken.unauthenticated(
                         request.getUsername(),
                         request.getPassword()
                 )
         );
 
-        return new LoginResponse(null, "Bearer");
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        String token = jwtService.generateToken(userDetails);
+        return new LoginResponse(token, "Bearer");
     }
 }

--- a/backend/backend/src/main/resources/application-docker.properties
+++ b/backend/backend/src/main/resources/application-docker.properties
@@ -10,3 +10,6 @@ app.security.admin.global.username=${ADMIN_GLOBAL_USERNAME}
 app.security.admin.global.password=${ADMIN_GLOBAL_PASSWORD}
 app.security.admin.site.password=${ADMIN_SITE_PASSWORD}
 app.security.admin.site.users=${ADMIN_SITE_USERS}
+app.security.jwt.secret=${JWT_SECRET}
+app.security.jwt.expiration-ms=${JWT_EXPIRATION_MS:3600000}
+app.security.swagger.permit-all=${SWAGGER_PERMIT_ALL:false}

--- a/backend/backend/src/main/resources/application.properties
+++ b/backend/backend/src/main/resources/application.properties
@@ -15,4 +15,7 @@ app.security.admin.global.username=${ADMIN_GLOBAL_USERNAME}
 app.security.admin.global.password=${ADMIN_GLOBAL_PASSWORD}
 app.security.admin.site.password=${ADMIN_SITE_PASSWORD}
 app.security.admin.site.users=${ADMIN_SITE_USERS}
+app.security.jwt.secret=${JWT_SECRET:cle-secrete-jwt-local-dev-ephec-padel-2026-123456789}
+app.security.jwt.expiration-ms=${JWT_EXPIRATION_MS:3600000}
+app.security.swagger.permit-all=${SWAGGER_PERMIT_ALL:true}
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/security/JwtServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/security/JwtServiceTest.java
@@ -1,0 +1,56 @@
+package be.ephec.padel.backend.unit.security;
+
+import be.ephec.padel.backend.security.JwtService;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtServiceTest {
+
+    private static final String SECRET = "cle-secrete-de-test-jwt-ephec-padel-2026-123456789";
+
+    @Test
+    void genere_un_token_valide_et_extrait_le_login() {
+        JwtService jwtService = new JwtService(SECRET, 60_000);
+        User user = new User("adminGlobal", "hash",
+                java.util.List.of(new SimpleGrantedAuthority("ROLE_ADMIN_GLOBAL")));
+
+        String token = jwtService.generateToken(user);
+
+        assertThat(token).isNotBlank();
+        assertThat(jwtService.extractUsername(token)).isEqualTo("adminGlobal");
+        assertThat(jwtService.isTokenValid(token)).isTrue();
+    }
+
+    @Test
+    void token_expire_declenche_une_exception() throws InterruptedException {
+        JwtService jwtService = new JwtService(SECRET, 5);
+        User user = new User("adminGlobal", "hash", java.util.List.of());
+
+        String token = jwtService.generateToken(user);
+        Thread.sleep(20);
+
+        assertThatThrownBy(() -> jwtService.extractUsername(token))
+                .isInstanceOf(ExpiredJwtException.class);
+    }
+
+    @Test
+    void token_signe_avec_un_autre_secret_est_invalide() {
+        JwtService jwtService = new JwtService(SECRET, 60_000);
+        JwtService otherJwtService = new JwtService(
+                "autre-cle-secrete-de-test-jwt-ephec-padel-2026-987654321",
+                60_000
+        );
+        User user = new User("adminGlobal", "hash", java.util.List.of());
+
+        String token = jwtService.generateToken(user);
+
+        assertThatThrownBy(() -> otherJwtService.extractUsername(token))
+                .isInstanceOf(JwtException.class);
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AuthenticationServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AuthenticationServiceTest.java
@@ -2,6 +2,7 @@ package be.ephec.padel.backend.unit.service;
 
 import be.ephec.padel.backend.dto.request.LoginRequest;
 import be.ephec.padel.backend.dto.response.LoginResponse;
+import be.ephec.padel.backend.security.JwtService;
 import be.ephec.padel.backend.service.AuthenticationService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,8 +12,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -20,6 +26,9 @@ class AuthenticationServiceTest {
 
     @Mock
     AuthenticationManager authenticationManager;
+
+    @Mock
+    JwtService jwtService;
 
     @InjectMocks
     AuthenticationService authenticationService;
@@ -30,6 +39,19 @@ class AuthenticationServiceTest {
         request.setUsername("adminGlobal");
         request.setPassword("test123");
 
+        User principal = new User(
+                "adminGlobal",
+                "hash",
+                java.util.List.of(new SimpleGrantedAuthority("ROLE_ADMIN_GLOBAL"))
+        );
+        Authentication authentication = UsernamePasswordAuthenticationToken.authenticated(
+                principal,
+                null,
+                principal.getAuthorities()
+        );
+        when(authenticationManager.authenticate(any())).thenReturn(authentication);
+        when(jwtService.generateToken(principal)).thenReturn("jwt-test");
+
         LoginResponse response = authenticationService.login(request);
 
         ArgumentCaptor<UsernamePasswordAuthenticationToken> captor =
@@ -39,7 +61,7 @@ class AuthenticationServiceTest {
         UsernamePasswordAuthenticationToken token = captor.getValue();
         assertThat(token.getPrincipal()).isEqualTo("adminGlobal");
         assertThat(token.getCredentials()).isEqualTo("test123");
-        assertThat(response.getToken()).isNull();
+        assertThat(response.getToken()).isEqualTo("jwt-test");
         assertThat(response.getType()).isEqualTo("Bearer");
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AuthControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AuthControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -35,7 +34,7 @@ class AuthControllerTest {
     @Test
     void login_ok_200_et_json() throws Exception {
         when(authenticationService.login(any()))
-                .thenReturn(new LoginResponse(null, "Bearer"));
+                .thenReturn(new LoginResponse("jwt-test", "Bearer"));
 
         mvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -47,7 +46,7 @@ class AuthControllerTest {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.token").value(nullValue()))
+                .andExpect(jsonPath("$.token").value("jwt-test"))
                 .andExpect(jsonPath("$.type").value("Bearer"));
     }
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/FermetureGlobaleControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/FermetureGlobaleControllerTest.java
@@ -45,6 +45,7 @@ class FermetureGlobaleControllerTest extends SqlServerTestContainerConfig {
 
     // GET reste public
     @Test
+    @WithMockUser(username = "joueur1", roles = "JOUEUR")
     void get_list_public_ok_200() throws Exception {
         mvc.perform(get("/api/v1/fermetures-globales"))
                 .andExpect(status().isOk());

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/JoueurControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/JoueurControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -32,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = JoueurController.class)
 @Import({SecurityConfig.class, ApiExceptionHandler.class})
+@WithMockUser(username = "joueur1", roles = "JOUEUR")
 class JoueurControllerTest {
 
     @Autowired
@@ -48,12 +50,14 @@ class JoueurControllerTest {
     // ===== Issue 62 : public doit être refusé sur listing / création =====
 
     @Test
+    @WithAnonymousUser
     void public_ne_peut_pas_lister_401() throws Exception {
         mvc.perform(get("/api/v1/joueurs"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
+    @WithAnonymousUser
     void public_ne_peut_pas_creer_401() throws Exception {
         mvc.perform(post("/api/v1/joueurs")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -44,6 +45,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = MatchController.class)
 @Import({SecurityConfig.class, ApiExceptionHandler.class})
+@WithMockUser(username = "joueur1", roles = "JOUEUR")
 class MatchControllerTest {
 
     @Autowired

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/PaiementControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/PaiementControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = PaiementController.class)
 @Import({SecurityConfig.class, ApiExceptionHandler.class})
+@WithMockUser(username = "joueur1", roles = "JOUEUR")
 class PaiementControllerTest {
 
     @Autowired

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/ParticipationControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/ParticipationControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = ParticipationController.class)
 @Import({SecurityConfig.class, ApiExceptionHandler.class})
+@WithMockUser(username = "joueur1", roles = "JOUEUR")
 class ParticipationControllerTest {
 
     @Autowired

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/SiteControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/SiteControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = SiteController.class)
 @Import({SecurityConfig.class, ApiExceptionHandler.class})
+@WithMockUser(username = "joueur1", roles = "JOUEUR")
 class SiteControllerTest {
 
     @Autowired
@@ -89,6 +91,7 @@ class SiteControllerTest {
     }
 
     @Test
+    @WithAnonymousUser
     void public_ne_peut_pas_creer_site_401() throws Exception {
         mvc.perform(post("/api/v1/sites")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/TerrainControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/TerrainControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = TerrainController.class)
 @Import({SecurityConfig.class, ApiExceptionHandler.class})
+@WithMockUser(username = "joueur1", roles = "JOUEUR")
 class TerrainControllerTest {
 
     @Autowired
@@ -102,6 +104,7 @@ class TerrainControllerTest {
     // ===== Issue 62 : public refusé sur WRITE =====
 
     @Test
+    @WithAnonymousUser
     void public_ne_peut_pas_creer_terrain_401() throws Exception {
         mvc.perform(post("/api/v1/terrains")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/security/JwtAuthenticationFilterTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,112 @@
+package be.ephec.padel.backend.web.security;
+
+import be.ephec.padel.backend.config.SecurityConfig;
+import be.ephec.padel.backend.controller.AdminGlobalController;
+import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.repository.UserRepository;
+import be.ephec.padel.backend.security.JwtService;
+import be.ephec.padel.backend.service.AdminStatsService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AdminGlobalController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = {
+        "app.security.swagger.permit-all=true",
+        "app.security.jwt.secret=cle-secrete-de-test-jwt-ephec-padel-2026-123456789",
+        "app.security.jwt.expiration-ms=3600000"
+})
+class JwtAuthenticationFilterTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    JwtService jwtService;
+
+    @MockitoBean
+    AdminStatsService adminStatsService;
+
+    @MockitoBean
+    UserRepository userRepository;
+
+    @Test
+    void route_protegee_sans_token_401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/stats/dettes"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Authentification requise"));
+    }
+
+    @Test
+    void route_protegee_avec_token_invalide_401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/stats/dettes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token-invalide"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Authentification requise"));
+    }
+
+    @Test
+    void route_protegee_avec_token_valide_et_role_autorise_200() throws Exception {
+        User user = new User();
+        user.setLogin("adminGlobal");
+        user.setPasswordHash("hash");
+        user.setActive(true);
+        user.addRole(SecurityRole.ROLE_ADMIN_GLOBAL);
+        when(userRepository.findByLogin("adminGlobal")).thenReturn(Optional.of(user));
+        when(adminStatsService.getDettes())
+                .thenReturn(new AdminDettesStatsDto(new BigDecimal("10.00"), 2L));
+
+        UserDetails principal = org.springframework.security.core.userdetails.User.builder()
+                .username("adminGlobal")
+                .password("hash")
+                .authorities(new SimpleGrantedAuthority("ROLE_ADMIN_GLOBAL"))
+                .build();
+        String token = jwtService.generateToken(principal);
+
+        mockMvc.perform(get("/api/v1/admin/stats/dettes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.detteTotale").value(10.0))
+                .andExpect(jsonPath("$.nbJoueursEnDette").value(2));
+    }
+
+    @Test
+    void route_protegee_avec_token_valide_mais_role_insuffisant_403() throws Exception {
+        User user = new User();
+        user.setLogin("joueur1");
+        user.setPasswordHash("hash");
+        user.setActive(true);
+        user.addRole(SecurityRole.ROLE_JOUEUR);
+        when(userRepository.findByLogin("joueur1")).thenReturn(Optional.of(user));
+
+        UserDetails principal = org.springframework.security.core.userdetails.User.builder()
+                .username("joueur1")
+                .password("hash")
+                .authorities(new SimpleGrantedAuthority("ROLE_JOUEUR"))
+                .build();
+        String token = jwtService.generateToken(principal);
+
+        mockMvc.perform(get("/api/v1/admin/stats/dettes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("Accès refusé"));
+    }
+}


### PR DESCRIPTION

- ajout du JwtService pour la génération et la validation des tokens
- implémentation du JwtAuthenticationFilter (support du header Bearer)
- remplacement de httpBasic par une sécurité stateless basée sur JWT
- sécurisation de tous les endpoints /api/v1/** (sauf login et Swagger en dev)
- ajout de handlers JSON pour les réponses 401 et 403
- mise à jour du AuthenticationService pour renvoyer un vrai JWT au login
- alignement de Swagger/OpenAPI sur bearerAuth
- rechargement des rôles depuis la base à chaque requête
- ajout de la configuration JWT (secret, expiration)