### PR TITLE
Issue #79 implémenter statistiques admin

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/error/ApiExceptionHandler.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/error/ApiExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -153,6 +154,23 @@ public class ApiExceptionHandler {
             HttpServletRequest request) {
 
         String msg = "Invalid value for parameter '" + ex.getName() + "': " + ex.getValue();
+
+        ApiErrorDto error = buildError(
+                HttpStatus.BAD_REQUEST,
+                msg,
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiErrorDto> handleMissingRequestParameter(
+            MissingServletRequestParameterException ex,
+            HttpServletRequest request) {
+
+        String msg = "Missing required parameter '" + ex.getParameterName() + "'";
 
         ApiErrorDto error = buildError(
                 HttpStatus.BAD_REQUEST,

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
@@ -59,10 +59,12 @@ public interface PaiementRepository extends JpaRepository<Paiement, Long> {
         from Paiement p
         where p.datePaiement >= :from
           and p.datePaiement < :to
+          and p.type = :typePaiement
     """)
-    BigDecimal sumMontantByDatePaiementBetween(
+    BigDecimal sumMontantByDatePaiementBetweenAndType(
             @Param("from") LocalDateTime from,
-            @Param("to") LocalDateTime to
+            @Param("to") LocalDateTime to,
+            @Param("typePaiement") TypePaiement typePaiement
     );
 
     @Query("""
@@ -70,11 +72,13 @@ public interface PaiementRepository extends JpaRepository<Paiement, Long> {
         from Paiement p
         where p.datePaiement >= :from
           and p.datePaiement < :to
+          and p.type = :typePaiement
           and p.participation.match.terrain.site.id = :siteId
     """)
-    BigDecimal sumMontantByDatePaiementBetweenAndSiteId(
+    BigDecimal sumMontantByDatePaiementBetweenAndSiteIdAndType(
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to,
-            @Param("siteId") Long siteId
+            @Param("siteId") Long siteId,
+            @Param("typePaiement") TypePaiement typePaiement
     );
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminSiteStatsService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminSiteStatsService.java
@@ -4,9 +4,12 @@ import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
 import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
 import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
 import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
 import be.ephec.padel.backend.security.ServiceAutorisationAdmin;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,33 +25,41 @@ public class AdminSiteStatsService {
     private final PaiementRepository paiementRepository;
     private final MatchPadelRepository matchPadelRepository;
     private final JoueurRepository joueurRepository;
+    private final SiteRepository siteRepository;
     private final ServiceAutorisationAdmin serviceAutorisationAdmin;
 
     public AdminSiteStatsService(PaiementRepository paiementRepository,
                                  MatchPadelRepository matchPadelRepository,
                                  JoueurRepository joueurRepository,
+                                 SiteRepository siteRepository,
                                  ServiceAutorisationAdmin serviceAutorisationAdmin) {
         this.paiementRepository = paiementRepository;
         this.matchPadelRepository = matchPadelRepository;
         this.joueurRepository = joueurRepository;
+        this.siteRepository = siteRepository;
         this.serviceAutorisationAdmin = serviceAutorisationAdmin;
     }
 
     public AdminCaStatsDto getCa(Long siteId, LocalDate from, LocalDate to) {
-        // Sécurité : ADMIN_GLOBAL ok partout, ADMIN_SITE seulement sur son site
         serviceAutorisationAdmin.verifierAccesAuSite(siteId);
+        verifySiteExists(siteId);
 
         validatePeriod(from, to);
         LocalDateTime fromStart = from.atStartOfDay();
         LocalDateTime toExclusive = to.plusDays(1).atStartOfDay();
 
-        BigDecimal ca = paiementRepository.sumMontantByDatePaiementBetweenAndSiteId(fromStart, toExclusive, siteId);
+        BigDecimal ca = paiementRepository.sumMontantByDatePaiementBetweenAndSiteIdAndType(
+                fromStart,
+                toExclusive,
+                siteId,
+                TypePaiement.ENCAISSEMENT
+        );
         return new AdminCaStatsDto(ca, from, to);
     }
 
     public AdminMatchsStatsDto getNbMatchs(Long siteId, LocalDate from, LocalDate to) {
-        // Sécurité : ADMIN_GLOBAL ok partout, ADMIN_SITE seulement sur son site
         serviceAutorisationAdmin.verifierAccesAuSite(siteId);
+        verifySiteExists(siteId);
 
         validatePeriod(from, to);
         LocalDateTime fromStart = from.atStartOfDay();
@@ -59,8 +70,8 @@ public class AdminSiteStatsService {
     }
 
     public AdminDettesStatsDto getDettes(Long siteId) {
-        // Sécurité : ADMIN_GLOBAL ok partout, ADMIN_SITE seulement sur son site
         serviceAutorisationAdmin.verifierAccesAuSite(siteId);
+        verifySiteExists(siteId);
 
         BigDecimal detteTotale = joueurRepository.sumDettesBySiteId(siteId);
         long nbJoueursEnDette = joueurRepository.countJoueursEnDetteBySiteId(siteId);
@@ -69,10 +80,16 @@ public class AdminSiteStatsService {
 
     private void validatePeriod(LocalDate from, LocalDate to) {
         if (from == null || to == null) {
-            throw new BusinessException("Les paramètres 'from' et 'to' sont obligatoires.");
+            throw new BusinessException("Les parametres 'from' et 'to' sont obligatoires.");
         }
         if (from.isAfter(to)) {
-            throw new BusinessException("La date 'from' doit être <= à la date 'to'.");
+            throw new BusinessException("La date 'from' doit etre <= a la date 'to'.");
+        }
+    }
+
+    private void verifySiteExists(Long siteId) {
+        if (!siteRepository.existsById(siteId)) {
+            throw new NotFoundException("Site introuvable: " + siteId);
         }
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminStatsService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminStatsService.java
@@ -7,6 +7,7 @@ import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +37,11 @@ public class AdminStatsService {
         LocalDateTime fromStart = from.atStartOfDay();
         LocalDateTime toExclusive = to.plusDays(1).atStartOfDay();
 
-        BigDecimal ca = paiementRepository.sumMontantByDatePaiementBetween(fromStart, toExclusive);
+        BigDecimal ca = paiementRepository.sumMontantByDatePaiementBetweenAndType(
+                fromStart,
+                toExclusive,
+                TypePaiement.ENCAISSEMENT
+        );
         return new AdminCaStatsDto(ca, from, to);
     }
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/integration/AdminPerimetreSiteStatsIntegrationTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/integration/AdminPerimetreSiteStatsIntegrationTest.java
@@ -111,4 +111,21 @@ class AdminPerimetreSiteStatsIntegrationTest extends SqlServerTestContainerConfi
                         .param("to", "2026-03-03"))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
+    void stats_site_inexistant_404() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/sites/99/stats/dettes"))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/v1/admin/sites/99/stats/ca")
+                        .param("from", "2026-03-02")
+                        .param("to", "2026-03-03"))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/v1/admin/sites/99/stats/matchs")
+                        .param("from", "2026-03-02")
+                        .param("to", "2026-03-03"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/repository/PaiementRepositoryTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/repository/PaiementRepositoryTest.java
@@ -95,4 +95,90 @@ class PaiementRepositoryTest extends SqlServerTestContainerConfig {
         assertThat(encaissements).isEqualByComparingTo(new BigDecimal("15.00"));
         assertThat(remboursements).isEqualByComparingTo(new BigDecimal("-6.00"));
     }
+
+    @Test
+    void sumMontantByDatePaiementBetweenAndType_ne_compte_que_les_encaissements() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+        Joueur j1 = joueurRepository.save(new Joueur("J001", "Alice", TypeJoueur.GLOBAL));
+
+        MatchPadel match = matchPadelRepository.save(
+                new MatchPadel(t, orga, LocalDateTime.of(2026, 3, 10, 10, 0), MatchVisibilite.PUBLIC)
+        );
+
+        Participation part = participationRepository.save(new Participation(match, j1));
+
+        paiementRepository.save(new Paiement(
+                part,
+                new BigDecimal("20.00"),
+                TypePaiement.ENCAISSEMENT,
+                LocalDateTime.of(2026, 3, 10, 12, 0)
+        ));
+        paiementRepository.save(new Paiement(
+                part,
+                new BigDecimal("-5.00"),
+                TypePaiement.REMBOURSEMENT,
+                LocalDateTime.of(2026, 3, 10, 13, 0)
+        ));
+
+        BigDecimal sum = paiementRepository.sumMontantByDatePaiementBetweenAndType(
+                LocalDateTime.of(2026, 3, 10, 0, 0),
+                LocalDateTime.of(2026, 3, 11, 0, 0),
+                TypePaiement.ENCAISSEMENT
+        );
+
+        assertThat(sum).isEqualByComparingTo(new BigDecimal("20.00"));
+    }
+
+    @Test
+    void sumMontantByDatePaiementBetweenAndSiteIdAndType_filtre_par_site_et_exclut_les_remboursements() {
+        Site siteA = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Site siteB = siteRepository.save(new Site("Site B", "Namur"));
+        Terrain terrainA = terrainRepository.save(new Terrain("T1", siteA));
+        Terrain terrainB = terrainRepository.save(new Terrain("T2", siteB));
+
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+        Joueur j1 = joueurRepository.save(new Joueur("J001", "Alice", TypeJoueur.GLOBAL));
+        Joueur j2 = joueurRepository.save(new Joueur("J002", "Bob", TypeJoueur.GLOBAL));
+
+        MatchPadel matchSiteA = matchPadelRepository.save(
+                new MatchPadel(terrainA, orga, LocalDateTime.of(2026, 3, 10, 10, 0), MatchVisibilite.PUBLIC)
+        );
+        MatchPadel matchSiteB = matchPadelRepository.save(
+                new MatchPadel(terrainB, orga, LocalDateTime.of(2026, 3, 10, 11, 0), MatchVisibilite.PUBLIC)
+        );
+
+        Participation partA = participationRepository.save(new Participation(matchSiteA, j1));
+        Participation partB = participationRepository.save(new Participation(matchSiteB, j2));
+
+        paiementRepository.save(new Paiement(
+                partA,
+                new BigDecimal("15.00"),
+                TypePaiement.ENCAISSEMENT,
+                LocalDateTime.of(2026, 3, 10, 12, 0)
+        ));
+        paiementRepository.save(new Paiement(
+                partA,
+                new BigDecimal("-3.00"),
+                TypePaiement.REMBOURSEMENT,
+                LocalDateTime.of(2026, 3, 10, 13, 0)
+        ));
+        paiementRepository.save(new Paiement(
+                partB,
+                new BigDecimal("8.00"),
+                TypePaiement.ENCAISSEMENT,
+                LocalDateTime.of(2026, 3, 10, 12, 30)
+        ));
+
+        BigDecimal sum = paiementRepository.sumMontantByDatePaiementBetweenAndSiteIdAndType(
+                LocalDateTime.of(2026, 3, 10, 0, 0),
+                LocalDateTime.of(2026, 3, 11, 0, 0),
+                siteA.getId(),
+                TypePaiement.ENCAISSEMENT
+        );
+
+        assertThat(sum).isEqualByComparingTo(new BigDecimal("15.00"));
+    }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminSiteStatsServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminSiteStatsServiceTest.java
@@ -1,10 +1,14 @@
 package be.ephec.padel.backend.unit.service;
 
 import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
+import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
 import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
 import be.ephec.padel.backend.security.ServiceAutorisationAdmin;
 import be.ephec.padel.backend.service.AdminSiteStatsService;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +21,9 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +37,8 @@ class AdminSiteStatsServiceTest {
     @Mock
     JoueurRepository joueurRepository;
     @Mock
+    SiteRepository siteRepository;
+    @Mock
     ServiceAutorisationAdmin serviceAutorisationAdmin;
 
     private AdminSiteStatsService service;
@@ -41,8 +49,30 @@ class AdminSiteStatsServiceTest {
                 paiementRepository,
                 matchPadelRepository,
                 joueurRepository,
+                siteRepository,
                 serviceAutorisationAdmin
         );
+    }
+
+    @Test
+    void getCa_utilise_uniquement_les_encaissements_du_site() {
+        Long siteId = 3L;
+        LocalDate from = LocalDate.of(2026, 3, 1);
+        LocalDate to = LocalDate.of(2026, 3, 31);
+
+        when(siteRepository.existsById(siteId)).thenReturn(true);
+        when(paiementRepository.sumMontantByDatePaiementBetweenAndSiteIdAndType(
+                eq(from.atStartOfDay()),
+                eq(to.plusDays(1).atStartOfDay()),
+                eq(siteId),
+                eq(TypePaiement.ENCAISSEMENT)
+        )).thenReturn(new BigDecimal("18.00"));
+
+        AdminCaStatsDto dto = service.getCa(siteId, from, to);
+
+        assertThat(dto.getCaTotal()).isEqualByComparingTo("18.00");
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(siteId);
+        verify(siteRepository).existsById(siteId);
     }
 
     @Test
@@ -51,6 +81,7 @@ class AdminSiteStatsServiceTest {
         LocalDate from = LocalDate.of(2026, 3, 1);
         LocalDate to = LocalDate.of(2026, 3, 31);
 
+        when(siteRepository.existsById(siteId)).thenReturn(true);
         when(matchPadelRepository.countByDateDebutBetweenAndSiteId(
                 eq(from.atStartOfDay()),
                 eq(to.plusDays(1).atStartOfDay()),
@@ -61,6 +92,7 @@ class AdminSiteStatsServiceTest {
 
         assertThat(dto.getNbMatchs()).isEqualTo(4L);
         verify(serviceAutorisationAdmin).verifierAccesAuSite(siteId);
+        verify(siteRepository).existsById(siteId);
         verify(matchPadelRepository).countByDateDebutBetweenAndSiteId(
                 from.atStartOfDay(),
                 to.plusDays(1).atStartOfDay(),
@@ -69,20 +101,33 @@ class AdminSiteStatsServiceTest {
     }
 
     @Test
-    void getCa_conserve_un_mode_cash_base_par_site() {
+    void getDettes_retourne_la_somme_et_le_nombre_de_joueurs_en_dette_du_site() {
         Long siteId = 3L;
-        LocalDate from = LocalDate.of(2026, 3, 1);
-        LocalDate to = LocalDate.of(2026, 3, 31);
 
-        when(paiementRepository.sumMontantByDatePaiementBetweenAndSiteId(
-                from.atStartOfDay(),
-                to.plusDays(1).atStartOfDay(),
-                siteId
-        )).thenReturn(new BigDecimal("18.00"));
+        when(siteRepository.existsById(siteId)).thenReturn(true);
+        when(joueurRepository.sumDettesBySiteId(siteId)).thenReturn(new BigDecimal("12.00"));
+        when(joueurRepository.countJoueursEnDetteBySiteId(siteId)).thenReturn(2L);
 
-        AdminCaStatsDto dto = service.getCa(siteId, from, to);
+        AdminDettesStatsDto dto = service.getDettes(siteId);
 
-        assertThat(dto.getCaTotal()).isEqualByComparingTo("18.00");
+        assertThat(dto.getDetteTotale()).isEqualByComparingTo("12.00");
+        assertThat(dto.getNbJoueursEnDette()).isEqualTo(2L);
         verify(serviceAutorisationAdmin).verifierAccesAuSite(siteId);
+        verify(siteRepository).existsById(siteId);
+    }
+
+    @Test
+    void getDettes_refuse_un_site_inexistant() {
+        Long siteId = 99L;
+
+        when(siteRepository.existsById(siteId)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getDettes(siteId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("Site introuvable: 99");
+
+        var inOrder = inOrder(serviceAutorisationAdmin, siteRepository);
+        inOrder.verify(serviceAutorisationAdmin).verifierAccesAuSite(siteId);
+        inOrder.verify(siteRepository).existsById(siteId);
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminStatsServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminStatsServiceTest.java
@@ -1,8 +1,10 @@
 package be.ephec.padel.backend.unit.service;
 
 import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
+import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
 import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
 import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
@@ -15,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -41,6 +42,27 @@ class AdminStatsServiceTest {
     }
 
     @Test
+    void getCa_utilise_uniquement_les_encaissements() {
+        LocalDate from = LocalDate.of(2026, 3, 1);
+        LocalDate to = LocalDate.of(2026, 3, 31);
+
+        when(paiementRepository.sumMontantByDatePaiementBetweenAndType(
+                eq(from.atStartOfDay()),
+                eq(to.plusDays(1).atStartOfDay()),
+                eq(TypePaiement.ENCAISSEMENT)
+        )).thenReturn(new BigDecimal("42.50"));
+
+        AdminCaStatsDto dto = service.getCa(from, to);
+
+        assertThat(dto.getCaTotal()).isEqualByComparingTo("42.50");
+        verify(paiementRepository).sumMontantByDatePaiementBetweenAndType(
+                from.atStartOfDay(),
+                to.plusDays(1).atStartOfDay(),
+                TypePaiement.ENCAISSEMENT
+        );
+    }
+
+    @Test
     void getNbMatchs_utilise_le_compteur_filtre_par_statut() {
         LocalDate from = LocalDate.of(2026, 3, 1);
         LocalDate to = LocalDate.of(2026, 3, 31);
@@ -60,18 +82,14 @@ class AdminStatsServiceTest {
     }
 
     @Test
-    void getCa_conserve_un_mode_cash_base() {
-        LocalDate from = LocalDate.of(2026, 3, 1);
-        LocalDate to = LocalDate.of(2026, 3, 31);
-        LocalDateTime fromStart = from.atStartOfDay();
-        LocalDateTime toExclusive = to.plusDays(1).atStartOfDay();
+    void getDettes_retourne_la_somme_et_le_nombre_de_joueurs_en_dette() {
+        when(joueurRepository.sumDettes()).thenReturn(new BigDecimal("50.00"));
+        when(joueurRepository.countJoueursEnDette()).thenReturn(3L);
 
-        when(paiementRepository.sumMontantByDatePaiementBetween(fromStart, toExclusive))
-                .thenReturn(new BigDecimal("42.50"));
+        AdminDettesStatsDto dto = service.getDettes();
 
-        AdminCaStatsDto dto = service.getCa(from, to);
-
-        assertThat(dto.getCaTotal()).isEqualByComparingTo("42.50");
+        assertThat(dto.getDetteTotale()).isEqualByComparingTo("50.00");
+        assertThat(dto.getNbJoueursEnDette()).isEqualTo(3L);
     }
 
     @Test

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AdminGlobalControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AdminGlobalControllerTest.java
@@ -5,6 +5,7 @@ import be.ephec.padel.backend.controller.AdminGlobalController;
 import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
 import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
 import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
+import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.service.AdminStatsService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,6 +99,41 @@ class AdminGlobalControllerTest {
 
     @Test
     @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
+    void statsCa_parametre_manquant_400() throws Exception {
+        mvc.perform(get("/api/v1/admin/stats/ca")
+                        .param("to", "2026-01-31"))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(adminStatsService);
+    }
+
+    @Test
+    void statsCa_sansAuth_401() throws Exception {
+        mvc.perform(get("/api/v1/admin/stats/ca")
+                        .param("from", "2026-01-01")
+                        .param("to", "2026-01-31"))
+                .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(adminStatsService);
+    }
+
+    @Test
+    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
+    void statsCa_periode_invalide_400() throws Exception {
+        LocalDate from = LocalDate.of(2026, 1, 31);
+        LocalDate to = LocalDate.of(2026, 1, 1);
+
+        when(adminStatsService.getCa(from, to))
+                .thenThrow(new BusinessException("La date 'from' doit etre <= a la date 'to'."));
+
+        mvc.perform(get("/api/v1/admin/stats/ca")
+                        .param("from", "2026-01-31")
+                        .param("to", "2026-01-01"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
     void statsMatchs_adminGlobal_200() throws Exception {
         LocalDate from = LocalDate.of(2026, 1, 1);
         LocalDate to = LocalDate.of(2026, 1, 31);
@@ -115,6 +151,16 @@ class AdminGlobalControllerTest {
 
         verify(adminStatsService, times(1)).getNbMatchs(from, to);
         verifyNoMoreInteractions(adminStatsService);
+    }
+
+    @Test
+    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
+    void statsMatchs_parametre_manquant_400() throws Exception {
+        mvc.perform(get("/api/v1/admin/stats/matchs")
+                        .param("from", "2026-01-01"))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(adminStatsService);
     }
 
     @Test

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminSiteControllerSecurityTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminSiteControllerSecurityTest.java
@@ -42,6 +42,12 @@ class AdminSiteControllerSecurityTest {
     }
 
     @Test
+    void statsSansAuth_401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/sites/1/stats/dettes"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     @WithMockUser(username = "adminSite1", roles = {"ADMIN_SITE"})
     void adminSite_auth_200_mapping_ok() throws Exception {
         mockMvc.perform(get("/api/v1/admin/sites/1/joueurs"))


### PR DESCRIPTION
Le bloc stats admin est maintenant stabilisé autour de :
- CA (encaissements uniquement)
- nombre de matchs (PLANIFIE)
- dettes (soldes joueurs > 0)

Améliorations :
- correction du calcul du CA (exclusion des remboursements)
- 400 pour paramètres manquants ou période invalide
- 404 si site inexistant
- respect du périmètre ADMIN_SITE

Endpoints et DTO inchangés.

Tests :
- couverture des cas critiques (CA, erreurs HTTP, sécurité, périmètre)
- suite de tests OK