### PR TITLE
Nettoyage post-migration identité authentifiée terminé.

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
@@ -59,7 +59,6 @@ public class SecurityConfig {
                             .requestMatchers(HttpMethod.GET, "/api/v1/joueurs").hasRole("ADMIN_GLOBAL")
                             .requestMatchers(HttpMethod.POST, "/api/v1/joueurs").hasRole("ADMIN_GLOBAL")
                             .requestMatchers(HttpMethod.POST, "/api/v1/sites").hasRole("ADMIN_GLOBAL")
-                            .requestMatchers(HttpMethod.PUT, "/api/v1/sites/*/horaires").hasRole("ADMIN_GLOBAL")
                             .requestMatchers(HttpMethod.POST, "/api/v1/terrains").hasRole("ADMIN_GLOBAL")
                             .requestMatchers(HttpMethod.POST, "/api/v1/fermetures-globales").hasRole("ADMIN_GLOBAL")
                             .requestMatchers(HttpMethod.DELETE, "/api/v1/fermetures-globales/*").hasRole("ADMIN_GLOBAL")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
@@ -52,13 +52,6 @@ public class JoueurService {
         this.currentUserFacade = currentUserFacade;
     }
 
-    public JoueurService(JoueurRepository joueurRepository,
-                         SiteRepository siteRepository,
-                         ParticipationRepository participationRepository,
-                         MatchPadelRepository matchPadelRepository) {
-        this(joueurRepository, siteRepository, participationRepository, matchPadelRepository, null);
-    }
-
     public Joueur creerJoueur(String matricule, String nom, TypeJoueur type, Long siteId) {
         if (matricule == null || matricule.isBlank()) {
             throw new BusinessException("Matricule obligatoire");

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -21,7 +21,6 @@ import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.FermetureGlobaleRepository;
-import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
@@ -51,7 +50,6 @@ public class MatchPadelService {
 
     private final MatchPadelRepository matchPadelRepository;
     private final TerrainRepository terrainRepository;
-    private final JoueurRepository joueurRepository;
     private final SoldeService soldeService;
     private final ParticipationRepository participationRepository;
     private final PaiementService paiementService;
@@ -65,7 +63,6 @@ public class MatchPadelService {
     @Autowired
     public MatchPadelService(MatchPadelRepository matchPadelRepository,
                              TerrainRepository terrainRepository,
-                             JoueurRepository joueurRepository,
                              SoldeService soldeService,
                              ParticipationRepository participationRepository,
                              PaiementService paiementService,
@@ -77,7 +74,6 @@ public class MatchPadelService {
                              CurrentUserFacade currentUserFacade) {
         this.matchPadelRepository = matchPadelRepository;
         this.terrainRepository = terrainRepository;
-        this.joueurRepository = joueurRepository;
         this.soldeService = soldeService;
         this.participationRepository = participationRepository;
         this.paiementService = paiementService;
@@ -87,22 +83,6 @@ public class MatchPadelService {
         this.fermetureGlobaleRepository = fermetureGlobaleRepository;
         this.clock = clock;
         this.currentUserFacade = currentUserFacade;
-    }
-
-    public MatchPadelService(MatchPadelRepository matchPadelRepository,
-                             TerrainRepository terrainRepository,
-                             JoueurRepository joueurRepository,
-                             SoldeService soldeService,
-                             ParticipationRepository participationRepository,
-                             PaiementService paiementService,
-                             HoraireSiteService horaireSiteService,
-                             FermetureSiteService fermetureSiteService,
-                             PaiementRepository paiementRepository,
-                             FermetureGlobaleRepository fermetureGlobaleRepository,
-                             Clock clock) {
-        this(matchPadelRepository, terrainRepository, joueurRepository, soldeService, participationRepository,
-                paiementService, horaireSiteService, fermetureSiteService, paiementRepository,
-                fermetureGlobaleRepository, clock, null);
     }
 
     @Transactional(readOnly = true)
@@ -162,14 +142,7 @@ public class MatchPadelService {
                                  LocalDateTime dateDebut,
                                  MatchVisibilite visibilite) {
         Joueur organisateur = currentUserFacade.getCurrentJoueur();
-        return creerMatch(terrainId, organisateur.getMatricule(), dateDebut, visibilite);
-    }
-
-    public MatchPadel creerMatch(Long terrainId,
-                                 String organisateurMatricule,
-                                 LocalDateTime dateDebut,
-                                 MatchVisibilite visibilite) {
-        if (organisateurMatricule == null || organisateurMatricule.isBlank()) {
+        if (organisateur == null) {
             throw new BusinessException("Organisateur obligatoire");
         }
 
@@ -190,9 +163,6 @@ public class MatchPadelService {
 
         Terrain terrain = terrainRepository.findById(terrainId)
                 .orElseThrow(() -> new NotFoundException("Terrain introuvable"));
-
-        Joueur organisateur = joueurRepository.findById(organisateurMatricule)
-                .orElseThrow(() -> new NotFoundException("Joueur introuvable"));
 
         if (organisateur.getSolde() != null && organisateur.getSolde().signum() > 0) {
             throw new BusinessException("Reservation impossible : dette en cours (" + organisateur.getSolde() + ").");
@@ -218,7 +188,7 @@ public class MatchPadelService {
         Participation participationOrganisateur = participationRepository.save(new Participation(saved, organisateur));
 
         BigDecimal part = Tarifs.PART_PAR_JOUEUR;
-        soldeService.debiter(organisateurMatricule, part);
+        soldeService.debiter(organisateur.getMatricule(), part);
         paiementService.payerParticipation(participationOrganisateur.getId(), part);
 
         return saved;
@@ -371,17 +341,6 @@ public class MatchPadelService {
             if (match.getVisibilite() == MatchVisibilite.PRIVE && !peutVoirMatchPrive(match, matricule)) {
                 throw new ForbiddenException("Acces refuse a ce match prive.");
             }
-        }
-
-        return buildMatchDetailDto(match);
-    }
-
-    @Transactional(readOnly = true)
-    public MatchDetailDto getMatchDetailDto(Long id, String matricule) {
-        MatchPadel match = getMatch(id);
-
-        if (match.getVisibilite() == MatchVisibilite.PRIVE && !peutVoirMatchPrive(match, matricule)) {
-            throw new ForbiddenException("Acces refuse a ce match prive.");
         }
 
         return buildMatchDetailDto(match);

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/PaiementService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/PaiementService.java
@@ -45,31 +45,14 @@ public class PaiementService {
         this.currentUserFacade = currentUserFacade;
     }
 
-    public PaiementService(PaiementRepository paiementRepository,
-                           ParticipationRepository participationRepository,
-                           SoldeService soldeService,
-                           Clock clock) {
-        this(paiementRepository, participationRepository, soldeService, clock, null);
-    }
-
     public Paiement payerParticipation(Long participationId, BigDecimal montant) {
         Participation participation = getParticipationByIdOrThrow(participationId);
         verifierPaiementAutorise(participation);
         return payerParticipationInterne(participationId, montant, TypePaiement.ENCAISSEMENT, false);
     }
 
-    public Paiement payerPourMatch(Long matchId, String joueurMatricule, BigDecimal montant) {
-        Participation participation = getParticipationOrThrow(matchId, joueurMatricule);
-        return payerParticipation(participation.getId(), montant);
-    }
-
     public Paiement payerParticipationAvecRattrapageDette(Long participationId, BigDecimal montant) {
         return payerParticipationInterne(participationId, montant, TypePaiement.ENCAISSEMENT, true);
-    }
-
-    public Paiement payerPourMatchAvecRattrapageDette(Long matchId, String joueurMatricule, BigDecimal montant) {
-        Participation participation = getParticipationOrThrow(matchId, joueurMatricule);
-        return payerParticipationAvecRattrapageDette(participation.getId(), montant);
     }
 
     Paiement enregistrerRemboursementAnnulation(Participation participation, BigDecimal montantRembourse) {
@@ -139,21 +122,12 @@ public class PaiementService {
         return saved;
     }
 
-    private Participation getParticipationOrThrow(Long matchId, String joueurMatricule) {
-        return participationRepository
-                .findByMatch_IdAndJoueur_Matricule(matchId, joueurMatricule)
-                .orElseThrow(() -> new NotFoundException("Participation introuvable pour ce match/joueur"));
-    }
-
     private Participation getParticipationByIdOrThrow(Long participationId) {
         return participationRepository.findById(participationId)
                 .orElseThrow(() -> new NotFoundException("Participation introuvable"));
     }
 
     private void verifierPaiementAutorise(Participation participation) {
-        if (currentUserFacade == null) {
-            return;
-        }
         String joueurCourantMatricule = currentUserFacade.getCurrentJoueur().getMatricule();
         String joueurParticipationMatricule = participation.getJoueur().getMatricule();
         if (!joueurCourantMatricule.equals(joueurParticipationMatricule)) {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java
@@ -47,20 +47,8 @@ public class ParticipationService {
         this.currentUserFacade = currentUserFacade;
     }
 
-    public ParticipationService(ParticipationRepository participationRepository,
-                                MatchPadelRepository matchPadelRepository,
-                                JoueurRepository joueurRepository,
-                                SoldeService soldeService,
-                                PaiementService paiementService) {
-        this(participationRepository, matchPadelRepository, joueurRepository, soldeService, paiementService, null);
-    }
-
     public Participation rejoindreEtPayerMatchPublic(Long matchId) {
         Joueur joueur = currentUserFacade.getCurrentJoueur();
-        return rejoindreEtPayerMatchPublic(matchId, joueur.getMatricule());
-    }
-
-    public Participation rejoindreEtPayerMatchPublic(Long matchId, String joueurMatricule) {
         MatchPadel match = matchPadelRepository.findByIdForUpdateWithParticipations(matchId)
                 .orElseThrow(() -> new NotFoundException("Match introuvable"));
         verifierMatchNonAnnule(match);
@@ -69,7 +57,7 @@ public class ParticipationService {
             throw new BusinessException("Match prive : seule l'organisation peut ajouter des joueurs.");
         }
 
-        Joueur joueur = getJoueurOrThrow(joueurMatricule);
+        String joueurMatricule = joueur.getMatricule();
 
         verifierNonDejaInscrit(matchId, joueurMatricule);
 
@@ -90,10 +78,6 @@ public class ParticipationService {
 
     public BigDecimal calculerMontantAttenduPourMatchPublic(Long matchId) {
         Joueur joueur = currentUserFacade.getCurrentJoueur();
-        return calculerMontantAttenduPourMatchPublic(matchId, joueur.getMatricule());
-    }
-
-    public BigDecimal calculerMontantAttenduPourMatchPublic(Long matchId, String joueurMatricule) {
         MatchPadel match = matchPadelRepository.findById(matchId)
                 .orElseThrow(() -> new NotFoundException("Match introuvable"));
         verifierMatchNonAnnule(match);
@@ -102,19 +86,12 @@ public class ParticipationService {
             throw new BusinessException("Match prive : ce calcul n'est valable que pour un match public.");
         }
 
-        Joueur joueur = getJoueurOrThrow(joueurMatricule);
         BigDecimal dette = joueur.getSolde() == null ? BigDecimal.ZERO : joueur.getSolde().setScale(2, RoundingMode.HALF_UP);
         return PART_JOUEUR.add(dette).setScale(2, RoundingMode.HALF_UP);
     }
 
     public Participation ajouterJoueurParOrganisateur(Long matchId, String joueurMatriculeAAjouter) {
         Joueur currentJoueur = currentUserFacade.getCurrentJoueur();
-        return ajouterJoueurParOrganisateur(matchId, currentJoueur.getMatricule(), joueurMatriculeAAjouter);
-    }
-
-    public Participation ajouterJoueurParOrganisateur(Long matchId,
-                                                      String organisateurMatricule,
-                                                      String joueurMatriculeAAjouter) {
         MatchPadel match = getMatchOrThrow(matchId);
         verifierMatchNonAnnule(match);
 
@@ -123,8 +100,8 @@ public class ParticipationService {
         }
 
         String orga = match.getOrganisateur().getMatricule();
-        boolean admin = currentUserFacade != null && currentUserFacade.isAdmin();
-        if (!admin && !orga.equals(organisateurMatricule)) {
+        boolean admin = currentUserFacade.isAdmin();
+        if (!admin && !orga.equals(currentJoueur.getMatricule())) {
             throw new BusinessException("Seul l'organisateur peut ajouter des joueurs a ce match.");
         }
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/integration/FermetureSiteAnnulationIntegrationIT.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/integration/FermetureSiteAnnulationIntegrationIT.java
@@ -1,6 +1,5 @@
 package be.ephec.padel.backend.integration;
 
-import be.ephec.padel.backend.dto.request.CreateFermetureSiteDateRequest;
 import be.ephec.padel.backend.model.entities.FermetureSite;
 import be.ephec.padel.backend.model.entities.HoraireSite;
 import be.ephec.padel.backend.model.entities.Joueur;
@@ -9,10 +8,12 @@ import be.ephec.padel.backend.model.entities.Paiement;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.entities.Site;
 import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.entities.User;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
-import be.ephec.padel.backend.model.enums.TypePaiement;
+import be.ephec.padel.backend.model.enums.SecurityRole;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.repository.FermetureSiteRepository;
 import be.ephec.padel.backend.repository.HoraireSiteRepository;
 import be.ephec.padel.backend.repository.JoueurRepository;
@@ -22,6 +23,7 @@ import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.SiteRepository;
 import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.repository.UserRepository;
 import be.ephec.padel.backend.service.MatchPadelService;
 import be.ephec.padel.backend.service.PaiementService;
 import be.ephec.padel.backend.service.ParticipationService;
@@ -37,7 +39,9 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -51,8 +55,11 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -85,6 +92,7 @@ class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig 
     @Autowired PaiementRepository paiementRepository;
     @Autowired MouvementSoldeRepository mouvementSoldeRepository;
     @Autowired FermetureSiteRepository fermetureSiteRepository;
+    @Autowired UserRepository userRepository;
 
     @Autowired MatchPadelService matchPadelService;
     @Autowired ParticipationService participationService;
@@ -110,6 +118,7 @@ class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig 
         paiementRepository.deleteAll();
         participationRepository.deleteAll();
         matchPadelRepository.deleteAll();
+        userRepository.deleteAll();
         mouvementSoldeRepository.deleteAll();
         fermetureSiteRepository.deleteAll();
         horaireSiteRepository.deleteAll();
@@ -136,29 +145,36 @@ class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig 
         joueur3 = joueurRepository.save(joueur("G0003", "Joueur 3"));
         joueur4 = joueurRepository.save(joueur("G0004", "Joueur 4"));
         joueur5 = joueurRepository.save(joueur("G0005", "Joueur 5"));
+
+        createUser("orga-login", orga, SecurityRole.ROLE_JOUEUR);
+        createUser("joueur3-login", joueur3, SecurityRole.ROLE_JOUEUR);
+        createUser("joueur5-login", joueur5, SecurityRole.ROLE_JOUEUR);
     }
 
     @Test
-    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
     void fermeture_date_annule_match_prive_compense_et_bloque_les_ecritures() throws Exception {
         LocalDateTime dateMatch = LocalDateTime.of(2030, 1, 2, 10, 0);
 
-        MatchPadel match = matchPadelService.creerMatch(
-                terrain.getId(),
-                orga.getMatricule(),
-                dateMatch,
-                MatchVisibilite.PRIVE
+        MatchPadel match = runAs("orga-login", List.of(SecurityRole.ROLE_JOUEUR), () ->
+                matchPadelService.creerMatch(terrain.getId(), dateMatch, MatchVisibilite.PRIVE)
         );
-
-        participationService.ajouterJoueurParOrganisateur(match.getId(), orga.getMatricule(), joueur2.getMatricule());
-        participationService.ajouterJoueurParOrganisateur(match.getId(), orga.getMatricule(), joueur3.getMatricule());
+        runAs("orga-login", List.of(SecurityRole.ROLE_JOUEUR), () -> {
+            participationService.ajouterJoueurParOrganisateur(match.getId(), joueur2.getMatricule());
+            participationService.ajouterJoueurParOrganisateur(match.getId(), joueur3.getMatricule());
+            return null;
+        });
 
         Participation participationJ3 = participationRepository
                 .findByMatch_IdAndJoueur_Matricule(match.getId(), joueur3.getMatricule())
                 .orElseThrow();
-        paiementService.payerParticipation(participationJ3.getId(), new BigDecimal("10.00"));
+        runAs("joueur3-login", List.of(SecurityRole.ROLE_JOUEUR), () -> {
+            paiementService.payerParticipation(participationJ3.getId(), new BigDecimal("10.00"));
+            return null;
+        });
 
         mockMvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .with(user("adminGlobal").roles("ADMIN_GLOBAL"))
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -188,6 +204,7 @@ class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig 
                 .containsExactlyInAnyOrder(new BigDecimal("-15.00"), new BigDecimal("-10.00"));
 
         mockMvc.perform(get("/api/v1/matchs/public")
+                        .with(user("orga-login").roles("JOUEUR"))
                         .param("from", "2030-01-01")
                         .param("to", "2030-01-03")
                         .param("siteId", site.getId().toString()))
@@ -195,34 +212,39 @@ class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig 
                 .andExpect(jsonPath("$").isEmpty());
 
         mockMvc.perform(get("/api/v1/matchs/" + match.getId())
-                        .param("matricule", orga.getMatricule()))
+                        .with(user("orga-login").roles("JOUEUR")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.statut").value("ANNULE"))
                 .andExpect(jsonPath("$.resteAPayer").value(0.00))
                 .andExpect(jsonPath("$.montantPaye").value(25.00))
                 .andExpect(jsonPath("$.montantRembourse").value(25.00));
 
-        mockMvc.perform(get("/api/v1/joueurs/" + joueur3.getMatricule() + "/matchs"))
+        mockMvc.perform(get("/api/v1/me/matchs")
+                        .with(user("joueur3-login").roles("JOUEUR")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].statut").value("ANNULE"));
 
-        mockMvc.perform(get("/api/v1/joueurs/" + orga.getMatricule() + "/matchs/organises"))
+        mockMvc.perform(get("/api/v1/me/matchs/organises")
+                        .with(user("orga-login").roles("JOUEUR")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].statut").value("ANNULE"))
                 .andExpect(jsonPath("$[0].risquePenaliteJ1").value(false));
 
         mockMvc.perform(post("/api/v1/matchs/" + match.getId() + "/participants/prive")
+                        .with(user("orga-login").roles("JOUEUR"))
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "organisateurMatricule": "%s",
                                   "joueurMatriculeAAjouter": "%s"
                                 }
-                                """.formatted(orga.getMatricule(), joueur4.getMatricule())))
+                                """.formatted(joueur4.getMatricule())))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Match annul")));
 
         mockMvc.perform(post("/api/v1/participations/" + participationJ3.getId() + "/paiements")
+                        .with(user("joueur3-login").roles("JOUEUR"))
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -233,7 +255,9 @@ class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig 
                 .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Match annul")));
 
         FermetureSite fermeture = fermetureSiteRepository.findAll().get(0);
-        mockMvc.perform(delete("/api/v1/admin/sites/" + site.getId() + "/fermetures/" + fermeture.getId()))
+        mockMvc.perform(delete("/api/v1/admin/sites/" + site.getId() + "/fermetures/" + fermeture.getId())
+                        .with(user("adminGlobal").roles("ADMIN_GLOBAL"))
+                        .with(csrf()))
                 .andExpect(status().isNoContent());
 
         MatchPadel stillCancelled = matchPadelRepository.findByIdWithDetails(match.getId()).orElseThrow();
@@ -241,18 +265,16 @@ class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig 
     }
 
     @Test
-    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
     void fermeture_date_annule_match_public_et_bloque_join_et_montant_attendu() throws Exception {
         LocalDateTime dateMatch = LocalDateTime.of(2030, 1, 2, 11, 0);
 
-        MatchPadel match = matchPadelService.creerMatch(
-                terrain.getId(),
-                orga.getMatricule(),
-                dateMatch,
-                MatchVisibilite.PUBLIC
+        MatchPadel match = runAs("orga-login", List.of(SecurityRole.ROLE_JOUEUR), () ->
+                matchPadelService.creerMatch(terrain.getId(), dateMatch, MatchVisibilite.PUBLIC)
         );
 
         mockMvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .with(user("adminGlobal").roles("ADMIN_GLOBAL"))
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -263,34 +285,28 @@ class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig 
                 .andExpect(status().isCreated());
 
         mockMvc.perform(get("/api/v1/matchs/" + match.getId() + "/participants/public/montant-attendu")
-                        .param("joueurMatricule", joueur5.getMatricule()))
+                        .with(user("joueur5-login").roles("JOUEUR")))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Match annul")));
 
         mockMvc.perform(post("/api/v1/matchs/" + match.getId() + "/participants/public")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "joueurMatricule": "%s"
-                                }
-                                """.formatted(joueur5.getMatricule())))
+                        .with(user("joueur5-login").roles("JOUEUR"))
+                        .with(csrf()))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Match annul")));
     }
 
     @Test
-    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
     void match_annule_est_ignore_par_schedulers_et_exclu_des_stats() throws Exception {
         LocalDateTime dateMatch = LocalDateTime.of(2030, 1, 2, 9, 1);
 
-        MatchPadel match = matchPadelService.creerMatch(
-                terrain.getId(),
-                orga.getMatricule(),
-                dateMatch,
-                MatchVisibilite.PRIVE
+        MatchPadel match = runAs("orga-login", List.of(SecurityRole.ROLE_JOUEUR), () ->
+                matchPadelService.creerMatch(terrain.getId(), dateMatch, MatchVisibilite.PRIVE)
         );
 
         mockMvc.perform(post("/api/v1/admin/sites/" + site.getId() + "/fermetures/date")
+                        .with(user("adminGlobal").roles("ADMIN_GLOBAL"))
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -317,18 +333,21 @@ class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig 
         assertThat(joueurRepository.findById(orga.getMatricule()).orElseThrow().getSolde()).isEqualByComparingTo("0.00");
 
         mockMvc.perform(get("/api/v1/admin/stats/matchs")
+                        .with(user("adminGlobal").roles("ADMIN_GLOBAL"))
                         .param("from", "2030-01-02")
                         .param("to", "2030-01-02"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.nbMatchs").value(0));
 
         mockMvc.perform(get("/api/v1/admin/stats/ca")
+                        .with(user("adminGlobal").roles("ADMIN_GLOBAL"))
                         .param("from", "2030-01-01")
                         .param("to", "2030-01-01"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.caTotal").value(0.00));
 
         mockMvc.perform(get("/api/v1/admin/sites/" + site.getId() + "/stats/matchs")
+                        .with(user("adminGlobal").roles("ADMIN_GLOBAL"))
                         .param("from", "2030-01-02")
                         .param("to", "2030-01-02"))
                 .andExpect(status().isOk())
@@ -339,6 +358,28 @@ class FermetureSiteAnnulationIntegrationIT extends SqlServerTestContainerConfig 
         Joueur joueur = new Joueur(matricule, nom, TypeJoueur.GLOBAL);
         joueur.setSolde(BigDecimal.ZERO);
         return joueur;
+    }
+
+    private void createUser(String login, Joueur joueur, SecurityRole role) {
+        User user = new User();
+        user.setLogin(login);
+        user.setPasswordHash("noop");
+        user.setJoueur(joueur);
+        user.addRole(role);
+        userRepository.save(user);
+    }
+
+    private <T> T runAs(String login, List<SecurityRole> roles, Supplier<T> supplier) {
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                login,
+                "N/A",
+                roles.stream().map(role -> new SimpleGrantedAuthority(role.name())).toList()
+        ));
+        try {
+            return supplier.get();
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
     }
 
     @TestConfiguration

--- a/backend/backend/src/test/java/be/ephec/padel/backend/integration/ParticipationPremierPayePremierServiIT.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/integration/ParticipationPremierPayePremierServiIT.java
@@ -1,23 +1,47 @@
 package be.ephec.padel.backend.integration;
 
 import be.ephec.padel.backend.exception.BusinessException;
-import be.ephec.padel.backend.model.entities.*;
+import be.ephec.padel.backend.model.entities.HoraireSite;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.entities.User;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.SecurityRole;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
-import be.ephec.padel.backend.repository.*;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.MouvementSoldeRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.repository.UserRepository;
 import be.ephec.padel.backend.service.ParticipationService;
 import be.ephec.padel.backend.support.SqlServerTestContainerConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Set;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @SpringBootTest
 class ParticipationPremierPayePremierServiIT extends SqlServerTestContainerConfig {
@@ -32,6 +56,7 @@ class ParticipationPremierPayePremierServiIT extends SqlServerTestContainerConfi
     @Autowired ParticipationRepository participationRepository;
     @Autowired PaiementRepository paiementRepository;
     @Autowired MouvementSoldeRepository mouvementSoldeRepository;
+    @Autowired UserRepository userRepository;
 
     private MatchPadel match;
     private Joueur j4;
@@ -39,37 +64,33 @@ class ParticipationPremierPayePremierServiIT extends SqlServerTestContainerConfi
 
     @BeforeEach
     void setup() {
-        // Clean (ordre FK)
         paiementRepository.deleteAll();
         participationRepository.deleteAll();
         matchPadelRepository.deleteAll();
+        userRepository.deleteAll();
         mouvementSoldeRepository.deleteAll();
         terrainRepository.deleteAll();
         joueurRepository.deleteAll();
         siteRepository.deleteAll();
 
         Site site = new Site("Site", "Ville");
-
         site.setJoursFermeture(Set.of());
         site = siteRepository.save(site);
 
         Terrain terrain = new Terrain("T1", site);
         terrain = terrainRepository.save(terrain);
-        HoraireSite horaire = new HoraireSite(
-                site,
-                2026,
-                LocalTime.of(8,0),
-                LocalTime.of(22,0)
+        new HoraireSite(site, 2026, LocalTime.of(8, 0), LocalTime.of(22, 0));
+
+        Joueur orga = joueurRepository.save(new Joueur("G0001", "Orga", TypeJoueur.GLOBAL));
+
+        match = new MatchPadel(
+                terrain,
+                orga,
+                LocalDateTime.now().plusDays(2).withHour(10).withMinute(0).withSecond(0).withNano(0),
+                MatchVisibilite.PUBLIC
         );
-
-        Joueur orga = new Joueur("G0001", "Orga", TypeJoueur.GLOBAL);
-        orga = joueurRepository.save(orga);
-
-        // Match PUBLIC dans le futur
-        match = new MatchPadel(terrain, orga, LocalDateTime.now().plusDays(2).withHour(10).withMinute(0).withSecond(0).withNano(0), MatchVisibilite.PUBLIC);
         match = matchPadelRepository.save(match);
 
-        // 3 joueurs déjà inscrits (on remplit jusqu’à 3)
         Joueur j1 = joueurRepository.save(new Joueur("G0002", "J1", TypeJoueur.GLOBAL));
         Joueur j2 = joueurRepository.save(new Joueur("G0003", "J2", TypeJoueur.GLOBAL));
         Joueur j3 = joueurRepository.save(new Joueur("G0004", "J3", TypeJoueur.GLOBAL));
@@ -78,9 +99,11 @@ class ParticipationPremierPayePremierServiIT extends SqlServerTestContainerConfi
         participationRepository.save(new Participation(match, j2));
         participationRepository.save(new Participation(match, j3));
 
-        // 2 candidats concurrents pour la 4e place
         j4 = joueurRepository.save(new Joueur("G0005", "J4", TypeJoueur.GLOBAL));
         j5 = joueurRepository.save(new Joueur("G0006", "J5", TypeJoueur.GLOBAL));
+
+        createUser("j4-login", j4, SecurityRole.ROLE_JOUEUR);
+        createUser("j5-login", j5, SecurityRole.ROLE_JOUEUR);
     }
 
     @Test
@@ -90,13 +113,12 @@ class ParticipationPremierPayePremierServiIT extends SqlServerTestContainerConfi
         CountDownLatch ready = new CountDownLatch(threads);
         CountDownLatch start = new CountDownLatch(1);
 
-        Callable<Boolean> task1 = () -> runJoinPay(ready, start, match.getId(), j4.getMatricule());
-        Callable<Boolean> task2 = () -> runJoinPay(ready, start, match.getId(), j5.getMatricule());
+        Callable<Boolean> task1 = () -> runJoinPay(ready, start, match.getId(), "j4-login");
+        Callable<Boolean> task2 = () -> runJoinPay(ready, start, match.getId(), "j5-login");
 
         Future<Boolean> f1 = executor.submit(task1);
         Future<Boolean> f2 = executor.submit(task2);
 
-        // attendre que les 2 threads soient prêts, puis démarrer en même temps
         ready.await(5, TimeUnit.SECONDS);
         start.countDown();
 
@@ -105,28 +127,44 @@ class ParticipationPremierPayePremierServiIT extends SqlServerTestContainerConfi
 
         executor.shutdownNow();
 
-        // exactement 1 succès
         assertNotEquals(r1, r2);
-
-        // et au final : 4 participations max
-        int nb = participationRepository.countByMatch_Id(match.getId());
-        assertEquals(4, nb);
+        assertEquals(4, participationRepository.countByMatch_Id(match.getId()));
     }
 
     private boolean runJoinPay(CountDownLatch ready,
                                CountDownLatch start,
                                Long matchId,
-                               String matricule) throws InterruptedException {
+                               String login) throws InterruptedException {
         ready.countDown();
         start.await(5, TimeUnit.SECONDS);
 
         try {
-            participationService.rejoindreEtPayerMatchPublic(matchId, matricule);
+            runAs(login, List.of(SecurityRole.ROLE_JOUEUR), () -> participationService.rejoindreEtPayerMatchPublic(matchId));
             return true;
         } catch (BusinessException ex) {
-            // l’un des deux doit tomber ici ("Match déjà complet")
             return false;
         }
     }
 
+    private void createUser(String login, Joueur joueur, SecurityRole role) {
+        User user = new User();
+        user.setLogin(login);
+        user.setPasswordHash("noop");
+        user.setJoueur(joueur);
+        user.addRole(role);
+        userRepository.save(user);
+    }
+
+    private void runAs(String login, List<SecurityRole> roles, Runnable runnable) {
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                login,
+                "N/A",
+                roles.stream().map(role -> new SimpleGrantedAuthority(role.name())).toList()
+        ));
+        try {
+            runnable.run();
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/JoueurServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/JoueurServiceTest.java
@@ -14,6 +14,7 @@ import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.SiteRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
 import be.ephec.padel.backend.service.JoueurService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,7 @@ class JoueurServiceTest {
     private JoueurService service;
     private MatchPadelRepository matchPadelRepo;
     private ParticipationRepository participationRepo;
+    private CurrentUserFacade currentUserFacade;
 
     @BeforeEach
     void setup() {
@@ -43,7 +45,8 @@ class JoueurServiceTest {
         siteRepo = mock(SiteRepository.class);
         participationRepo = mock(ParticipationRepository.class);
         matchPadelRepo = mock(MatchPadelRepository.class);
-        service = new JoueurService(joueurRepo, siteRepo, participationRepo,matchPadelRepo);
+        currentUserFacade = mock(CurrentUserFacade.class);
+        service = new JoueurService(joueurRepo, siteRepo, participationRepo, matchPadelRepo, currentUserFacade);
     }
 
     private Participation mockParticipation(String organisateurMatricule,

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
@@ -19,6 +19,7 @@ import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.TerrainRepository;
 import be.ephec.padel.backend.repository.projection.PublicMatchSummaryProjection;
+import be.ephec.padel.backend.security.CurrentUserFacade;
 import be.ephec.padel.backend.service.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,7 @@ class MatchPadelServiceTest {
     private FermetureGlobaleRepository fermetureGlobaleRepo;
     private FermetureSiteService fermetureSiteService;
     private HoraireSiteService horaireSiteService;
+    private CurrentUserFacade currentUserFacade;
     private Clock clock;
 
     private MatchPadelService service;
@@ -66,6 +68,7 @@ class MatchPadelServiceTest {
         fermetureGlobaleRepo = mock(FermetureGlobaleRepository.class);
         fermetureSiteService = mock(FermetureSiteService.class);
         horaireSiteService = mock(HoraireSiteService.class);
+        currentUserFacade = mock(CurrentUserFacade.class);
         clock = Clock.fixed(
                 Instant.parse("2026-03-24T10:00:00Z"),
                 ZoneId.of("Europe/Brussels")
@@ -74,7 +77,6 @@ class MatchPadelServiceTest {
         service = new MatchPadelService(
                 matchRepo,
                 terrainRepo,
-                joueurRepo,
                 soldeService,
                 participationRepo,
                 paiementService,
@@ -82,8 +84,11 @@ class MatchPadelServiceTest {
                 fermetureSiteService,
                 paiementRepo,
                 fermetureGlobaleRepo,
-                clock
+                clock,
+                currentUserFacade
         );
+
+        stubCurrentJoueur("G0001", TypeJoueur.GLOBAL, BigDecimal.ZERO);
     }
 
     // ----------------
@@ -112,11 +117,16 @@ class MatchPadelServiceTest {
     }
 
     private Joueur stubOrgaGlobalSansDette(String matricule) {
-        Joueur orga = mock(Joueur.class);
-        when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
-        when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
-        when(joueurRepo.findById(matricule)).thenReturn(Optional.of(orga));
-        return orga;
+        return stubCurrentJoueur(matricule, TypeJoueur.GLOBAL, BigDecimal.ZERO);
+    }
+
+    private Joueur stubCurrentJoueur(String matricule, TypeJoueur type, BigDecimal solde) {
+        Joueur joueur = mock(Joueur.class);
+        when(joueur.getMatricule()).thenReturn(matricule);
+        when(joueur.getType()).thenReturn(type);
+        when(joueur.getSolde()).thenReturn(solde);
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
+        return joueur;
     }
 
     // ----------------
@@ -269,37 +279,39 @@ class MatchPadelServiceTest {
     @Test
     void creerMatch_terrainIdNull_refuse() {
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(null, "G0001", dateValide(), MatchVisibilite.PUBLIC));
+                service.creerMatch(null, dateValide(), MatchVisibilite.PUBLIC));
         verifyNoInteractions(matchRepo, terrainRepo, joueurRepo, participationRepo, soldeService, paiementService);
     }
 
     @Test
     void creerMatch_organisateurBlank_refuse() {
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(null);
+
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "   ", dateValide(), MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, dateValide(), MatchVisibilite.PUBLIC));
         verifyNoInteractions(matchRepo, terrainRepo, joueurRepo, participationRepo, soldeService, paiementService);
     }
 
     @Test
     void creerMatch_dateNull_refuse() {
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", null, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, null, MatchVisibilite.PUBLIC));
         verifyNoInteractions(matchRepo, terrainRepo, joueurRepo, participationRepo, soldeService, paiementService);
     }
 
     @Test
     void creerMatch_visibiliteNull_refuse() {
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", dateValide(), null));
+                service.creerMatch(1L, dateValide(), null));
         verifyNoInteractions(matchRepo, terrainRepo, joueurRepo, participationRepo, soldeService, paiementService);
     }
 
     @Test
     void creerMatch_datePasDansFutur_refuse() {
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", LocalDateTime.now(clock), MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, LocalDateTime.now(clock), MatchVisibilite.PUBLIC));
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", LocalDateTime.now(clock).minusMinutes(1), MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, LocalDateTime.now(clock).minusMinutes(1), MatchVisibilite.PUBLIC));
     }
 
     @Test
@@ -307,19 +319,19 @@ class MatchPadelServiceTest {
         when(terrainRepo.findById(1L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class, () ->
-                service.creerMatch(1L, "G0001", dateValide(), MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, dateValide(), MatchVisibilite.PUBLIC));
 
         verifyNoInteractions(joueurRepo, matchRepo, participationRepo, soldeService, paiementService);
     }
 
     @Test
-    void creerMatch_joueurIntrouvable_notFound() {
+    void creerMatch_sansOrganisateurAuthentifie_refuse() {
         Terrain t = mock(Terrain.class);
         when(terrainRepo.findById(1L)).thenReturn(Optional.of(t));
-        when(joueurRepo.findById("G0001")).thenReturn(Optional.empty());
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(null);
 
-        assertThrows(NotFoundException.class, () ->
-                service.creerMatch(1L, "G0001", dateValide(), MatchVisibilite.PUBLIC));
+        assertThrows(BusinessException.class, () ->
+                service.creerMatch(1L, dateValide(), MatchVisibilite.PUBLIC));
 
         verifyNoInteractions(matchRepo, participationRepo, soldeService, paiementService);
     }
@@ -332,10 +344,10 @@ class MatchPadelServiceTest {
 
         Joueur orga = mock(Joueur.class);
         when(orga.getSolde()).thenReturn(new BigDecimal("0.01"));
-        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", dateValide(), MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, dateValide(), MatchVisibilite.PUBLIC));
 
         verifyNoInteractions(matchRepo, participationRepo, soldeService, paiementService);
     }
@@ -350,10 +362,10 @@ class MatchPadelServiceTest {
         when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
         when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
         when(orga.getPenaliteJusqua()).thenReturn(LocalDateTime.now(clock).plusDays(1));
-        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
 
         BusinessException ex = assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", dateValide(), MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, dateValide(), MatchVisibilite.PUBLIC));
 
         assertTrue(ex.getMessage().toLowerCase().contains("activ"));
         verifyNoInteractions(matchRepo, participationRepo, soldeService, paiementService);
@@ -381,7 +393,7 @@ class MatchPadelServiceTest {
         when(p.getId()).thenReturn(123L);
         when(participationRepo.save(any(Participation.class))).thenReturn(p);
 
-        MatchPadel res = service.creerMatch(1L, "G0001", dateValide(), MatchVisibilite.PUBLIC);
+        MatchPadel res = service.creerMatch(1L, dateValide(), MatchVisibilite.PUBLIC);
         assertSame(savedMatch, res);
     }
 
@@ -398,12 +410,12 @@ class MatchPadelServiceTest {
         Joueur orga = mock(Joueur.class);
         when(orga.getType()).thenReturn(TypeJoueur.GLOBAL);
         when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
-        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(orga));
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
 
         LocalDateTime date = LocalDateTime.now(clock).plusWeeks(3).plusMinutes(1);
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, date, MatchVisibilite.PUBLIC));
     }
 
     @Test
@@ -415,12 +427,12 @@ class MatchPadelServiceTest {
         Joueur orga = mock(Joueur.class);
         when(orga.getType()).thenReturn(TypeJoueur.LIBRE);
         when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
-        when(joueurRepo.findById("L0001")).thenReturn(Optional.of(orga));
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
 
         LocalDateTime date = LocalDateTime.now(clock).plusDays(5).plusMinutes(1);
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "L0001", date, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, date, MatchVisibilite.PUBLIC));
     }
 
     @Test
@@ -436,13 +448,12 @@ class MatchPadelServiceTest {
         when(orga.getType()).thenReturn(TypeJoueur.SITE);
         when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
         when(orga.getSite()).thenReturn(null);
-
-        when(joueurRepo.findById("S0001")).thenReturn(Optional.of(orga));
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
 
         LocalDateTime date = dateValide();
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "S0001", date, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, date, MatchVisibilite.PUBLIC));
     }
 
     @Test
@@ -461,13 +472,12 @@ class MatchPadelServiceTest {
         Site siteJoueur = mock(Site.class);
         when(siteJoueur.getId()).thenReturn(1L);
         when(orga.getSite()).thenReturn(siteJoueur);
-
-        when(joueurRepo.findById("S0001")).thenReturn(Optional.of(orga));
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
 
         LocalDateTime date = dateValide();
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "S0001", date, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, date, MatchVisibilite.PUBLIC));
     }
 
     @Test
@@ -481,7 +491,7 @@ class MatchPadelServiceTest {
         Joueur orga = mock(Joueur.class);
         when(orga.getType()).thenReturn(TypeJoueur.SITE);
         when(orga.getSolde()).thenReturn(BigDecimal.ZERO);
-        when(joueurRepo.findById("S0001")).thenReturn(Optional.of(orga));
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
 
         Site siteJoueur = mock(Site.class);
         when(siteJoueur.getId()).thenReturn(1L);
@@ -490,7 +500,7 @@ class MatchPadelServiceTest {
         LocalDateTime date = LocalDateTime.now(clock).plusWeeks(2).plusMinutes(1);
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "S0001", date, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, date, MatchVisibilite.PUBLIC));
     }
 
     // ----------------
@@ -515,7 +525,7 @@ class MatchPadelServiceTest {
                 .thenReturn(List.of(existing));
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, date, MatchVisibilite.PUBLIC));
     }
 
     @Test
@@ -542,7 +552,7 @@ class MatchPadelServiceTest {
         when(p.getId()).thenReturn(123L);
         when(participationRepo.save(any(Participation.class))).thenReturn(p);
 
-        MatchPadel res = service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC);
+        MatchPadel res = service.creerMatch(1L, date, MatchVisibilite.PUBLIC);
         assertSame(savedMatch, res);
     }
 
@@ -562,7 +572,7 @@ class MatchPadelServiceTest {
         when(fermetureGlobaleRepo.existsByDate(date.toLocalDate())).thenReturn(true);
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, date, MatchVisibilite.PUBLIC));
     }
 
     @Test
@@ -586,7 +596,7 @@ class MatchPadelServiceTest {
         when(p.getId()).thenReturn(123L);
         when(participationRepo.save(any(Participation.class))).thenReturn(p);
 
-        MatchPadel res = service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC);
+        MatchPadel res = service.creerMatch(1L, date, MatchVisibilite.PUBLIC);
         assertSame(savedMatch, res);
     }
 
@@ -616,7 +626,7 @@ class MatchPadelServiceTest {
         when(fermetureGlobaleRepo.existsByDate(date.toLocalDate())).thenReturn(false);
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, date, MatchVisibilite.PUBLIC));
     }
 
     @Test
@@ -643,7 +653,7 @@ class MatchPadelServiceTest {
         when(fermetureGlobaleRepo.existsByDate(date.toLocalDate())).thenReturn(false);
 
         assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, date, MatchVisibilite.PUBLIC));
     }
 
     @Test
@@ -667,7 +677,7 @@ class MatchPadelServiceTest {
         when(p.getId()).thenReturn(123L);
         when(participationRepo.save(any(Participation.class))).thenReturn(p);
 
-        MatchPadel res = service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC);
+        MatchPadel res = service.creerMatch(1L, date, MatchVisibilite.PUBLIC);
         assertSame(savedMatch, res);
     }
 
@@ -835,6 +845,8 @@ class MatchPadelServiceTest {
 
     @Test
     void getMatchDetailDto_public_sansMatricule_ok() {
+        stubCurrentJoueur("G0009", TypeJoueur.GLOBAL, BigDecimal.ZERO);
+
         MatchPadel match = mock(MatchPadel.class);
         when(match.getId()).thenReturn(1L);
         when(match.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
@@ -861,7 +873,7 @@ class MatchPadelServiceTest {
 
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
 
-        MatchDetailDto dto = service.getMatchDetailDto(1L, null);
+        MatchDetailDto dto = service.getMatchDetailDto(1L);
 
         assertEquals(1L, dto.getId());
         assertEquals("Site Delta", dto.getSiteNom());
@@ -876,19 +888,23 @@ class MatchPadelServiceTest {
 
     @Test
     void getMatchDetailDto_prive_sansMatricule_refuse() {
+        when(currentUserFacade.getCurrentJoueur()).thenThrow(new ForbiddenException("Utilisateur authentifie requis."));
+
         MatchPadel match = mock(MatchPadel.class);
         when(match.getVisibilite()).thenReturn(MatchVisibilite.PRIVE);
 
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
 
         assertThrows(ForbiddenException.class,
-                () -> service.getMatchDetailDto(1L, null));
+                () -> service.getMatchDetailDto(1L));
 
         verify(paiementRepo, never()).sumMontantByParticipationIdAndType(anyLong(), any());
     }
 
     @Test
     void getMatchDetailDto_prive_organisateur_ok() {
+        when(currentUserFacade.isAdmin()).thenReturn(false);
+
         MatchPadel match = mock(MatchPadel.class);
         when(match.getId()).thenReturn(1L);
         when(match.getVisibilite()).thenReturn(MatchVisibilite.PRIVE);
@@ -915,7 +931,7 @@ class MatchPadelServiceTest {
 
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
 
-        MatchDetailDto dto = service.getMatchDetailDto(1L, "G0001");
+        MatchDetailDto dto = service.getMatchDetailDto(1L);
 
         assertEquals(1L, dto.getId());
         assertEquals("G0001", dto.getOrganisateurMatricule());
@@ -923,6 +939,8 @@ class MatchPadelServiceTest {
 
     @Test
     void getMatchDetailDto_prive_participant_ok() {
+        when(currentUserFacade.isAdmin()).thenReturn(false);
+
         MatchPadel match = mock(MatchPadel.class);
         when(match.getId()).thenReturn(1L);
         when(match.getVisibilite()).thenReturn(MatchVisibilite.PRIVE);
@@ -947,6 +965,7 @@ class MatchPadelServiceTest {
 
         when(joueur.getMatricule()).thenReturn("J0001");
         when(joueur.getNom()).thenReturn("Alice");
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
 
         when(participation.getJoueur()).thenReturn(joueur);
         when(participation.getId()).thenReturn(51L);
@@ -959,7 +978,7 @@ class MatchPadelServiceTest {
         when(paiementRepo.sumMontantByParticipationIdAndType(51L, TypePaiement.ENCAISSEMENT)).thenReturn(BigDecimal.ZERO);
         when(paiementRepo.sumMontantByParticipationIdAndType(51L, TypePaiement.REMBOURSEMENT)).thenReturn(BigDecimal.ZERO);
 
-        MatchDetailDto dto = service.getMatchDetailDto(1L, "J0001");
+        MatchDetailDto dto = service.getMatchDetailDto(1L);
 
         assertEquals(1, dto.getParticipants().size());
         assertEquals("J0001", dto.getParticipants().get(0).getMatricule());
@@ -967,6 +986,9 @@ class MatchPadelServiceTest {
 
     @Test
     void getMatchDetailDto_prive_autreJoueur_refuse() {
+        when(currentUserFacade.isAdmin()).thenReturn(false);
+        stubCurrentJoueur("X9999", TypeJoueur.GLOBAL, BigDecimal.ZERO);
+
         MatchPadel match = mock(MatchPadel.class);
         Joueur orga = mock(Joueur.class);
         Joueur joueur = mock(Joueur.class);
@@ -984,13 +1006,15 @@ class MatchPadelServiceTest {
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.of(match));
 
         assertThrows(ForbiddenException.class,
-                () -> service.getMatchDetailDto(1L, "X9999"));
+                () -> service.getMatchDetailDto(1L));
 
         verify(paiementRepo, never()).sumMontantByParticipationIdAndType(anyLong(), any());
     }
 
     @Test
     void getMatchDetailDto_matchAnnule_exposeStatut_et_montantRembourse() {
+        stubCurrentJoueur("G0009", TypeJoueur.GLOBAL, BigDecimal.ZERO);
+
         MatchPadel match = mock(MatchPadel.class);
         when(match.getId()).thenReturn(1L);
         when(match.getVisibilite()).thenReturn(MatchVisibilite.PUBLIC);
@@ -1008,6 +1032,7 @@ class MatchPadelServiceTest {
         when(terrain.getSite()).thenReturn(site);
         when(orga.getMatricule()).thenReturn("G0001");
         when(orga.getNom()).thenReturn("Orga");
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
 
         when(match.getTerrain()).thenReturn(terrain);
         when(match.getOrganisateur()).thenReturn(orga);
@@ -1025,7 +1050,7 @@ class MatchPadelServiceTest {
         when(paiementRepo.sumMontantByParticipationIdAndType(61L, TypePaiement.REMBOURSEMENT))
                 .thenReturn(new BigDecimal("-20.00"));
 
-        MatchDetailDto dto = service.getMatchDetailDto(1L, null);
+        MatchDetailDto dto = service.getMatchDetailDto(1L);
 
         assertEquals(MatchStatut.ANNULE, dto.getStatut());
         assertEquals(new BigDecimal("15.00"), dto.getMontantPaye());
@@ -1035,10 +1060,12 @@ class MatchPadelServiceTest {
 
     @Test
     void getMatchDetailDto_introuvable_notFound() {
+        stubCurrentJoueur("G0009", TypeJoueur.GLOBAL, BigDecimal.ZERO);
+
         when(matchRepo.findByIdWithDetails(1L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
-                () -> service.getMatchDetailDto(1L, null));
+                () -> service.getMatchDetailDto(1L));
     }
 
     @Test
@@ -1064,7 +1091,7 @@ class MatchPadelServiceTest {
         when(fermetureSiteService.isDateFermeePourSite(99L, date.toLocalDate())).thenReturn(true);
 
         BusinessException ex = assertThrows(BusinessException.class, () ->
-                service.creerMatch(1L, "G0001", date, MatchVisibilite.PUBLIC));
+                service.creerMatch(1L, date, MatchVisibilite.PUBLIC));
 
         assertTrue(ex.getMessage().toLowerCase().contains("site"));
         verify(fermetureSiteService).isDateFermeePourSite(99L, date.toLocalDate());

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/PaiementServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/PaiementServiceTest.java
@@ -1,6 +1,7 @@
 package be.ephec.padel.backend.unit.service;
 
 import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.ForbiddenException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
@@ -10,10 +11,11 @@ import be.ephec.padel.backend.model.entities.Site;
 import be.ephec.padel.backend.model.entities.Terrain;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
-import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
 import be.ephec.padel.backend.service.PaiementService;
 import be.ephec.padel.backend.service.SoldeService;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,15 +28,22 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class PaiementServiceTest {
 
     private PaiementRepository paiementRepo;
     private ParticipationRepository participationRepo;
     private SoldeService soldeService;
+    private CurrentUserFacade currentUserFacade;
     private Clock clock;
 
     private PaiementService service;
@@ -44,14 +53,18 @@ class PaiementServiceTest {
         paiementRepo = mock(PaiementRepository.class);
         participationRepo = mock(ParticipationRepository.class);
         soldeService = mock(SoldeService.class);
+        currentUserFacade = mock(CurrentUserFacade.class);
         clock = Clock.fixed(Instant.parse("2030-01-01T09:00:00Z"), ZoneOffset.UTC);
 
-        service = new PaiementService(paiementRepo, participationRepo, soldeService, clock);
+        service = new PaiementService(paiementRepo, participationRepo, soldeService, clock, currentUserFacade);
     }
 
-    // ----------------
-    // payerParticipation
-    // ----------------
+    private Joueur stubCurrentJoueur(String matricule) {
+        Joueur joueur = mock(Joueur.class);
+        when(joueur.getMatricule()).thenReturn(matricule);
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
+        return joueur;
+    }
 
     @Test
     void payerParticipation_participationIntrouvable_notFound() {
@@ -63,9 +76,25 @@ class PaiementServiceTest {
     }
 
     @Test
+    void payerParticipation_refuse_si_joueur_courant_non_proprietaire() {
+        Participation participation = mock(Participation.class);
+        Joueur participant = mock(Joueur.class);
+        when(participant.getMatricule()).thenReturn("G2");
+        when(participation.getJoueur()).thenReturn(participant);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(participation));
+        stubCurrentJoueur("G1");
+
+        assertThrows(ForbiddenException.class, () -> service.payerParticipation(1L, new BigDecimal("5.00")));
+
+        verifyNoInteractions(paiementRepo, soldeService);
+    }
+
+    @Test
     void payerParticipation_montantNull_refuse() {
-        Participation p = mock(Participation.class);
-        when(participationRepo.findById(1L)).thenReturn(Optional.of(p));
+        Participation participation = mock(Participation.class);
+        Joueur joueur = stubCurrentJoueur("G1");
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(participation));
 
         assertThrows(BusinessException.class, () -> service.payerParticipation(1L, null));
 
@@ -74,8 +103,10 @@ class PaiementServiceTest {
 
     @Test
     void payerParticipation_montantNegatifOuZero_refuse() {
-        Participation p = mock(Participation.class);
-        when(participationRepo.findById(1L)).thenReturn(Optional.of(p));
+        Participation participation = mock(Participation.class);
+        Joueur joueur = stubCurrentJoueur("G1");
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(participation));
 
         assertThrows(BusinessException.class, () -> service.payerParticipation(1L, BigDecimal.ZERO));
         assertThrows(BusinessException.class, () -> service.payerParticipation(1L, new BigDecimal("-1.00")));
@@ -85,11 +116,13 @@ class PaiementServiceTest {
 
     @Test
     void payerParticipation_matchAnnule_refuse() {
-        Participation p = mock(Participation.class);
+        Participation participation = mock(Participation.class);
         MatchPadel match = mock(MatchPadel.class);
+        Joueur joueur = stubCurrentJoueur("G1");
         when(match.getStatut()).thenReturn(MatchStatut.ANNULE);
-        when(p.getMatch()).thenReturn(match);
-        when(participationRepo.findById(1L)).thenReturn(Optional.of(p));
+        when(participation.getMatch()).thenReturn(match);
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(participation));
 
         assertThrows(BusinessException.class, () -> service.payerParticipation(1L, new BigDecimal("5.00")));
 
@@ -98,41 +131,36 @@ class PaiementServiceTest {
 
     @Test
     void payerParticipation_dejaPayeTotalement_refuse() {
-        Participation p = mock(Participation.class);
-        when(participationRepo.findById(1L)).thenReturn(Optional.of(p));
-
-        // PART_JOUEUR = 15.00, si dejaPaye >= 15 => reste <= 0
+        Participation participation = mock(Participation.class);
+        Joueur joueur = stubCurrentJoueur("G1");
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(participation));
         when(paiementRepo.sumMontantByParticipationId(1L)).thenReturn(new BigDecimal("15.00"));
 
         assertThrows(BusinessException.class, () -> service.payerParticipation(1L, new BigDecimal("1.00")));
 
-        verify(paiementRepo, never()).save(any(Paiement.class));
         verifyNoInteractions(soldeService);
     }
 
     @Test
     void payerParticipation_paiementTropEleve_refuse() {
-        Participation p = mock(Participation.class);
-        when(participationRepo.findById(1L)).thenReturn(Optional.of(p));
-
-        // deja payé 10 => reste 5
+        Participation participation = mock(Participation.class);
+        Joueur joueur = stubCurrentJoueur("G1");
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(participation));
         when(paiementRepo.sumMontantByParticipationId(1L)).thenReturn(new BigDecimal("10.00"));
 
         assertThrows(BusinessException.class, () -> service.payerParticipation(1L, new BigDecimal("6.00")));
 
-        verify(paiementRepo, never()).save(any(Paiement.class));
         verifyNoInteractions(soldeService);
     }
 
     @Test
     void payerParticipation_ok_dejaPayeNull_considererZero_et_crediter() {
-        Participation p = mock(Participation.class);
-        when(participationRepo.findById(1L)).thenReturn(Optional.of(p));
-
-        Joueur j = mock(Joueur.class);
-        when(j.getMatricule()).thenReturn("G1");
-        when(p.getJoueur()).thenReturn(j);
-
+        Participation participation = mock(Participation.class);
+        Joueur joueur = stubCurrentJoueur("G1");
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(participation));
         when(paiementRepo.sumMontantByParticipationId(1L)).thenReturn(null);
 
         Paiement saved = mock(Paiement.class);
@@ -150,14 +178,10 @@ class PaiementServiceTest {
 
     @Test
     void payerParticipation_ok_paiementPartiel_et_crediter() {
-        Participation p = mock(Participation.class);
-        when(participationRepo.findById(1L)).thenReturn(Optional.of(p));
-
-        Joueur j = mock(Joueur.class);
-        when(j.getMatricule()).thenReturn("G1");
-        when(p.getJoueur()).thenReturn(j);
-
-        // deja payé 7.50 => reste 7.50
+        Participation participation = mock(Participation.class);
+        Joueur joueur = stubCurrentJoueur("G1");
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(participation));
         when(paiementRepo.sumMontantByParticipationId(1L)).thenReturn(new BigDecimal("7.50"));
 
         Paiement saved = mock(Paiement.class);
@@ -175,19 +199,15 @@ class PaiementServiceTest {
 
     @Test
     void payerParticipation_arrondi_scale2() {
-        Participation p = mock(Participation.class);
-        when(participationRepo.findById(1L)).thenReturn(Optional.of(p));
-
-        Joueur j = mock(Joueur.class);
-        when(j.getMatricule()).thenReturn("G1");
-        when(p.getJoueur()).thenReturn(j);
-
+        Participation participation = mock(Participation.class);
+        Joueur joueur = stubCurrentJoueur("G1");
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(participation));
         when(paiementRepo.sumMontantByParticipationId(1L)).thenReturn(BigDecimal.ZERO);
 
         Paiement saved = mock(Paiement.class);
         when(paiementRepo.save(any(Paiement.class))).thenReturn(saved);
 
-        // 5.1 doit devenir 5.10
         Paiement result = service.payerParticipation(1L, new BigDecimal("5.1"));
 
         assertSame(saved, result);
@@ -196,51 +216,6 @@ class PaiementServiceTest {
                         && paiement.getMontant().compareTo(new BigDecimal("5.10")) == 0
         ));
         verify(soldeService).crediter("G1", new BigDecimal("5.10"));
-    }
-
-    // ----------------
-    // payerPourMatch
-    // ----------------
-
-    @Test
-    void payerPourMatch_participationIntrouvable_notFound() {
-        when(participationRepo.findByMatch_IdAndJoueur_Matricule(10L, "G1"))
-                .thenReturn(Optional.empty());
-
-        assertThrows(NotFoundException.class,
-                () -> service.payerPourMatch(10L, "G1", new BigDecimal("5.00")));
-
-        verifyNoInteractions(paiementRepo, soldeService);
-    }
-
-    @Test
-    void payerPourMatch_ok_appelle_payerParticipation() {
-        Participation p = mock(Participation.class);
-        when(p.getId()).thenReturn(77L);
-
-        when(participationRepo.findByMatch_IdAndJoueur_Matricule(10L, "G1"))
-                .thenReturn(Optional.of(p));
-
-        // pour payerParticipation : il faut que findById(77) renvoie la même participation
-        when(participationRepo.findById(77L)).thenReturn(Optional.of(p));
-
-        Joueur j = mock(Joueur.class);
-        when(j.getMatricule()).thenReturn("G1");
-        when(p.getJoueur()).thenReturn(j);
-
-        when(paiementRepo.sumMontantByParticipationId(77L)).thenReturn(BigDecimal.ZERO);
-
-        Paiement saved = mock(Paiement.class);
-        when(paiementRepo.save(any(Paiement.class))).thenReturn(saved);
-
-        Paiement result = service.payerPourMatch(10L, "G1", new BigDecimal("5.00"));
-
-        assertSame(saved, result);
-        verify(paiementRepo).save(argThat(paiement ->
-                paiement.getType() == TypePaiement.ENCAISSEMENT
-                        && paiement.getMontant().compareTo(new BigDecimal("5.00")) == 0
-        ));
-        verify(soldeService).crediter("G1", new BigDecimal("5.00"));
     }
 
     @Test

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceMontantAttenduTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceMontantAttenduTest.java
@@ -9,6 +9,7 @@ import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
 import be.ephec.padel.backend.service.PaiementService;
 import be.ephec.padel.backend.service.ParticipationService;
 import be.ephec.padel.backend.service.SoldeService;
@@ -40,6 +41,8 @@ class ParticipationServiceMontantAttenduTest {
     SoldeService soldeService;
     @Mock
     PaiementService paiementService;
+    @Mock
+    CurrentUserFacade currentUserFacade;
 
     private ParticipationService participationService;
 
@@ -50,24 +53,23 @@ class ParticipationServiceMontantAttenduTest {
                 matchPadelRepository,
                 joueurRepository,
                 soldeService,
-                paiementService
+                paiementService,
+                currentUserFacade
         );
     }
 
     @Test
     void montantAttendu_public_sansDette_retourne15() {
         Long matchId = 1L;
-        String mat = "J1";
-
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
 
-        Joueur joueur = new Joueur(mat, "Nom", TypeJoueur.GLOBAL);
+        Joueur joueur = new Joueur("J1", "Nom", TypeJoueur.GLOBAL);
 
         when(matchPadelRepository.findById(matchId)).thenReturn(Optional.of(match));
-        when(joueurRepository.findById(mat)).thenReturn(Optional.of(joueur));
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
 
-        BigDecimal montant = participationService.calculerMontantAttenduPourMatchPublic(matchId, mat);
+        BigDecimal montant = participationService.calculerMontantAttenduPourMatchPublic(matchId);
 
         assertThat(montant).isEqualByComparingTo(Tarifs.PART_PAR_JOUEUR.setScale(2, RoundingMode.HALF_UP));
     }
@@ -75,18 +77,16 @@ class ParticipationServiceMontantAttenduTest {
     @Test
     void montantAttendu_public_avecDette15_retourne30() {
         Long matchId = 2L;
-        String mat = "J2";
-
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
 
-        Joueur joueur = new Joueur(mat, "Nom", TypeJoueur.GLOBAL);
+        Joueur joueur = new Joueur("J2", "Nom", TypeJoueur.GLOBAL);
         joueur.setSolde(new BigDecimal("15.00"));
 
         when(matchPadelRepository.findById(matchId)).thenReturn(Optional.of(match));
-        when(joueurRepository.findById(mat)).thenReturn(Optional.of(joueur));
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
 
-        BigDecimal montant = participationService.calculerMontantAttenduPourMatchPublic(matchId, mat);
+        BigDecimal montant = participationService.calculerMontantAttenduPourMatchPublic(matchId);
 
         assertThat(montant).isEqualByComparingTo(new BigDecimal("30.00"));
     }
@@ -94,14 +94,12 @@ class ParticipationServiceMontantAttenduTest {
     @Test
     void montantAttendu_matchPrive_lanceBusinessException() {
         Long matchId = 3L;
-        String mat = "J3";
-
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PRIVE);
 
         when(matchPadelRepository.findById(matchId)).thenReturn(Optional.of(match));
 
-        assertThatThrownBy(() -> participationService.calculerMontantAttenduPourMatchPublic(matchId, mat))
+        assertThatThrownBy(() -> participationService.calculerMontantAttenduPourMatchPublic(matchId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Match prive");
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceRejoindrePublicTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceRejoindrePublicTest.java
@@ -10,6 +10,7 @@ import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
 import be.ephec.padel.backend.service.PaiementService;
 import be.ephec.padel.backend.service.ParticipationService;
 import be.ephec.padel.backend.service.SoldeService;
@@ -45,6 +46,8 @@ class ParticipationServiceRejoindrePublicTest {
     SoldeService soldeService;
     @Mock
     PaiementService paiementService;
+    @Mock
+    CurrentUserFacade currentUserFacade;
 
     private ParticipationService participationService;
 
@@ -55,27 +58,26 @@ class ParticipationServiceRejoindrePublicTest {
                 matchPadelRepository,
                 joueurRepository,
                 soldeService,
-                paiementService
+                paiementService,
+                currentUserFacade
         );
     }
 
     @Test
     void rejoindrePublic_avecDette15_paie30_et_debite15() {
         Long matchId = 10L;
-        String mat = "J1";
-
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
         match.setDateDebut(LocalDateTime.now());
 
-        Joueur joueur = new Joueur(mat, "Nom", TypeJoueur.GLOBAL);
+        Joueur joueur = new Joueur("J1", "Nom", TypeJoueur.GLOBAL);
         joueur.setSolde(new BigDecimal("15.00"));
 
         when(matchPadelRepository.findByIdForUpdateWithParticipations(matchId))
                 .thenReturn(Optional.of(match));
-        when(joueurRepository.findById(mat))
-                .thenReturn(Optional.of(joueur));
-        when(participationRepository.existsByMatch_IdAndJoueur_Matricule(matchId, mat))
+        when(currentUserFacade.getCurrentJoueur())
+                .thenReturn(joueur);
+        when(participationRepository.existsByMatch_IdAndJoueur_Matricule(matchId, "J1"))
                 .thenReturn(false);
         when(participationRepository.save(any(Participation.class)))
                 .thenAnswer(inv -> {
@@ -84,18 +86,16 @@ class ParticipationServiceRejoindrePublicTest {
                     return p;
                 });
 
-        Participation saved = participationService.rejoindreEtPayerMatchPublic(matchId, mat);
+        Participation saved = participationService.rejoindreEtPayerMatchPublic(matchId);
 
         assertThat(saved).isNotNull();
-        verify(soldeService).debiter(eq(mat), eq(Tarifs.PART_PAR_JOUEUR));
+        verify(soldeService).debiter(eq("J1"), eq(Tarifs.PART_PAR_JOUEUR));
         verify(paiementService).payerParticipationAvecRattrapageDette(eq(99L), eq(new BigDecimal("30.00")));
     }
 
     @Test
     void rejoindrePublic_matchDejaComplet_refuse() {
         Long matchId = 11L;
-        String mat = "J2";
-
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
         match.getParticipations().add(new Participation());
@@ -105,12 +105,12 @@ class ParticipationServiceRejoindrePublicTest {
 
         when(matchPadelRepository.findByIdForUpdateWithParticipations(matchId))
                 .thenReturn(Optional.of(match));
-        when(joueurRepository.findById(mat))
-                .thenReturn(Optional.of(new Joueur(mat, "Nom", TypeJoueur.GLOBAL)));
-        when(participationRepository.existsByMatch_IdAndJoueur_Matricule(matchId, mat))
+        when(currentUserFacade.getCurrentJoueur())
+                .thenReturn(new Joueur("J2", "Nom", TypeJoueur.GLOBAL));
+        when(participationRepository.existsByMatch_IdAndJoueur_Matricule(matchId, "J2"))
                 .thenReturn(false);
 
-        assertThatThrownBy(() -> participationService.rejoindreEtPayerMatchPublic(matchId, mat))
+        assertThatThrownBy(() -> participationService.rejoindreEtPayerMatchPublic(matchId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Match deja complet");
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceTest.java
@@ -12,6 +12,7 @@ import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
 import be.ephec.padel.backend.service.PaiementService;
 import be.ephec.padel.backend.service.ParticipationService;
 import be.ephec.padel.backend.service.SoldeService;
@@ -23,9 +24,17 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class ParticipationServiceTest {
 
@@ -34,6 +43,7 @@ class ParticipationServiceTest {
     private JoueurRepository joueurRepo;
     private SoldeService soldeService;
     private PaiementService paiementService;
+    private CurrentUserFacade currentUserFacade;
 
     private ParticipationService service;
 
@@ -44,20 +54,30 @@ class ParticipationServiceTest {
         joueurRepo = mock(JoueurRepository.class);
         soldeService = mock(SoldeService.class);
         paiementService = mock(PaiementService.class);
+        currentUserFacade = mock(CurrentUserFacade.class);
 
-        service = new ParticipationService(participationRepo, matchRepo, joueurRepo, soldeService, paiementService);
+        service = new ParticipationService(
+                participationRepo,
+                matchRepo,
+                joueurRepo,
+                soldeService,
+                paiementService,
+                currentUserFacade
+        );
     }
 
-    // -----------------------------------
-    // calculerMontantAttenduPourMatchPublic
-    // -----------------------------------
+    private Joueur stubCurrentJoueur(String matricule) {
+        Joueur joueur = new Joueur(matricule, "Nom", TypeJoueur.GLOBAL);
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
+        return joueur;
+    }
 
     @Test
     void calculerMontantAttendu_matchIntrouvable_notFound() {
         when(matchRepo.findById(1L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
-                () -> service.calculerMontantAttenduPourMatchPublic(1L, "G1"));
+                () -> service.calculerMontantAttenduPourMatchPublic(1L));
 
         verifyNoInteractions(joueurRepo);
     }
@@ -70,7 +90,7 @@ class ParticipationServiceTest {
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
 
         assertThrows(BusinessException.class,
-                () -> service.calculerMontantAttenduPourMatchPublic(1L, "G1"));
+                () -> service.calculerMontantAttenduPourMatchPublic(1L));
 
         verifyNoInteractions(joueurRepo);
     }
@@ -84,7 +104,7 @@ class ParticipationServiceTest {
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
 
         assertThrows(BusinessException.class,
-                () -> service.calculerMontantAttenduPourMatchPublic(1L, "G1"));
+                () -> service.calculerMontantAttenduPourMatchPublic(1L));
 
         verifyNoInteractions(joueurRepo);
     }
@@ -94,15 +114,14 @@ class ParticipationServiceTest {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
 
-        Joueur joueur = new Joueur("G1", "Nom", TypeJoueur.GLOBAL);
-        // solde par défaut: 0
+        Joueur joueur = stubCurrentJoueur("G1");
 
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
-        when(joueurRepo.findById("G1")).thenReturn(Optional.of(joueur));
 
-        BigDecimal montant = service.calculerMontantAttenduPourMatchPublic(1L, "G1");
+        BigDecimal montant = service.calculerMontantAttenduPourMatchPublic(1L);
 
         assertEquals(new BigDecimal("15.00"), montant);
+        assertEquals(BigDecimal.ZERO, joueur.getSolde());
     }
 
     @Test
@@ -110,27 +129,22 @@ class ParticipationServiceTest {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
 
-        Joueur joueur = new Joueur("G1", "Nom", TypeJoueur.GLOBAL);
-        joueur.setSolde(new BigDecimal("15.00")); // dette
+        Joueur joueur = stubCurrentJoueur("G1");
+        joueur.setSolde(new BigDecimal("15.00"));
 
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
-        when(joueurRepo.findById("G1")).thenReturn(Optional.of(joueur));
 
-        BigDecimal montant = service.calculerMontantAttenduPourMatchPublic(1L, "G1");
+        BigDecimal montant = service.calculerMontantAttenduPourMatchPublic(1L);
 
         assertEquals(new BigDecimal("30.00"), montant);
     }
-
-    // -------------------------
-    // rejoindreEtPayerMatchPublic
-    // -------------------------
 
     @Test
     void rejoindreEtPayerMatchPublic_matchIntrouvable_notFound() {
         when(matchRepo.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
-                () -> service.rejoindreEtPayerMatchPublic(1L, "G1"));
+                () -> service.rejoindreEtPayerMatchPublic(1L));
 
         verifyNoInteractions(joueurRepo, participationRepo, soldeService, paiementService);
     }
@@ -143,7 +157,7 @@ class ParticipationServiceTest {
         when(matchRepo.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
 
         assertThrows(BusinessException.class,
-                () -> service.rejoindreEtPayerMatchPublic(1L, "G1"));
+                () -> service.rejoindreEtPayerMatchPublic(1L));
 
         verifyNoInteractions(joueurRepo, participationRepo, soldeService, paiementService);
     }
@@ -157,23 +171,9 @@ class ParticipationServiceTest {
         when(matchRepo.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
 
         assertThrows(BusinessException.class,
-                () -> service.rejoindreEtPayerMatchPublic(1L, "G1"));
+                () -> service.rejoindreEtPayerMatchPublic(1L));
 
         verifyNoInteractions(joueurRepo, participationRepo, soldeService, paiementService);
-    }
-
-    @Test
-    void rejoindreEtPayerMatchPublic_joueurIntrouvable_notFound() {
-        MatchPadel match = new MatchPadel();
-        match.setVisibilite(MatchVisibilite.PUBLIC);
-
-        when(matchRepo.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
-        when(joueurRepo.findById("G1")).thenReturn(Optional.empty());
-
-        assertThrows(NotFoundException.class,
-                () -> service.rejoindreEtPayerMatchPublic(1L, "G1"));
-
-        verifyNoInteractions(participationRepo, soldeService, paiementService);
     }
 
     @Test
@@ -181,14 +181,13 @@ class ParticipationServiceTest {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
 
-        Joueur joueur = new Joueur("G1", "Nom", TypeJoueur.GLOBAL);
+        Joueur joueur = stubCurrentJoueur("G1");
 
         when(matchRepo.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
-        when(joueurRepo.findById("G1")).thenReturn(Optional.of(joueur));
-        when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, "G1")).thenReturn(true);
+        when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, joueur.getMatricule())).thenReturn(true);
 
         assertThrows(BusinessException.class,
-                () -> service.rejoindreEtPayerMatchPublic(1L, "G1"));
+                () -> service.rejoindreEtPayerMatchPublic(1L));
 
         verify(participationRepo, never()).save(any());
         verifyNoInteractions(soldeService, paiementService);
@@ -199,21 +198,18 @@ class ParticipationServiceTest {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
         match.setDateDebut(LocalDateTime.now());
-
-        // 4 participations => complet
         match.getParticipations().add(new Participation());
         match.getParticipations().add(new Participation());
         match.getParticipations().add(new Participation());
         match.getParticipations().add(new Participation());
 
-        Joueur joueur = new Joueur("G1", "Nom", TypeJoueur.GLOBAL);
+        Joueur joueur = stubCurrentJoueur("G1");
 
         when(matchRepo.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
-        when(joueurRepo.findById("G1")).thenReturn(Optional.of(joueur));
-        when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, "G1")).thenReturn(false);
+        when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, joueur.getMatricule())).thenReturn(false);
 
         assertThrows(BusinessException.class,
-                () -> service.rejoindreEtPayerMatchPublic(1L, "G1"));
+                () -> service.rejoindreEtPayerMatchPublic(1L));
 
         verify(participationRepo, never()).save(any());
         verifyNoInteractions(soldeService, paiementService);
@@ -224,21 +220,18 @@ class ParticipationServiceTest {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
 
-        Joueur joueur = new Joueur("G1", "Nom", TypeJoueur.GLOBAL);
-        // dette = 0
+        Joueur joueur = stubCurrentJoueur("G1");
 
         when(matchRepo.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
-        when(joueurRepo.findById("G1")).thenReturn(Optional.of(joueur));
-        when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, "G1")).thenReturn(false);
-
+        when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, joueur.getMatricule())).thenReturn(false);
         when(participationRepo.save(any(Participation.class)))
                 .thenAnswer(inv -> {
-                    Participation p = inv.getArgument(0);
-                    ReflectionTestUtils.setField(p, "id", 99L);
-                    return p;
+                    Participation participation = inv.getArgument(0);
+                    ReflectionTestUtils.setField(participation, "id", 99L);
+                    return participation;
                 });
 
-        Participation result = service.rejoindreEtPayerMatchPublic(1L, "G1");
+        Participation result = service.rejoindreEtPayerMatchPublic(1L);
         assertNotNull(result);
 
         verify(soldeService).debiter(eq("G1"), eq(Tarifs.PART_PAR_JOUEUR));
@@ -250,37 +243,31 @@ class ParticipationServiceTest {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PUBLIC);
 
-        Joueur joueur = new Joueur("G1", "Nom", TypeJoueur.GLOBAL);
-        joueur.setSolde(new BigDecimal("15.00")); // dette existante
+        Joueur joueur = stubCurrentJoueur("G1");
+        joueur.setSolde(new BigDecimal("15.00"));
 
         when(matchRepo.findByIdForUpdateWithParticipations(1L)).thenReturn(Optional.of(match));
-        when(joueurRepo.findById("G1")).thenReturn(Optional.of(joueur));
-        when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, "G1")).thenReturn(false);
-
+        when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, joueur.getMatricule())).thenReturn(false);
         when(participationRepo.save(any(Participation.class)))
                 .thenAnswer(inv -> {
-                    Participation p = inv.getArgument(0);
-                    ReflectionTestUtils.setField(p, "id", 100L);
-                    return p;
+                    Participation participation = inv.getArgument(0);
+                    ReflectionTestUtils.setField(participation, "id", 100L);
+                    return participation;
                 });
 
-        Participation result = service.rejoindreEtPayerMatchPublic(1L, "G1");
+        Participation result = service.rejoindreEtPayerMatchPublic(1L);
         assertNotNull(result);
 
         verify(soldeService).debiter(eq("G1"), eq(Tarifs.PART_PAR_JOUEUR));
         verify(paiementService).payerParticipationAvecRattrapageDette(eq(100L), eq(new BigDecimal("30.00")));
     }
 
-    // -------------------------
-    // ajouterJoueurParOrganisateur
-    // -------------------------
-
     @Test
     void ajouterJoueurParOrganisateur_matchIntrouvable_notFound() {
         when(matchRepo.findById(1L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
-                () -> service.ajouterJoueurParOrganisateur(1L, "G1", "G2"));
+                () -> service.ajouterJoueurParOrganisateur(1L, "G2"));
 
         verifyNoInteractions(joueurRepo, participationRepo, soldeService, paiementService);
     }
@@ -293,7 +280,7 @@ class ParticipationServiceTest {
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
 
         assertThrows(BusinessException.class,
-                () -> service.ajouterJoueurParOrganisateur(1L, "G1", "G2"));
+                () -> service.ajouterJoueurParOrganisateur(1L, "G2"));
 
         verifyNoInteractions(joueurRepo, participationRepo, soldeService, paiementService);
     }
@@ -307,7 +294,7 @@ class ParticipationServiceTest {
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
 
         assertThrows(BusinessException.class,
-                () -> service.ajouterJoueurParOrganisateur(1L, "G1", "G2"));
+                () -> service.ajouterJoueurParOrganisateur(1L, "G2"));
 
         verifyNoInteractions(joueurRepo, participationRepo, soldeService, paiementService);
     }
@@ -316,14 +303,13 @@ class ParticipationServiceTest {
     void ajouterJoueurParOrganisateur_organisateurDifferent_refuse() {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PRIVE);
+        match.setOrganisateur(new Joueur("G999", "Orga", TypeJoueur.GLOBAL));
 
-        Joueur orga = new Joueur("G999", "Orga", TypeJoueur.GLOBAL);
-        match.setOrganisateur(orga);
-
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(new Joueur("G1", "Current", TypeJoueur.GLOBAL));
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
 
         assertThrows(BusinessException.class,
-                () -> service.ajouterJoueurParOrganisateur(1L, "G1", "G2"));
+                () -> service.ajouterJoueurParOrganisateur(1L, "G2"));
 
         verifyNoInteractions(joueurRepo, participationRepo, soldeService, paiementService);
     }
@@ -332,15 +318,15 @@ class ParticipationServiceTest {
     void ajouterJoueurParOrganisateur_joueurAAjouterIntrouvable_notFound() {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PRIVE);
-
         Joueur orga = new Joueur("G1", "Orga", TypeJoueur.GLOBAL);
         match.setOrganisateur(orga);
 
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
         when(joueurRepo.findById("G2")).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
-                () -> service.ajouterJoueurParOrganisateur(1L, "G1", "G2"));
+                () -> service.ajouterJoueurParOrganisateur(1L, "G2"));
 
         verifyNoInteractions(participationRepo, soldeService, paiementService);
     }
@@ -349,19 +335,16 @@ class ParticipationServiceTest {
     void ajouterJoueurParOrganisateur_dejaInscrit_refuse() {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PRIVE);
-
         Joueur orga = new Joueur("G1", "Orga", TypeJoueur.GLOBAL);
         match.setOrganisateur(orga);
 
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
-
-        Joueur joueur = new Joueur("G2", "Joueur", TypeJoueur.GLOBAL);
-        when(joueurRepo.findById("G2")).thenReturn(Optional.of(joueur));
-
+        when(joueurRepo.findById("G2")).thenReturn(Optional.of(new Joueur("G2", "Joueur", TypeJoueur.GLOBAL)));
         when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, "G2")).thenReturn(true);
 
         assertThrows(BusinessException.class,
-                () -> service.ajouterJoueurParOrganisateur(1L, "G1", "G2"));
+                () -> service.ajouterJoueurParOrganisateur(1L, "G2"));
 
         verify(participationRepo, never()).save(any());
         verifyNoInteractions(soldeService, paiementService);
@@ -371,20 +354,17 @@ class ParticipationServiceTest {
     void ajouterJoueurParOrganisateur_matchComplet_refuse() {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PRIVE);
-
         Joueur orga = new Joueur("G1", "Orga", TypeJoueur.GLOBAL);
         match.setOrganisateur(orga);
 
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
-
-        Joueur joueur = new Joueur("G2", "Joueur", TypeJoueur.GLOBAL);
-        when(joueurRepo.findById("G2")).thenReturn(Optional.of(joueur));
-
+        when(joueurRepo.findById("G2")).thenReturn(Optional.of(new Joueur("G2", "Joueur", TypeJoueur.GLOBAL)));
         when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, "G2")).thenReturn(false);
         when(participationRepo.countByMatch_Id(1L)).thenReturn(4);
 
         assertThrows(BusinessException.class,
-                () -> service.ajouterJoueurParOrganisateur(1L, "G1", "G2"));
+                () -> service.ajouterJoueurParOrganisateur(1L, "G2"));
 
         verify(participationRepo, never()).save(any());
         verifyNoInteractions(soldeService, paiementService);
@@ -394,25 +374,21 @@ class ParticipationServiceTest {
     void ajouterJoueurParOrganisateur_ok_creeParticipation_et_debite_sans_payer() {
         MatchPadel match = new MatchPadel();
         match.setVisibilite(MatchVisibilite.PRIVE);
-
         Joueur orga = new Joueur("G1", "Orga", TypeJoueur.GLOBAL);
         match.setOrganisateur(orga);
 
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(orga);
         when(matchRepo.findById(1L)).thenReturn(Optional.of(match));
-
-        Joueur joueur = new Joueur("G2", "Joueur", TypeJoueur.GLOBAL);
-        when(joueurRepo.findById("G2")).thenReturn(Optional.of(joueur));
-
+        when(joueurRepo.findById("G2")).thenReturn(Optional.of(new Joueur("G2", "Joueur", TypeJoueur.GLOBAL)));
         when(participationRepo.existsByMatch_IdAndJoueur_Matricule(1L, "G2")).thenReturn(false);
         when(participationRepo.countByMatch_Id(1L)).thenReturn(1);
 
         Participation saved = new Participation();
         when(participationRepo.save(any(Participation.class))).thenReturn(saved);
 
-        Participation result = service.ajouterJoueurParOrganisateur(1L, "G1", "G2");
+        Participation result = service.ajouterJoueurParOrganisateur(1L, "G2");
 
         assertSame(saved, result);
-
         verify(participationRepo).save(any(Participation.class));
         verify(soldeService).debiter(eq("G2"), eq(Tarifs.PART_PAR_JOUEUR));
         verifyNoInteractions(paiementService);


### PR DESCRIPTION
- Suppression complète du code de transition (fallback et surcharges legacy)
- Centralisation de l’identité utilisateur via CurrentUserFacade
- Suppression de toute dépendance à une identité fournie par le client
- Nettoyage de la configuration sécurité
- Mise à jour des tests vers le modèle JWT → User → Joueur
- Contrat API nettoyé (aucun paramètre legacy pour l’utilisateur courant)

Les usages restants de "matricule" sont strictement métier et non liés à l’identité du caller.

Validation fonctionnelle et tests OK.