### PR TITLE
feat(issue-89): implémentation du workflow d’inscription utilisateur avec validation administrateur

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
@@ -53,6 +53,8 @@ public class SecurityConfig {
 
                     auth
                             .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
+                            .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").permitAll()
+                            .requestMatchers("/api/v1/admin/inscriptions/**").hasRole("ADMIN_GLOBAL")
                             .requestMatchers("/api/v1/admin/stats/**").hasRole("ADMIN_GLOBAL")
                             .requestMatchers("/api/v1/admin/sites/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")
                             .requestMatchers("/api/v1/admin/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminRegistrationController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminRegistrationController.java
@@ -1,0 +1,40 @@
+package be.ephec.padel.backend.controller;
+
+import be.ephec.padel.backend.dto.request.ValidateRegistrationRequest;
+import be.ephec.padel.backend.dto.response.PendingRegistrationDto;
+import be.ephec.padel.backend.dto.response.RegistrationDecisionResponse;
+import be.ephec.padel.backend.service.AdminRegistrationService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/v1/admin/inscriptions")
+public class AdminRegistrationController {
+
+    private final AdminRegistrationService adminRegistrationService;
+
+    public AdminRegistrationController(AdminRegistrationService adminRegistrationService) {
+        this.adminRegistrationService = adminRegistrationService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PendingRegistrationDto>> listPending() {
+        return ResponseEntity.ok(adminRegistrationService.listPendingRegistrations());
+    }
+
+    @PostMapping("/{userId}/validate")
+    public ResponseEntity<RegistrationDecisionResponse> validate(@PathVariable Long userId,
+                                                                 @Valid @RequestBody ValidateRegistrationRequest request) {
+        return ResponseEntity.ok(adminRegistrationService.validate(userId, request));
+    }
+
+    @PostMapping("/{userId}/reject")
+    public ResponseEntity<RegistrationDecisionResponse> reject(@PathVariable Long userId) {
+        return ResponseEntity.ok(adminRegistrationService.reject(userId));
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AuthController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AuthController.java
@@ -1,26 +1,42 @@
 package be.ephec.padel.backend.controller;
 
 import be.ephec.padel.backend.dto.request.LoginRequest;
+import be.ephec.padel.backend.dto.request.RegisterRequest;
 import be.ephec.padel.backend.dto.response.LoginResponse;
+import be.ephec.padel.backend.dto.response.RegisterResponse;
 import be.ephec.padel.backend.service.AuthenticationService;
+import be.ephec.padel.backend.service.RegistrationService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController {
 
     private final AuthenticationService authenticationService;
+    private final RegistrationService registrationService;
 
-    public AuthController(AuthenticationService authenticationService) {
+    public AuthController(AuthenticationService authenticationService,
+                          RegistrationService registrationService) {
         this.authenticationService = authenticationService;
+        this.registrationService = registrationService;
     }
 
     @SecurityRequirements
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(authenticationService.login(request));
+    }
+
+    @SecurityRequirements
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
+        RegisterResponse response = registrationService.register(request);
+        URI location = URI.create("/api/v1/admin/inscriptions/" + response.getUserId());
+        return ResponseEntity.created(location).body(response);
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/RegisterRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/RegisterRequest.java
@@ -1,0 +1,66 @@
+package be.ephec.padel.backend.dto.request;
+
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class RegisterRequest {
+
+    @NotBlank
+    @Size(max = 100)
+    private String username;
+
+    @NotBlank
+    @Size(max = 255)
+    private String password;
+
+    @NotBlank
+    @Size(max = 255)
+    private String nom;
+
+    @NotNull
+    private TypeJoueur typeAbonnementDemande;
+
+    private Long siteIdDemande;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getNom() {
+        return nom;
+    }
+
+    public void setNom(String nom) {
+        this.nom = nom;
+    }
+
+    public TypeJoueur getTypeAbonnementDemande() {
+        return typeAbonnementDemande;
+    }
+
+    public void setTypeAbonnementDemande(TypeJoueur typeAbonnementDemande) {
+        this.typeAbonnementDemande = typeAbonnementDemande;
+    }
+
+    public Long getSiteIdDemande() {
+        return siteIdDemande;
+    }
+
+    public void setSiteIdDemande(Long siteIdDemande) {
+        this.siteIdDemande = siteIdDemande;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/ValidateRegistrationRequest.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/ValidateRegistrationRequest.java
@@ -1,0 +1,28 @@
+package be.ephec.padel.backend.dto.request;
+
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import jakarta.validation.constraints.NotNull;
+
+public class ValidateRegistrationRequest {
+
+    @NotNull
+    private TypeJoueur typeAbonnementFinal;
+
+    private Long siteIdFinal;
+
+    public TypeJoueur getTypeAbonnementFinal() {
+        return typeAbonnementFinal;
+    }
+
+    public void setTypeAbonnementFinal(TypeJoueur typeAbonnementFinal) {
+        this.typeAbonnementFinal = typeAbonnementFinal;
+    }
+
+    public Long getSiteIdFinal() {
+        return siteIdFinal;
+    }
+
+    public void setSiteIdFinal(Long siteIdFinal) {
+        this.siteIdFinal = siteIdFinal;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PendingRegistrationDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PendingRegistrationDto.java
@@ -1,0 +1,59 @@
+package be.ephec.padel.backend.dto.response;
+
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.UserStatus;
+
+public class PendingRegistrationDto {
+
+    private Long userId;
+    private String username;
+    private String nomDemande;
+    private TypeJoueur typeAbonnementDemande;
+    private Long siteIdDemande;
+    private String siteNomDemande;
+    private UserStatus status;
+
+    public PendingRegistrationDto(Long userId,
+                                  String username,
+                                  String nomDemande,
+                                  TypeJoueur typeAbonnementDemande,
+                                  Long siteIdDemande,
+                                  String siteNomDemande,
+                                  UserStatus status) {
+        this.userId = userId;
+        this.username = username;
+        this.nomDemande = nomDemande;
+        this.typeAbonnementDemande = typeAbonnementDemande;
+        this.siteIdDemande = siteIdDemande;
+        this.siteNomDemande = siteNomDemande;
+        this.status = status;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getNomDemande() {
+        return nomDemande;
+    }
+
+    public TypeJoueur getTypeAbonnementDemande() {
+        return typeAbonnementDemande;
+    }
+
+    public Long getSiteIdDemande() {
+        return siteIdDemande;
+    }
+
+    public String getSiteNomDemande() {
+        return siteNomDemande;
+    }
+
+    public UserStatus getStatus() {
+        return status;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/RegisterResponse.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/RegisterResponse.java
@@ -1,0 +1,37 @@
+package be.ephec.padel.backend.dto.response;
+
+import be.ephec.padel.backend.model.enums.UserStatus;
+
+public class RegisterResponse {
+
+    private Long userId;
+    private String username;
+    private UserStatus status;
+    private String message;
+
+    public RegisterResponse() {
+    }
+
+    public RegisterResponse(Long userId, String username, UserStatus status, String message) {
+        this.userId = userId;
+        this.username = username;
+        this.status = status;
+        this.message = message;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public UserStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/RegistrationDecisionResponse.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/RegistrationDecisionResponse.java
@@ -1,0 +1,69 @@
+package be.ephec.padel.backend.dto.response;
+
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.UserStatus;
+
+public class RegistrationDecisionResponse {
+
+    private Long userId;
+    private String username;
+    private UserStatus status;
+    private String message;
+    private String joueurMatricule;
+    private String joueurNom;
+    private TypeJoueur joueurType;
+    private Long joueurSiteId;
+
+    public RegistrationDecisionResponse() {
+    }
+
+    public RegistrationDecisionResponse(Long userId,
+                                        String username,
+                                        UserStatus status,
+                                        String message,
+                                        String joueurMatricule,
+                                        String joueurNom,
+                                        TypeJoueur joueurType,
+                                        Long joueurSiteId) {
+        this.userId = userId;
+        this.username = username;
+        this.status = status;
+        this.message = message;
+        this.joueurMatricule = joueurMatricule;
+        this.joueurNom = joueurNom;
+        this.joueurType = joueurType;
+        this.joueurSiteId = joueurSiteId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public UserStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getJoueurMatricule() {
+        return joueurMatricule;
+    }
+
+    public String getJoueurNom() {
+        return joueurNom;
+    }
+
+    public TypeJoueur getJoueurType() {
+        return joueurType;
+    }
+
+    public Long getJoueurSiteId() {
+        return joueurSiteId;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/User.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/User.java
@@ -1,6 +1,8 @@
 package be.ephec.padel.backend.model.entities;
 
 import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.UserStatus;
 import jakarta.persistence.*;
 
 import java.util.LinkedHashSet;
@@ -22,6 +24,21 @@ public class User {
 
     @Column(nullable = false)
     private boolean active = true;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserStatus status = UserStatus.ACTIVE;
+
+    @Column(name = "requested_nom", length = 255)
+    private String requestedNom;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "requested_type", length = 20)
+    private TypeJoueur requestedType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requested_site_id")
+    private Site requestedSite;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "joueur_id", referencedColumnName = "id")
@@ -62,6 +79,38 @@ public class User {
 
     public void setActive(boolean active) {
         this.active = active;
+    }
+
+    public UserStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(UserStatus status) {
+        this.status = status;
+    }
+
+    public String getRequestedNom() {
+        return requestedNom;
+    }
+
+    public void setRequestedNom(String requestedNom) {
+        this.requestedNom = requestedNom;
+    }
+
+    public TypeJoueur getRequestedType() {
+        return requestedType;
+    }
+
+    public void setRequestedType(TypeJoueur requestedType) {
+        this.requestedType = requestedType;
+    }
+
+    public Site getRequestedSite() {
+        return requestedSite;
+    }
+
+    public void setRequestedSite(Site requestedSite) {
+        this.requestedSite = requestedSite;
     }
 
     public Joueur getJoueur() {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/UserStatus.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/UserStatus.java
@@ -1,0 +1,7 @@
+package be.ephec.padel.backend.model.enums;
+
+public enum UserStatus {
+    PENDING,
+    ACTIVE,
+    REJECTED
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/JoueurRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/JoueurRepository.java
@@ -12,6 +12,7 @@ public interface JoueurRepository extends JpaRepository<Joueur, String> {
 
     Optional<Joueur> findById(String matricule); // déjà fourni par JpaRepository
     boolean existsById(String matricule);
+    Optional<Joueur> findFirstByMatriculeStartingWithOrderByMatriculeDesc(String prefix);
     List<Joueur> findBySite_Id(Long siteId);
 
     @Query("""

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/UserRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/UserRepository.java
@@ -1,8 +1,14 @@
 package be.ephec.padel.backend.repository;
 
 import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.UserStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -10,4 +16,16 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByLogin(String login);
 
     boolean existsByLogin(String login);
+
+    List<User> findByStatusOrderByIdAsc(UserStatus status);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select u
+        from User u
+        left join fetch u.requestedSite
+        left join fetch u.joueur
+        where u.id = :id
+    """)
+    Optional<User> findByIdForUpdate(@Param("id") Long id);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminRegistrationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminRegistrationService.java
@@ -1,0 +1,166 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.dto.request.ValidateRegistrationRequest;
+import be.ephec.padel.backend.dto.response.PendingRegistrationDto;
+import be.ephec.padel.backend.dto.response.RegistrationDecisionResponse;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.UserStatus;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.UserRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class AdminRegistrationService {
+
+    private final UserRepository userRepository;
+    private final SiteRepository siteRepository;
+    private final JoueurService joueurService;
+    private final MatriculeGeneratorService matriculeGeneratorService;
+
+    public AdminRegistrationService(UserRepository userRepository,
+                                    SiteRepository siteRepository,
+                                    JoueurService joueurService,
+                                    MatriculeGeneratorService matriculeGeneratorService) {
+        this.userRepository = userRepository;
+        this.siteRepository = siteRepository;
+        this.joueurService = joueurService;
+        this.matriculeGeneratorService = matriculeGeneratorService;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PendingRegistrationDto> listPendingRegistrations() {
+        return userRepository.findByStatusOrderByIdAsc(UserStatus.PENDING).stream()
+                .map(this::toPendingDto)
+                .toList();
+    }
+
+    public RegistrationDecisionResponse validate(Long userId, ValidateRegistrationRequest request) {
+        if (request == null) {
+            throw new BusinessException("Requête de validation obligatoire");
+        }
+
+        User user = getPendingUser(userId);
+        TypeJoueur finalType = request.getTypeAbonnementFinal();
+        if (finalType == null) {
+            throw new BusinessException("Type abonnement final obligatoire");
+        }
+
+        try {
+            Site finalSite = resolveFinalSite(finalType, request.getSiteIdFinal());
+            String matricule = matriculeGeneratorService.generateFor(finalType);
+            Joueur joueur = joueurService.creerJoueur(
+                    matricule,
+                    user.getRequestedNom(),
+                    finalType,
+                    finalSite == null ? null : finalSite.getId()
+            );
+
+            user.setJoueur(joueur);
+            user.setActive(true);
+            user.setStatus(UserStatus.ACTIVE);
+            user.addRole(SecurityRole.ROLE_JOUEUR);
+            userRepository.save(user);
+
+            return new RegistrationDecisionResponse(
+                    user.getId(),
+                    user.getLogin(),
+                    user.getStatus(),
+                    "Inscription validée. Le compte est maintenant actif.",
+                    joueur.getMatricule(),
+                    joueur.getNom(),
+                    joueur.getType(),
+                    joueur.getSite() == null ? null : joueur.getSite().getId()
+            );
+        } catch (DataIntegrityViolationException ex) {
+            throw mapIntegrityViolation(ex);
+        }
+    }
+
+    public RegistrationDecisionResponse reject(Long userId) {
+        User user = getPendingUser(userId);
+        user.setActive(false);
+        user.setStatus(UserStatus.REJECTED);
+        userRepository.save(user);
+
+        return new RegistrationDecisionResponse(
+                user.getId(),
+                user.getLogin(),
+                user.getStatus(),
+                "Inscription refusée. Le compte ne peut pas être utilisé.",
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private User getPendingUser(Long userId) {
+        if (userId == null) {
+            throw new BusinessException("UserId obligatoire");
+        }
+
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new NotFoundException("Demande d'inscription introuvable"));
+
+        if (user.getStatus() != UserStatus.PENDING) {
+            throw new BusinessException("Cette demande n'est plus en attente.");
+        }
+
+        return user;
+    }
+
+    private Site resolveFinalSite(TypeJoueur finalType, Long siteIdFinal) {
+        if (finalType == TypeJoueur.SITE) {
+            if (siteIdFinal == null) {
+                throw new BusinessException("Le champ 'siteIdFinal' est obligatoire pour le type SITE.");
+            }
+            return siteRepository.findById(siteIdFinal)
+                    .orElseThrow(() -> new NotFoundException("Site introuvable"));
+        }
+
+        if (siteIdFinal != null) {
+            throw new BusinessException("Le champ 'siteIdFinal' est interdit pour le type " + finalType + ".");
+        }
+
+        return null;
+    }
+
+    private PendingRegistrationDto toPendingDto(User user) {
+        Site requestedSite = user.getRequestedSite();
+        return new PendingRegistrationDto(
+                user.getId(),
+                user.getLogin(),
+                user.getRequestedNom(),
+                user.getRequestedType(),
+                requestedSite == null ? null : requestedSite.getId(),
+                requestedSite == null ? null : requestedSite.getNom(),
+                user.getStatus()
+        );
+    }
+
+    private BusinessException mapIntegrityViolation(DataIntegrityViolationException ex) {
+        String message = ex.getMostSpecificCause() == null ? ex.getMessage() : ex.getMostSpecificCause().getMessage();
+        String normalized = message == null ? "" : message.toLowerCase();
+
+        if (normalized.contains("joueur") && normalized.contains("primary key")) {
+            return new BusinessException("Collision de matricule détectée. Veuillez relancer la validation.");
+        }
+
+        if (normalized.contains("joueur_id")) {
+            return new BusinessException("Un joueur est déjà lié à un autre utilisateur.");
+        }
+
+        return new BusinessException("Erreur d'intégrité lors de la validation de l'inscription.");
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AuthenticationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AuthenticationService.java
@@ -2,11 +2,15 @@ package be.ephec.padel.backend.service;
 
 import be.ephec.padel.backend.dto.request.LoginRequest;
 import be.ephec.padel.backend.dto.response.LoginResponse;
+import be.ephec.padel.backend.exception.ForbiddenException;
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.UserStatus;
+import be.ephec.padel.backend.repository.UserRepository;
 import be.ephec.padel.backend.security.JwtService;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,14 +18,19 @@ public class AuthenticationService {
 
     private final AuthenticationManager authenticationManager;
     private final JwtService jwtService;
+    private final UserRepository userRepository;
 
     public AuthenticationService(AuthenticationManager authenticationManager,
-                                 JwtService jwtService) {
+                                 JwtService jwtService,
+                                 UserRepository userRepository) {
         this.authenticationManager = authenticationManager;
         this.jwtService = jwtService;
+        this.userRepository = userRepository;
     }
 
     public LoginResponse login(LoginRequest request) {
+        precheckUserStatus(request.getUsername());
+
         Authentication authentication = authenticationManager.authenticate(
                 UsernamePasswordAuthenticationToken.unauthenticated(
                         request.getUsername(),
@@ -32,5 +41,24 @@ public class AuthenticationService {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         String token = jwtService.generateToken(userDetails);
         return new LoginResponse(token, "Bearer");
+    }
+
+    private void precheckUserStatus(String username) {
+        if (username == null || username.isBlank()) {
+            return;
+        }
+
+        User user = userRepository.findByLogin(username.trim()).orElse(null);
+        if (user == null) {
+            return;
+        }
+
+        if (user.getStatus() == UserStatus.PENDING) {
+            throw new ForbiddenException("Compte en attente de validation administrateur.");
+        }
+
+        if (user.getStatus() == UserStatus.REJECTED) {
+            throw new ForbiddenException("Demande d'inscription refusée.");
+        }
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatriculeGeneratorService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatriculeGeneratorService.java
@@ -1,0 +1,55 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MatriculeGeneratorService {
+
+    private final JoueurRepository joueurRepository;
+
+    public MatriculeGeneratorService(JoueurRepository joueurRepository) {
+        this.joueurRepository = joueurRepository;
+    }
+
+    public String generateFor(TypeJoueur type) {
+        if (type == null) {
+            throw new BusinessException("Type joueur obligatoire");
+        }
+
+        String prefix = switch (type) {
+            case GLOBAL -> "G";
+            case SITE -> "S";
+            case LIBRE -> "L";
+        };
+
+        int nextNumber = joueurRepository.findFirstByMatriculeStartingWithOrderByMatriculeDesc(prefix)
+                .map(Joueur::getMatricule)
+                .map(this::extractSequence)
+                .map(last -> last + 1)
+                .orElse(1);
+
+        if (nextNumber > 9999) {
+            throw new BusinessException("Plus aucun matricule disponible pour le type " + type);
+        }
+
+        return prefix + String.format("%04d", nextNumber);
+    }
+
+    private int extractSequence(String matricule) {
+        if (matricule == null || matricule.length() != 5) {
+            throw new BusinessException("Matricule existant invalide: " + matricule);
+        }
+
+        try {
+            return Integer.parseInt(matricule.substring(1));
+        } catch (NumberFormatException ex) {
+            throw new BusinessException("Matricule existant invalide: " + matricule);
+        }
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/RegistrationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/RegistrationService.java
@@ -1,0 +1,108 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.dto.request.RegisterRequest;
+import be.ephec.padel.backend.dto.response.RegisterResponse;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.UserStatus;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class RegistrationService {
+
+    private final UserRepository userRepository;
+    private final SiteRepository siteRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public RegistrationService(UserRepository userRepository,
+                               SiteRepository siteRepository,
+                               PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.siteRepository = siteRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public RegisterResponse register(RegisterRequest request) {
+        if (request == null) {
+            throw new BusinessException("Requête d'inscription obligatoire");
+        }
+
+        String username = normalize(request.getUsername(), "Username obligatoire");
+        String password = normalize(request.getPassword(), "Password obligatoire");
+        String nom = normalize(request.getNom(), "Nom obligatoire");
+
+        if (userRepository.existsByLogin(username)) {
+            throw new BusinessException("Username deja utilise");
+        }
+
+        TypeJoueur requestedType = request.getTypeAbonnementDemande();
+        if (requestedType == null) {
+            throw new BusinessException("Type abonnement demande obligatoire");
+        }
+
+        Site requestedSite = resolveSiteForType(
+                requestedType,
+                request.getSiteIdDemande(),
+                "typeAbonnementDemande",
+                "siteIdDemande"
+        );
+
+        User user = new User();
+        user.setLogin(username);
+        user.setPasswordHash(passwordEncoder.encode(password));
+        user.setActive(false);
+        user.setStatus(UserStatus.PENDING);
+        user.setRequestedNom(nom);
+        user.setRequestedType(requestedType);
+        user.setRequestedSite(requestedSite);
+        user.addRole(SecurityRole.ROLE_JOUEUR);
+
+        User savedUser = userRepository.save(user);
+
+        return new RegisterResponse(
+                savedUser.getId(),
+                savedUser.getLogin(),
+                savedUser.getStatus(),
+                "Demande d'inscription en attente de validation administrateur."
+        );
+    }
+
+    private Site resolveSiteForType(TypeJoueur type,
+                                    Long siteId,
+                                    String typeField,
+                                    String siteField) {
+        if (type == TypeJoueur.SITE) {
+            if (siteId == null) {
+                throw new BusinessException("Le champ '" + siteField + "' est obligatoire pour le type SITE.");
+            }
+            return siteRepository.findById(siteId)
+                    .orElseThrow(() -> new NotFoundException("Site introuvable"));
+        }
+
+        if (siteId != null) {
+            throw new BusinessException("Le champ '" + siteField + "' est interdit pour le type " + type + ".");
+        }
+
+        if (type != TypeJoueur.GLOBAL && type != TypeJoueur.LIBRE) {
+            throw new BusinessException("Valeur invalide pour '" + typeField + "'.");
+        }
+
+        return null;
+    }
+
+    private String normalize(String value, String errorMessage) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(errorMessage);
+        }
+        return value.trim();
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/UserBootstrapService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/UserBootstrapService.java
@@ -2,6 +2,7 @@ package be.ephec.padel.backend.service;
 
 import be.ephec.padel.backend.model.entities.User;
 import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.model.enums.UserStatus;
 import be.ephec.padel.backend.repository.UserRepository;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
@@ -84,6 +85,7 @@ public class UserBootstrapService {
         user.setLogin(login);
         user.setPasswordHash(passwordEncoder.encode(rawPassword));
         user.setActive(true);
+        user.setStatus(UserStatus.ACTIVE);
         user.addRole(role);
         userRepository.save(user);
     }

--- a/backend/backend/src/main/resources/db/changelog/008-user-registration.yaml
+++ b/backend/backend/src/main/resources/db/changelog/008-user-registration.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  - changeSet:
+      id: 008-1-add-user-registration-columns
+      author: codex
+      changes:
+        - addColumn:
+            tableName: app_user
+            columns:
+              - column:
+                  name: status
+                  type: varchar(20)
+                  defaultValue: ACTIVE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: requested_nom
+                  type: varchar(255)
+              - column:
+                  name: requested_type
+                  type: varchar(20)
+              - column:
+                  name: requested_site_id
+                  type: bigint
+        - addForeignKeyConstraint:
+            baseTableName: app_user
+            baseColumnNames: requested_site_id
+            referencedTableName: site
+            referencedColumnNames: id
+            constraintName: fk_app_user_requested_site_id
+            onDelete: NO ACTION
+            onUpdate: NO ACTION

--- a/backend/backend/src/main/resources/db/changelog/009-registration-hardening.yaml
+++ b/backend/backend/src/main/resources/db/changelog/009-registration-hardening.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 009-1-add-unique-filtered-index-on-app-user-joueur-id
+      author: codex
+      preConditions:
+        - dbms:
+            type: mssql
+      changes:
+        - sql:
+            dbms: mssql
+            sql: |
+              CREATE UNIQUE INDEX uk_app_user_joueur_id_not_null
+              ON app_user(joueur_id)
+              WHERE joueur_id IS NOT NULL;

--- a/backend/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -13,4 +13,8 @@ databaseChangeLog:
       file: db/changelog/006-type-paiement.yaml
   - include:
       file: db/changelog/007-auth-user.yaml
+  - include:
+      file: db/changelog/008-user-registration.yaml
+  - include:
+      file: db/changelog/009-registration-hardening.yaml
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/integration/RegistrationLifecycleIntegrationTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/integration/RegistrationLifecycleIntegrationTest.java
@@ -1,0 +1,354 @@
+package be.ephec.padel.backend.integration;
+
+import be.ephec.padel.backend.dto.request.ValidateRegistrationRequest;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.UserStatus;
+import be.ephec.padel.backend.repository.FermetureGlobaleRepository;
+import be.ephec.padel.backend.repository.FermetureSiteRepository;
+import be.ephec.padel.backend.repository.HoraireSiteRepository;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.MouvementSoldeRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.repository.UserRepository;
+import be.ephec.padel.backend.service.AdminRegistrationService;
+import be.ephec.padel.backend.support.SqlServerTestContainerConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "app.security.admin.global.username=adminGlobal",
+        "app.security.admin.global.password=test123",
+        "app.security.admin.site.users=",
+        "app.security.admin.site.password=test123"
+})
+class RegistrationLifecycleIntegrationTest extends SqlServerTestContainerConfig {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    SiteRepository siteRepository;
+
+    @Autowired
+    TerrainRepository terrainRepository;
+
+    @Autowired
+    HoraireSiteRepository horaireSiteRepository;
+
+    @Autowired
+    FermetureSiteRepository fermetureSiteRepository;
+
+    @Autowired
+    FermetureGlobaleRepository fermetureGlobaleRepository;
+
+    @Autowired
+    PaiementRepository paiementRepository;
+
+    @Autowired
+    ParticipationRepository participationRepository;
+
+    @Autowired
+    MatchPadelRepository matchPadelRepository;
+
+    @Autowired
+    MouvementSoldeRepository mouvementSoldeRepository;
+
+    @Autowired
+    JoueurRepository joueurRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    AdminRegistrationService adminRegistrationService;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    private Site site;
+
+    @BeforeEach
+    void cleanAndSeed() {
+        cleanupData();
+
+        site = new Site("Site Delta", "Bruxelles");
+        site.setJoursFermeture(Set.of());
+        site = siteRepository.save(site);
+    }
+
+    @AfterEach
+    void cleanupAfterTest() {
+        cleanupData();
+    }
+
+    private void cleanupData() {
+        paiementRepository.deleteAll();
+        participationRepository.deleteAll();
+        matchPadelRepository.deleteAll();
+        mouvementSoldeRepository.deleteAll();
+        fermetureSiteRepository.deleteAll();
+        horaireSiteRepository.deleteAll();
+        terrainRepository.deleteAll();
+        fermetureGlobaleRepository.deleteAll();
+
+        List<User> nonAdminUsers = userRepository.findAll().stream()
+                .filter(user -> user.getRoles().stream().noneMatch(this::isAdminRole))
+                .toList();
+        userRepository.deleteAll(nonAdminUsers);
+
+        joueurRepository.deleteAll();
+        siteRepository.deleteAll();
+    }
+
+    @Test
+    void register_validate_login_et_me_fonctionnent_de_bout_en_bout() throws Exception {
+        MvcResult registerResult = mvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "alice",
+                                  "password": "secret123",
+                                  "nom": "Alice",
+                                  "typeAbonnementDemande": "SITE",
+                                  "siteIdDemande": %d
+                                }
+                                """.formatted(site.getId())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.message").value(containsString("en attente")))
+                .andReturn();
+
+        String registerBody = registerResult.getResponse().getContentAsString();
+        String userId = extractNumericField(registerBody, "userId");
+
+        mvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "alice",
+                                  "password": "secret123"
+                                }
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("Compte en attente de validation administrateur."));
+
+        String adminToken = extractStringField(
+                mvc.perform(post("/api/v1/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "username": "adminGlobal",
+                                          "password": "test123"
+                                        }
+                                        """))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString(),
+                "token"
+        );
+
+        mvc.perform(get("/api/v1/admin/inscriptions")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].username").value("alice"))
+                .andExpect(jsonPath("$[0].typeAbonnementDemande").value("SITE"))
+                .andExpect(jsonPath("$[0].siteIdDemande").value(site.getId()))
+                .andExpect(jsonPath("$[0].siteNomDemande").value("Site Delta"));
+
+        mvc.perform(post("/api/v1/admin/inscriptions/" + userId + "/validate")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "typeAbonnementFinal": "SITE",
+                                  "siteIdFinal": %d
+                                }
+                                """.formatted(site.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.joueurMatricule").value(startsWith("S")))
+                .andExpect(jsonPath("$.joueurNom").value("Alice"))
+                .andExpect(jsonPath("$.joueurType").value("SITE"))
+                .andExpect(jsonPath("$.joueurSiteId").value(site.getId()));
+
+        String playerToken = extractStringField(
+                mvc.perform(post("/api/v1/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "username": "alice",
+                                          "password": "secret123"
+                                        }
+                                        """))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString(),
+                "token"
+        );
+
+        mvc.perform(get("/api/v1/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + playerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nom").value("Alice"))
+                .andExpect(jsonPath("$.type").value("SITE"))
+                .andExpect(jsonPath("$.siteId").value(site.getId()))
+                .andExpect(jsonPath("$.matricule").value(startsWith("S")));
+    }
+
+    @Test
+    void validate_en_concurrence_sur_le_meme_user_ne_valide_qu_une_seule_fois() throws Exception {
+        User user = pendingUser("race-user", "Race User", TypeJoueur.GLOBAL, null);
+        ValidateRegistrationRequest request = new ValidateRegistrationRequest();
+        request.setTypeAbonnementFinal(TypeJoueur.GLOBAL);
+
+        CountDownLatch startGate = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<String> first = executor.submit(() -> runConcurrentValidation(user.getId(), request, startGate));
+            Future<String> second = executor.submit(() -> runConcurrentValidation(user.getId(), request, startGate));
+
+            startGate.countDown();
+
+            List<String> outcomes = new ArrayList<>();
+            outcomes.add(first.get());
+            outcomes.add(second.get());
+
+            assertThat(outcomes).containsExactlyInAnyOrder("SUCCESS", "PENDING_GONE");
+
+            User reloaded = userRepository.findById(user.getId()).orElseThrow();
+            assertThat(reloaded.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(reloaded.isActive()).isTrue();
+            assertThat(reloaded.getJoueur()).isNotNull();
+            assertThat(joueurRepository.findAll()).hasSize(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void un_meme_joueur_ne_peut_pas_etre_lie_a_deux_users() throws Exception {
+        Joueur joueur = joueurRepository.save(new Joueur("G0001", "Linked Player", TypeJoueur.GLOBAL));
+
+        User user1 = new User();
+        user1.setLogin("linked-user-1");
+        user1.setPasswordHash(passwordEncoder.encode("secret123"));
+        user1.setActive(true);
+        user1.setStatus(UserStatus.ACTIVE);
+        user1.addRole(SecurityRole.ROLE_JOUEUR);
+        user1.setJoueur(joueur);
+        userRepository.saveAndFlush(user1);
+
+        User user2 = new User();
+        user2.setLogin("linked-user-2");
+        user2.setPasswordHash(passwordEncoder.encode("secret123"));
+        user2.setActive(true);
+        user2.setStatus(UserStatus.ACTIVE);
+        user2.addRole(SecurityRole.ROLE_JOUEUR);
+        user2.setJoueur(joueur);
+
+        assertThatThrownBy(() -> userRepository.saveAndFlush(user2))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    private boolean isAdminRole(SecurityRole role) {
+        return role == SecurityRole.ROLE_ADMIN_GLOBAL || role == SecurityRole.ROLE_ADMIN_SITE;
+    }
+
+    private User pendingUser(String login, String nom, TypeJoueur requestedType, Site requestedSite) {
+        User user = new User();
+        user.setLogin(login);
+        user.setPasswordHash(passwordEncoder.encode("secret123"));
+        user.setActive(false);
+        user.setStatus(UserStatus.PENDING);
+        user.setRequestedNom(nom);
+        user.setRequestedType(requestedType);
+        user.setRequestedSite(requestedSite);
+        user.addRole(SecurityRole.ROLE_JOUEUR);
+        return userRepository.saveAndFlush(user);
+    }
+
+    private String runConcurrentValidation(Long userId,
+                                           ValidateRegistrationRequest request,
+                                           CountDownLatch startGate) throws Exception {
+        startGate.await();
+        try {
+            adminRegistrationService.validate(userId, request);
+            return "SUCCESS";
+        } catch (BusinessException ex) {
+            if ("Cette demande n'est plus en attente.".equals(ex.getMessage())) {
+                return "PENDING_GONE";
+            }
+            throw ex;
+        }
+    }
+
+    private String extractNumericField(String json, String fieldName) {
+        return extractStringField(json, fieldName);
+    }
+
+    private String extractStringField(String json, String fieldName) {
+        String token = "\"" + fieldName + "\":";
+        int start = json.indexOf(token);
+        if (start < 0) {
+            throw new IllegalStateException("Field not found: " + fieldName);
+        }
+
+        int valueStart = start + token.length();
+        while (valueStart < json.length() && Character.isWhitespace(json.charAt(valueStart))) {
+            valueStart++;
+        }
+
+        if (json.charAt(valueStart) == '"') {
+            int valueEnd = json.indexOf('"', valueStart + 1);
+            return json.substring(valueStart + 1, valueEnd);
+        }
+
+        int valueEnd = valueStart;
+        while (valueEnd < json.length() && Character.isDigit(json.charAt(valueEnd))) {
+            valueEnd++;
+        }
+        return json.substring(valueStart, valueEnd);
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminRegistrationServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminRegistrationServiceTest.java
@@ -1,0 +1,189 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.dto.request.ValidateRegistrationRequest;
+import be.ephec.padel.backend.dto.response.PendingRegistrationDto;
+import be.ephec.padel.backend.dto.response.RegistrationDecisionResponse;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.UserStatus;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.UserRepository;
+import be.ephec.padel.backend.service.AdminRegistrationService;
+import be.ephec.padel.backend.service.JoueurService;
+import be.ephec.padel.backend.service.MatriculeGeneratorService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminRegistrationServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    SiteRepository siteRepository;
+
+    @Mock
+    JoueurService joueurService;
+
+    @Mock
+    MatriculeGeneratorService matriculeGeneratorService;
+
+    @InjectMocks
+    AdminRegistrationService adminRegistrationService;
+
+    @Test
+    void listPendingRegistrations_expose_les_infos_utiles_au_front() throws Exception {
+        Site site = site(3L, "Site Delta");
+        User user = pendingUser(10L, "alice", "Alice", TypeJoueur.SITE);
+        user.setRequestedSite(site);
+
+        when(userRepository.findByStatusOrderByIdAsc(UserStatus.PENDING)).thenReturn(List.of(user));
+
+        List<PendingRegistrationDto> result = adminRegistrationService.listPendingRegistrations();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getUserId()).isEqualTo(10L);
+        assertThat(result.getFirst().getUsername()).isEqualTo("alice");
+        assertThat(result.getFirst().getNomDemande()).isEqualTo("Alice");
+        assertThat(result.getFirst().getTypeAbonnementDemande()).isEqualTo(TypeJoueur.SITE);
+        assertThat(result.getFirst().getSiteIdDemande()).isEqualTo(3L);
+        assertThat(result.getFirst().getSiteNomDemande()).isEqualTo("Site Delta");
+    }
+
+    @Test
+    void validate_cree_le_joueur_lie_le_user_et_active_le_compte() throws Exception {
+        User user = pendingUser(10L, "alice", "Alice", TypeJoueur.GLOBAL);
+        Site site = site(7L, "Site Final");
+        Joueur joueur = new Joueur("S0007", "Alice", TypeJoueur.SITE, site);
+
+        ValidateRegistrationRequest request = new ValidateRegistrationRequest();
+        request.setTypeAbonnementFinal(TypeJoueur.SITE);
+        request.setSiteIdFinal(7L);
+
+        when(userRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(user));
+        when(siteRepository.findById(7L)).thenReturn(Optional.of(site));
+        when(matriculeGeneratorService.generateFor(TypeJoueur.SITE)).thenReturn("S0007");
+        when(joueurService.creerJoueur("S0007", "Alice", TypeJoueur.SITE, 7L)).thenReturn(joueur);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RegistrationDecisionResponse response = adminRegistrationService.validate(10L, request);
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        User savedUser = captor.getValue();
+
+        assertThat(savedUser.isActive()).isTrue();
+        assertThat(savedUser.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(savedUser.getJoueur()).isSameAs(joueur);
+
+        assertThat(response.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(response.getJoueurMatricule()).isEqualTo("S0007");
+        assertThat(response.getJoueurType()).isEqualTo(TypeJoueur.SITE);
+        assertThat(response.getJoueurSiteId()).isEqualTo(7L);
+    }
+
+    @Test
+    void reject_conserve_le_user_et_le_passe_en_rejected() throws Exception {
+        User user = pendingUser(11L, "bob", "Bob", TypeJoueur.LIBRE);
+        when(userRepository.findByIdForUpdate(11L)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RegistrationDecisionResponse response = adminRegistrationService.reject(11L);
+
+        assertThat(user.isActive()).isFalse();
+        assertThat(user.getStatus()).isEqualTo(UserStatus.REJECTED);
+        assertThat(response.getStatus()).isEqualTo(UserStatus.REJECTED);
+        assertThat(response.getMessage()).contains("refusée");
+    }
+
+    @Test
+    void validate_refuse_si_la_demande_n_est_plus_pending() throws Exception {
+        User user = pendingUser(12L, "charlie", "Charlie", TypeJoueur.GLOBAL);
+        user.setStatus(UserStatus.REJECTED);
+
+        ValidateRegistrationRequest request = new ValidateRegistrationRequest();
+        request.setTypeAbonnementFinal(TypeJoueur.GLOBAL);
+
+        when(userRepository.findByIdForUpdate(12L)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> adminRegistrationService.validate(12L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Cette demande n'est plus en attente.");
+    }
+
+    @Test
+    void validate_traduit_une_collision_de_matricule_en_erreur_metier_claire() throws Exception {
+        User user = pendingUser(13L, "david", "David", TypeJoueur.GLOBAL);
+        ValidateRegistrationRequest request = new ValidateRegistrationRequest();
+        request.setTypeAbonnementFinal(TypeJoueur.GLOBAL);
+
+        when(userRepository.findByIdForUpdate(13L)).thenReturn(Optional.of(user));
+        when(matriculeGeneratorService.generateFor(TypeJoueur.GLOBAL)).thenReturn("G0007");
+        when(joueurService.creerJoueur("G0007", "David", TypeJoueur.GLOBAL, null))
+                .thenThrow(new DataIntegrityViolationException(
+                        "Violation of PRIMARY KEY constraint on dbo.joueur"
+                ));
+
+        assertThatThrownBy(() -> adminRegistrationService.validate(13L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Collision de matricule détectée. Veuillez relancer la validation.");
+    }
+
+    @Test
+    void validate_traduit_un_conflit_de_liaison_user_joueur_en_erreur_metier_claire() throws Exception {
+        User user = pendingUser(14L, "eve", "Eve", TypeJoueur.GLOBAL);
+        Joueur joueur = new Joueur("G0008", "Eve", TypeJoueur.GLOBAL);
+        ValidateRegistrationRequest request = new ValidateRegistrationRequest();
+        request.setTypeAbonnementFinal(TypeJoueur.GLOBAL);
+
+        when(userRepository.findByIdForUpdate(14L)).thenReturn(Optional.of(user));
+        when(matriculeGeneratorService.generateFor(TypeJoueur.GLOBAL)).thenReturn("G0008");
+        when(joueurService.creerJoueur("G0008", "Eve", TypeJoueur.GLOBAL, null)).thenReturn(joueur);
+        when(userRepository.save(any(User.class)))
+                .thenThrow(new DataIntegrityViolationException("Violation of UNIQUE INDEX on app_user.joueur_id"));
+
+        assertThatThrownBy(() -> adminRegistrationService.validate(14L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Un joueur est déjà lié à un autre utilisateur.");
+    }
+
+    private User pendingUser(Long id, String login, String nom, TypeJoueur type) throws Exception {
+        User user = new User();
+        Field field = User.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(user, id);
+        user.setLogin(login);
+        user.setRequestedNom(nom);
+        user.setRequestedType(type);
+        user.setStatus(UserStatus.PENDING);
+        user.setActive(false);
+        return user;
+    }
+
+    private Site site(Long id, String nom) throws Exception {
+        Site site = new Site(nom, "Ville");
+        Field field = Site.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(site, id);
+        return site;
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AuthenticationServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AuthenticationServiceTest.java
@@ -2,6 +2,9 @@ package be.ephec.padel.backend.unit.service;
 
 import be.ephec.padel.backend.dto.request.LoginRequest;
 import be.ephec.padel.backend.dto.response.LoginResponse;
+import be.ephec.padel.backend.exception.ForbiddenException;
+import be.ephec.padel.backend.model.enums.UserStatus;
+import be.ephec.padel.backend.repository.UserRepository;
 import be.ephec.padel.backend.security.JwtService;
 import be.ephec.padel.backend.service.AuthenticationService;
 import org.junit.jupiter.api.Test;
@@ -17,6 +20,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -29,6 +33,9 @@ class AuthenticationServiceTest {
 
     @Mock
     JwtService jwtService;
+
+    @Mock
+    UserRepository userRepository;
 
     @InjectMocks
     AuthenticationService authenticationService;
@@ -49,6 +56,7 @@ class AuthenticationServiceTest {
                 null,
                 principal.getAuthorities()
         );
+        when(userRepository.findByLogin("adminGlobal")).thenReturn(java.util.Optional.empty());
         when(authenticationManager.authenticate(any())).thenReturn(authentication);
         when(jwtService.generateToken(principal)).thenReturn("jwt-test");
 
@@ -63,5 +71,37 @@ class AuthenticationServiceTest {
         assertThat(token.getCredentials()).isEqualTo("test123");
         assertThat(response.getToken()).isEqualTo("jwt-test");
         assertThat(response.getType()).isEqualTo("Bearer");
+    }
+
+    @Test
+    void login_refuse_avec_message_clair_si_compte_pending() {
+        LoginRequest request = new LoginRequest();
+        request.setUsername("futurePlayer");
+        request.setPassword("secret");
+
+        be.ephec.padel.backend.model.entities.User user = new be.ephec.padel.backend.model.entities.User();
+        user.setLogin("futurePlayer");
+        user.setStatus(UserStatus.PENDING);
+        when(userRepository.findByLogin("futurePlayer")).thenReturn(java.util.Optional.of(user));
+
+        assertThatThrownBy(() -> authenticationService.login(request))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Compte en attente de validation administrateur.");
+    }
+
+    @Test
+    void login_refuse_avec_message_clair_si_compte_rejected() {
+        LoginRequest request = new LoginRequest();
+        request.setUsername("rejectedPlayer");
+        request.setPassword("secret");
+
+        be.ephec.padel.backend.model.entities.User user = new be.ephec.padel.backend.model.entities.User();
+        user.setLogin("rejectedPlayer");
+        user.setStatus(UserStatus.REJECTED);
+        when(userRepository.findByLogin("rejectedPlayer")).thenReturn(java.util.Optional.of(user));
+
+        assertThatThrownBy(() -> authenticationService.login(request))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Demande d'inscription refusée.");
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatriculeGeneratorServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatriculeGeneratorServiceTest.java
@@ -1,0 +1,58 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.service.MatriculeGeneratorService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MatriculeGeneratorServiceTest {
+
+    @Mock
+    JoueurRepository joueurRepository;
+
+    @InjectMocks
+    MatriculeGeneratorService matriculeGeneratorService;
+
+    @Test
+    void generateFor_commence_a_0001_si_aucun_joueur_du_type() {
+        when(joueurRepository.findFirstByMatriculeStartingWithOrderByMatriculeDesc("G"))
+                .thenReturn(Optional.empty());
+
+        String matricule = matriculeGeneratorService.generateFor(TypeJoueur.GLOBAL);
+
+        assertThat(matricule).isEqualTo("G0001");
+    }
+
+    @Test
+    void generateFor_prend_le_suivant_du_prefixe() {
+        when(joueurRepository.findFirstByMatriculeStartingWithOrderByMatriculeDesc("S"))
+                .thenReturn(Optional.of(new Joueur("S0042", "Nom", TypeJoueur.SITE)));
+
+        String matricule = matriculeGeneratorService.generateFor(TypeJoueur.SITE);
+
+        assertThat(matricule).isEqualTo("S0043");
+    }
+
+    @Test
+    void generateFor_refuse_si_compteur_depasse_9999() {
+        when(joueurRepository.findFirstByMatriculeStartingWithOrderByMatriculeDesc("L"))
+                .thenReturn(Optional.of(new Joueur("L9999", "Nom", TypeJoueur.LIBRE)));
+
+        assertThatThrownBy(() -> matriculeGeneratorService.generateFor(TypeJoueur.LIBRE))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Plus aucun matricule disponible");
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/RegistrationServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/RegistrationServiceTest.java
@@ -1,0 +1,140 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.dto.request.RegisterRequest;
+import be.ephec.padel.backend.dto.response.RegisterResponse;
+import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.UserStatus;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.UserRepository;
+import be.ephec.padel.backend.service.RegistrationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RegistrationServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    SiteRepository siteRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    RegistrationService registrationService;
+
+    @Test
+    void register_cree_un_user_pending_sans_joueur() {
+        RegisterRequest request = new RegisterRequest();
+        request.setUsername("alice");
+        request.setPassword("secret123");
+        request.setNom("Alice");
+        request.setTypeAbonnementDemande(TypeJoueur.GLOBAL);
+
+        when(userRepository.existsByLogin("alice")).thenReturn(false);
+        when(passwordEncoder.encode("secret123")).thenReturn("hash");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            java.lang.reflect.Field field = User.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(user, 12L);
+            return user;
+        });
+
+        RegisterResponse response = registrationService.register(request);
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        User savedUser = captor.getValue();
+
+        assertThat(savedUser.getLogin()).isEqualTo("alice");
+        assertThat(savedUser.getPasswordHash()).isEqualTo("hash");
+        assertThat(savedUser.isActive()).isFalse();
+        assertThat(savedUser.getStatus()).isEqualTo(UserStatus.PENDING);
+        assertThat(savedUser.getRequestedNom()).isEqualTo("Alice");
+        assertThat(savedUser.getRequestedType()).isEqualTo(TypeJoueur.GLOBAL);
+        assertThat(savedUser.getRequestedSite()).isNull();
+        assertThat(savedUser.getJoueur()).isNull();
+        assertThat(savedUser.getRoles()).containsExactly(SecurityRole.ROLE_JOUEUR);
+
+        assertThat(response.getUserId()).isEqualTo(12L);
+        assertThat(response.getStatus()).isEqualTo(UserStatus.PENDING);
+        assertThat(response.getMessage()).contains("en attente");
+    }
+
+    @Test
+    void register_refuse_si_username_deja_utilise() {
+        RegisterRequest request = new RegisterRequest();
+        request.setUsername("alice");
+        request.setPassword("secret123");
+        request.setNom("Alice");
+        request.setTypeAbonnementDemande(TypeJoueur.GLOBAL);
+
+        when(userRepository.existsByLogin("alice")).thenReturn(true);
+
+        assertThatThrownBy(() -> registrationService.register(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Username deja utilise");
+    }
+
+    @Test
+    void register_refuse_si_type_site_sans_siteId() {
+        RegisterRequest request = new RegisterRequest();
+        request.setUsername("bob");
+        request.setPassword("secret123");
+        request.setNom("Bob");
+        request.setTypeAbonnementDemande(TypeJoueur.SITE);
+
+        when(userRepository.existsByLogin("bob")).thenReturn(false);
+
+        assertThatThrownBy(() -> registrationService.register(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("siteIdDemande");
+    }
+
+    @Test
+    void register_lie_le_site_demande_si_type_site() throws Exception {
+        RegisterRequest request = new RegisterRequest();
+        request.setUsername("carol");
+        request.setPassword("secret123");
+        request.setNom("Carol");
+        request.setTypeAbonnementDemande(TypeJoueur.SITE);
+        request.setSiteIdDemande(5L);
+
+        Site site = new Site("Delta", "Bruxelles");
+        java.lang.reflect.Field field = Site.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(site, 5L);
+
+        when(userRepository.existsByLogin("carol")).thenReturn(false);
+        when(siteRepository.findById(5L)).thenReturn(Optional.of(site));
+        when(passwordEncoder.encode(eq("secret123"))).thenReturn("hash");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        registrationService.register(request);
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getRequestedSite()).isSameAs(site);
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/UserBootstrapServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/UserBootstrapServiceTest.java
@@ -2,6 +2,7 @@ package be.ephec.padel.backend.unit.service;
 
 import be.ephec.padel.backend.model.entities.User;
 import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.model.enums.UserStatus;
 import be.ephec.padel.backend.repository.UserRepository;
 import be.ephec.padel.backend.service.UserBootstrapService;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,5 +64,8 @@ class UserBootstrapServiceTest {
                 .containsExactly(SecurityRole.ROLE_ADMIN_SITE);
         assertThat(captor.getAllValues().get(2).getRoles())
                 .containsExactly(SecurityRole.ROLE_ADMIN_SITE);
+        assertThat(captor.getAllValues())
+                .extracting(User::getStatus)
+                .containsOnly(UserStatus.ACTIVE);
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AdminRegistrationControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AdminRegistrationControllerTest.java
@@ -1,0 +1,124 @@
+package be.ephec.padel.backend.web.controller;
+
+import be.ephec.padel.backend.config.SecurityConfig;
+import be.ephec.padel.backend.controller.AdminRegistrationController;
+import be.ephec.padel.backend.dto.response.PendingRegistrationDto;
+import be.ephec.padel.backend.dto.response.RegistrationDecisionResponse;
+import be.ephec.padel.backend.error.ApiExceptionHandler;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.UserStatus;
+import be.ephec.padel.backend.service.AdminRegistrationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AdminRegistrationController.class)
+@Import({SecurityConfig.class, ApiExceptionHandler.class})
+class AdminRegistrationControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockitoBean
+    AdminRegistrationService adminRegistrationService;
+
+    @Test
+    @WithAnonymousUser
+    void listPending_sans_auth_401() throws Exception {
+        mvc.perform(get("/api/v1/admin/inscriptions"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_SITE")
+    void listPending_adminSite_refuse_403() throws Exception {
+        mvc.perform(get("/api/v1/admin/inscriptions"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void listPending_adminGlobal_ok_200() throws Exception {
+        when(adminRegistrationService.listPendingRegistrations()).thenReturn(List.of(
+                new PendingRegistrationDto(12L, "alice", "Alice", TypeJoueur.SITE, 3L, "Site Delta", UserStatus.PENDING)
+        ));
+
+        mvc.perform(get("/api/v1/admin/inscriptions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].userId").value(12))
+                .andExpect(jsonPath("$[0].username").value("alice"))
+                .andExpect(jsonPath("$[0].nomDemande").value("Alice"))
+                .andExpect(jsonPath("$[0].typeAbonnementDemande").value("SITE"))
+                .andExpect(jsonPath("$[0].siteIdDemande").value(3))
+                .andExpect(jsonPath("$[0].siteNomDemande").value("Site Delta"))
+                .andExpect(jsonPath("$[0].status").value("PENDING"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void validate_ok_200_et_reponse_explicite() throws Exception {
+        when(adminRegistrationService.validate(eq(12L), any()))
+                .thenReturn(new RegistrationDecisionResponse(
+                        12L,
+                        "alice",
+                        UserStatus.ACTIVE,
+                        "Inscription validée. Le compte est maintenant actif.",
+                        "S0007",
+                        "Alice",
+                        TypeJoueur.SITE,
+                        7L
+                ));
+
+        mvc.perform(post("/api/v1/admin/inscriptions/12/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "typeAbonnementFinal": "SITE",
+                                  "siteIdFinal": 7
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.message").value("Inscription validée. Le compte est maintenant actif."))
+                .andExpect(jsonPath("$.joueurMatricule").value("S0007"))
+                .andExpect(jsonPath("$.joueurType").value("SITE"))
+                .andExpect(jsonPath("$.joueurSiteId").value(7));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN_GLOBAL")
+    void reject_ok_200_et_reponse_explicite() throws Exception {
+        when(adminRegistrationService.reject(13L))
+                .thenReturn(new RegistrationDecisionResponse(
+                        13L,
+                        "bob",
+                        UserStatus.REJECTED,
+                        "Inscription refusée. Le compte ne peut pas être utilisé.",
+                        null,
+                        null,
+                        null,
+                        null
+                ));
+
+        mvc.perform(post("/api/v1/admin/inscriptions/13/reject"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("REJECTED"))
+                .andExpect(jsonPath("$.message").value("Inscription refusée. Le compte ne peut pas être utilisé."));
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AuthControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AuthControllerTest.java
@@ -2,9 +2,13 @@ package be.ephec.padel.backend.web.controller;
 
 import be.ephec.padel.backend.config.SecurityConfig;
 import be.ephec.padel.backend.controller.AuthController;
-import be.ephec.padel.backend.dto.response.LoginResponse;
+import be.ephec.padel.backend.dto.response.RegisterResponse;
 import be.ephec.padel.backend.error.ApiExceptionHandler;
+import be.ephec.padel.backend.exception.ForbiddenException;
+import be.ephec.padel.backend.dto.response.LoginResponse;
+import be.ephec.padel.backend.model.enums.UserStatus;
 import be.ephec.padel.backend.service.AuthenticationService;
+import be.ephec.padel.backend.service.RegistrationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -30,6 +34,9 @@ class AuthControllerTest {
 
     @MockitoBean
     AuthenticationService authenticationService;
+
+    @MockitoBean
+    RegistrationService registrationService;
 
     @Test
     void login_ok_200_et_json() throws Exception {
@@ -73,5 +80,66 @@ class AuthControllerTest {
                                 """))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.message").value("Authentication required"));
+    }
+
+    @Test
+    void login_403_si_compte_pending() throws Exception {
+        when(authenticationService.login(any()))
+                .thenThrow(new ForbiddenException("Compte en attente de validation administrateur."));
+
+        mvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "futurePlayer",
+                                  "password": "secret123"
+                                }
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("Compte en attente de validation administrateur."));
+    }
+
+    @Test
+    void login_403_si_compte_rejected() throws Exception {
+        when(authenticationService.login(any()))
+                .thenThrow(new ForbiddenException("Demande d'inscription refusée."));
+
+        mvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "rejectedPlayer",
+                                  "password": "secret123"
+                                }
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("Demande d'inscription refusée."));
+    }
+
+    @Test
+    void register_ok_201_et_message_clair() throws Exception {
+        when(registrationService.register(any()))
+                .thenReturn(new RegisterResponse(
+                        12L,
+                        "alice",
+                        UserStatus.PENDING,
+                        "Demande d'inscription en attente de validation administrateur."
+                ));
+
+        mvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "alice",
+                                  "password": "secret123",
+                                  "nom": "Alice",
+                                  "typeAbonnementDemande": "GLOBAL"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.userId").value(12))
+                .andExpect(jsonPath("$.username").value("alice"))
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.message").value("Demande d'inscription en attente de validation administrateur."));
     }
 }


### PR DESCRIPTION
- ajout du statut UserStatus (PENDING, ACTIVE, REJECTED)
- création d’un utilisateur en statut PENDING via POST /api/v1/auth/register
- blocage du login pour les comptes PENDING et REJECTED avec messages explicites
- ajout du processus de validation admin (ADMIN_GLOBAL uniquement)
  - validation : création du Joueur, génération du matricule, activation du compte
  - refus : passage en REJECTED sans création de Joueur
- ajout des champs de demande (nom, type, site) dans User pour le MVP
- ajout des endpoints admin :
  - GET /api/v1/admin/inscriptions
  - POST /api/v1/admin/inscriptions/{userId}/validate
  - POST /api/v1/admin/inscriptions/{userId}/reject
- génération du matricule via MatriculeGeneratorService (format G/S/L + numéro)
- ajout des verrous pessimistes pour sécuriser la validation concurrente
- ajout des DTO dédiés (register, pending, decision)
- ajout des services RegistrationService et AdminRegistrationService
- compatibilité conservée avec le login JWT existant et les endpoints /api/v1/me/**
- ajout des tests unitaires, web et d’intégration couvrant le cycle comple