### PR TITLE
Implémentation statistiques joueur

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/MeController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/MeController.java
@@ -2,10 +2,12 @@ package be.ephec.padel.backend.controller;
 
 import be.ephec.padel.backend.dto.response.DetteDto;
 import be.ephec.padel.backend.dto.response.JoueurDto;
+import be.ephec.padel.backend.dto.response.MeStatsDto;
 import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
 import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
 import be.ephec.padel.backend.mapper.JoueurMapper;
 import be.ephec.padel.backend.service.JoueurService;
+import be.ephec.padel.backend.service.MeStatsService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,9 +22,11 @@ import java.util.List;
 public class MeController {
 
     private final JoueurService joueurService;
+    private final MeStatsService meStatsService;
 
-    public MeController(JoueurService joueurService) {
+    public MeController(JoueurService joueurService, MeStatsService meStatsService) {
         this.joueurService = joueurService;
+        this.meStatsService = meStatsService;
     }
 
     @GetMapping
@@ -43,5 +47,10 @@ public class MeController {
     @GetMapping("/dette")
     public ResponseEntity<DetteDto> getMyDette() {
         return ResponseEntity.ok(new DetteDto(joueurService.currentUserADette()));
+    }
+
+    @GetMapping("/stats")
+    public ResponseEntity<MeStatsDto> getMyStats() {
+        return ResponseEntity.ok(meStatsService.getCurrentUserStats());
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MeStatsDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MeStatsDto.java
@@ -1,0 +1,58 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.math.BigDecimal;
+
+public class MeStatsDto {
+
+    private final long nbMatchsParticipes;
+    private final long nbMatchsOrganises;
+    private final long nbMatchsPasses;
+    private final long nbMatchsFuturs;
+    private final long nbMatchsAnnules;
+    private final BigDecimal montantTotalPaye;
+    private final BigDecimal detteActuelle;
+
+    public MeStatsDto(long nbMatchsParticipes,
+                      long nbMatchsOrganises,
+                      long nbMatchsPasses,
+                      long nbMatchsFuturs,
+                      long nbMatchsAnnules,
+                      BigDecimal montantTotalPaye,
+                      BigDecimal detteActuelle) {
+        this.nbMatchsParticipes = nbMatchsParticipes;
+        this.nbMatchsOrganises = nbMatchsOrganises;
+        this.nbMatchsPasses = nbMatchsPasses;
+        this.nbMatchsFuturs = nbMatchsFuturs;
+        this.nbMatchsAnnules = nbMatchsAnnules;
+        this.montantTotalPaye = montantTotalPaye;
+        this.detteActuelle = detteActuelle;
+    }
+
+    public long getNbMatchsParticipes() {
+        return nbMatchsParticipes;
+    }
+
+    public long getNbMatchsOrganises() {
+        return nbMatchsOrganises;
+    }
+
+    public long getNbMatchsPasses() {
+        return nbMatchsPasses;
+    }
+
+    public long getNbMatchsFuturs() {
+        return nbMatchsFuturs;
+    }
+
+    public long getNbMatchsAnnules() {
+        return nbMatchsAnnules;
+    }
+
+    public BigDecimal getMontantTotalPaye() {
+        return montantTotalPaye;
+    }
+
+    public BigDecimal getDetteActuelle() {
+        return detteActuelle;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -97,6 +97,8 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
 """)
     long countByDateDebutBetween(LocalDateTime from, LocalDateTime to);
 
+    long countByOrganisateur_Matricule(String matricule);
+
     @Query("""
         select count(m)
         from MatchPadel m
@@ -123,6 +125,62 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to
     );
+
+    @Query("""
+        select count(distinct m.id)
+        from MatchPadel m
+        where m.statut <> be.ephec.padel.backend.model.enums.MatchStatut.ANNULE
+          and m.dateDebut < :now
+          and (
+              m.organisateur.matricule = :matricule
+              or exists (
+                  select 1
+                  from Participation p
+                  where p.match = m
+                    and p.joueur.matricule = :matricule
+              )
+          )
+    """)
+    long countDistinctLinkedPastMatchesByMatricule(
+            @Param("matricule") String matricule,
+            @Param("now") LocalDateTime now
+    );
+
+    @Query("""
+        select count(distinct m.id)
+        from MatchPadel m
+        where m.statut <> be.ephec.padel.backend.model.enums.MatchStatut.ANNULE
+          and m.dateDebut >= :now
+          and (
+              m.organisateur.matricule = :matricule
+              or exists (
+                  select 1
+                  from Participation p
+                  where p.match = m
+                    and p.joueur.matricule = :matricule
+              )
+          )
+    """)
+    long countDistinctLinkedFutureMatchesByMatricule(
+            @Param("matricule") String matricule,
+            @Param("now") LocalDateTime now
+    );
+
+    @Query("""
+        select count(distinct m.id)
+        from MatchPadel m
+        where m.statut = be.ephec.padel.backend.model.enums.MatchStatut.ANNULE
+          and (
+              m.organisateur.matricule = :matricule
+              or exists (
+                  select 1
+                  from Participation p
+                  where p.match = m
+                    and p.joueur.matricule = :matricule
+              )
+          )
+    """)
+    long countDistinctLinkedCancelledMatchesByMatricule(@Param("matricule") String matricule);
 
     @Query("""
     select

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
@@ -81,4 +81,15 @@ public interface PaiementRepository extends JpaRepository<Paiement, Long> {
             @Param("siteId") Long siteId,
             @Param("typePaiement") TypePaiement typePaiement
     );
+
+    @Query("""
+        select coalesce(sum(p.montant), 0)
+        from Paiement p
+        where p.participation.joueur.matricule = :matricule
+          and p.type = :typePaiement
+    """)
+    BigDecimal sumMontantByParticipationJoueurMatriculeAndType(
+            @Param("matricule") String matricule,
+            @Param("typePaiement") TypePaiement typePaiement
+    );
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
@@ -10,6 +10,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     List<Participation> findByMatch_Id(Long matchId);
     List<Participation> findByJoueur_Matricule(String matricule);
     List<Participation> findByJoueur_MatriculeOrderByMatch_DateDebutAsc(String matricule);
+    long countByJoueur_Matricule(String matricule);
     boolean existsByMatch_IdAndJoueur_Matricule(Long matchId, String joueurMatricule);
 
     Optional<Participation> findByMatch_IdAndJoueur_Matricule(Long matchId, String matricule);

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MeStatsService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MeStatsService.java
@@ -1,0 +1,65 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.dto.response.MeStatsDto;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.enums.TypePaiement;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@Service
+@Transactional(readOnly = true)
+public class MeStatsService {
+
+    private final CurrentUserFacade currentUserFacade;
+    private final ParticipationRepository participationRepository;
+    private final MatchPadelRepository matchPadelRepository;
+    private final PaiementRepository paiementRepository;
+    private final Clock clock;
+
+    public MeStatsService(CurrentUserFacade currentUserFacade,
+                          ParticipationRepository participationRepository,
+                          MatchPadelRepository matchPadelRepository,
+                          PaiementRepository paiementRepository,
+                          Clock clock) {
+        this.currentUserFacade = currentUserFacade;
+        this.participationRepository = participationRepository;
+        this.matchPadelRepository = matchPadelRepository;
+        this.paiementRepository = paiementRepository;
+        this.clock = clock;
+    }
+
+    public MeStatsDto getCurrentUserStats() {
+        Joueur joueur = currentUserFacade.getCurrentJoueur();
+        String matricule = joueur.getMatricule();
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        long nbMatchsParticipes = participationRepository.countByJoueur_Matricule(matricule);
+        long nbMatchsOrganises = matchPadelRepository.countByOrganisateur_Matricule(matricule);
+        long nbMatchsPasses = matchPadelRepository.countDistinctLinkedPastMatchesByMatricule(matricule, now);
+        long nbMatchsFuturs = matchPadelRepository.countDistinctLinkedFutureMatchesByMatricule(matricule, now);
+        long nbMatchsAnnules = matchPadelRepository.countDistinctLinkedCancelledMatchesByMatricule(matricule);
+        BigDecimal montantTotalPaye = paiementRepository.sumMontantByParticipationJoueurMatriculeAndType(
+                matricule,
+                TypePaiement.ENCAISSEMENT
+        );
+        BigDecimal detteActuelle = joueur.getSolde() == null ? BigDecimal.ZERO : joueur.getSolde();
+
+        return new MeStatsDto(
+                nbMatchsParticipes,
+                nbMatchsOrganises,
+                nbMatchsPasses,
+                nbMatchsFuturs,
+                nbMatchsAnnules,
+                montantTotalPaye,
+                detteActuelle
+        );
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/repository/MatchPadelRepositoryTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/repository/MatchPadelRepositoryTest.java
@@ -479,4 +479,65 @@ class MatchPadelRepositoryTest extends SqlServerTestContainerConfig {
 
         assertThat(rows).extracting(MatchPadel::getId).containsExactly(inScope.getId());
     }
+
+    @Test
+    void countByOrganisateurMatricule_compte_les_matchs_organises() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+        Joueur other = joueurRepository.save(new Joueur("ORG2", "Other", TypeJoueur.GLOBAL));
+
+        matchPadelRepository.save(new MatchPadel(
+                t, orga, LocalDateTime.of(2030, 1, 1, 10, 0), MatchVisibilite.PUBLIC
+        ));
+        MatchPadel cancelled = new MatchPadel(
+                t, orga, LocalDateTime.of(2030, 1, 2, 10, 0), MatchVisibilite.PUBLIC
+        );
+        cancelled.setStatut(MatchStatut.ANNULE);
+        matchPadelRepository.save(cancelled);
+        matchPadelRepository.save(new MatchPadel(
+                t, other, LocalDateTime.of(2030, 1, 3, 10, 0), MatchVisibilite.PUBLIC
+        ));
+
+        assertThat(matchPadelRepository.countByOrganisateur_Matricule("ORG1")).isEqualTo(2L);
+        assertThat(matchPadelRepository.countByOrganisateur_Matricule("ORG2")).isEqualTo(1L);
+    }
+
+    @Test
+    void countDistinctLinkedMatches_dedoublonne_et_separe_passe_futur_annule() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+
+        Joueur joueur = joueurRepository.save(new Joueur("J001", "Alice", TypeJoueur.GLOBAL));
+        Joueur other = joueurRepository.save(new Joueur("J002", "Bob", TypeJoueur.GLOBAL));
+
+        LocalDateTime now = LocalDateTime.of(2030, 1, 10, 9, 30);
+
+        MatchPadel pastAsParticipant = matchPadelRepository.save(new MatchPadel(
+                t, other, LocalDateTime.of(2030, 1, 9, 10, 0), MatchVisibilite.PUBLIC
+        ));
+        MatchPadel futureAsOrganizer = matchPadelRepository.save(new MatchPadel(
+                t, joueur, LocalDateTime.of(2030, 1, 11, 10, 0), MatchVisibilite.PUBLIC
+        ));
+        MatchPadel futureOrganizerAndParticipant = matchPadelRepository.save(new MatchPadel(
+                t, joueur, LocalDateTime.of(2030, 1, 12, 10, 0), MatchVisibilite.PRIVE
+        ));
+        MatchPadel cancelledLinked = new MatchPadel(
+                t, other, LocalDateTime.of(2030, 1, 8, 10, 0), MatchVisibilite.PUBLIC
+        );
+        cancelledLinked.setStatut(MatchStatut.ANNULE);
+        cancelledLinked = matchPadelRepository.save(cancelledLinked);
+
+        participationRepository.save(new Participation(pastAsParticipant, joueur));
+        participationRepository.save(new Participation(futureOrganizerAndParticipant, joueur));
+        participationRepository.save(new Participation(cancelledLinked, joueur));
+
+        long past = matchPadelRepository.countDistinctLinkedPastMatchesByMatricule("J001", now);
+        long future = matchPadelRepository.countDistinctLinkedFutureMatchesByMatricule("J001", now);
+        long cancelled = matchPadelRepository.countDistinctLinkedCancelledMatchesByMatricule("J001");
+
+        assertThat(past).isEqualTo(1L);
+        assertThat(future).isEqualTo(2L);
+        assertThat(cancelled).isEqualTo(1L);
+    }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/repository/PaiementRepositoryTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/repository/PaiementRepositoryTest.java
@@ -181,4 +181,47 @@ class PaiementRepositoryTest extends SqlServerTestContainerConfig {
 
         assertThat(sum).isEqualByComparingTo(new BigDecimal("15.00"));
     }
+
+    @Test
+    void sumMontantByParticipationJoueurMatriculeAndType_somme_uniquement_les_encaissements_du_joueur() {
+        Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain t = terrainRepository.save(new Terrain("T1", s));
+
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+        Joueur j1 = joueurRepository.save(new Joueur("J001", "Alice", TypeJoueur.GLOBAL));
+        Joueur j2 = joueurRepository.save(new Joueur("J002", "Bob", TypeJoueur.GLOBAL));
+
+        MatchPadel match = matchPadelRepository.save(
+                new MatchPadel(t, orga, LocalDateTime.of(2026, 3, 10, 10, 0), MatchVisibilite.PUBLIC)
+        );
+
+        Participation part1 = participationRepository.save(new Participation(match, j1));
+        Participation part2 = participationRepository.save(new Participation(match, j2));
+
+        paiementRepository.save(new Paiement(
+                part1,
+                new BigDecimal("10.00"),
+                TypePaiement.ENCAISSEMENT,
+                LocalDateTime.of(2026, 3, 10, 12, 0)
+        ));
+        paiementRepository.save(new Paiement(
+                part1,
+                new BigDecimal("-4.00"),
+                TypePaiement.REMBOURSEMENT,
+                LocalDateTime.of(2026, 3, 10, 13, 0)
+        ));
+        paiementRepository.save(new Paiement(
+                part2,
+                new BigDecimal("8.00"),
+                TypePaiement.ENCAISSEMENT,
+                LocalDateTime.of(2026, 3, 10, 14, 0)
+        ));
+
+        BigDecimal sum = paiementRepository.sumMontantByParticipationJoueurMatriculeAndType(
+                "J001",
+                TypePaiement.ENCAISSEMENT
+        );
+
+        assertThat(sum).isEqualByComparingTo(new BigDecimal("10.00"));
+    }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/repository/ParticipationRepositoryTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/repository/ParticipationRepositoryTest.java
@@ -58,4 +58,28 @@ class ParticipationRepositoryTest extends SqlServerTestContainerConfig {
         assertThat(participationRepository.countByMatch_Id(match.getId()))
                 .isEqualTo(2);
     }
+
+    @Test
+    void countByJoueurMatricule_compte_les_participations_du_joueur() {
+        Site s = siteRepository.save(new Site("Site C", "Liege"));
+        Terrain t = terrainRepository.save(new Terrain("T3", s));
+
+        Joueur orga = joueurRepository.save(new Joueur("ORG3", "Orga3", TypeJoueur.GLOBAL));
+        Joueur j1 = joueurRepository.save(new Joueur("J020", "Alice", TypeJoueur.GLOBAL));
+        Joueur j2 = joueurRepository.save(new Joueur("J021", "Bob", TypeJoueur.GLOBAL));
+
+        MatchPadel match1 = matchPadelRepository.save(
+                new MatchPadel(t, orga, LocalDateTime.of(2030, 1, 1, 10, 0), MatchVisibilite.PUBLIC)
+        );
+        MatchPadel match2 = matchPadelRepository.save(
+                new MatchPadel(t, orga, LocalDateTime.of(2030, 1, 2, 10, 0), MatchVisibilite.PRIVE)
+        );
+
+        participationRepository.save(new Participation(match1, j1));
+        participationRepository.save(new Participation(match2, j1));
+        participationRepository.save(new Participation(match2, j2));
+
+        assertThat(participationRepository.countByJoueur_Matricule("J020")).isEqualTo(2L);
+        assertThat(participationRepository.countByJoueur_Matricule("J021")).isEqualTo(1L);
+    }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MeStatsServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MeStatsServiceTest.java
@@ -1,0 +1,139 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.dto.response.MeStatsDto;
+import be.ephec.padel.backend.exception.ForbiddenException;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.TypePaiement;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
+import be.ephec.padel.backend.service.MeStatsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MeStatsServiceTest {
+
+    @Mock
+    CurrentUserFacade currentUserFacade;
+    @Mock
+    ParticipationRepository participationRepository;
+    @Mock
+    MatchPadelRepository matchPadelRepository;
+    @Mock
+    PaiementRepository paiementRepository;
+
+    private MeStatsService service;
+    private Clock fixedClock;
+
+    @BeforeEach
+    void setUp() {
+        fixedClock = Clock.fixed(Instant.parse("2030-01-10T09:30:00Z"), ZoneOffset.UTC);
+        service = new MeStatsService(
+                currentUserFacade,
+                participationRepository,
+                matchPadelRepository,
+                paiementRepository,
+                fixedClock
+        );
+    }
+
+    @Test
+    void getCurrentUserStats_calcule_le_snapshot_nominal() {
+        Joueur joueur = new Joueur("G0001", "Alice", TypeJoueur.GLOBAL);
+        joueur.setSolde(new BigDecimal("12.50"));
+
+        LocalDateTime now = LocalDateTime.now(fixedClock);
+
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
+        when(participationRepository.countByJoueur_Matricule("G0001")).thenReturn(5L);
+        when(matchPadelRepository.countByOrganisateur_Matricule("G0001")).thenReturn(3L);
+        when(matchPadelRepository.countDistinctLinkedPastMatchesByMatricule("G0001", now)).thenReturn(2L);
+        when(matchPadelRepository.countDistinctLinkedFutureMatchesByMatricule("G0001", now)).thenReturn(4L);
+        when(matchPadelRepository.countDistinctLinkedCancelledMatchesByMatricule("G0001")).thenReturn(1L);
+        when(paiementRepository.sumMontantByParticipationJoueurMatriculeAndType("G0001", TypePaiement.ENCAISSEMENT))
+                .thenReturn(new BigDecimal("42.00"));
+
+        MeStatsDto dto = service.getCurrentUserStats();
+
+        assertThat(dto.getNbMatchsParticipes()).isEqualTo(5L);
+        assertThat(dto.getNbMatchsOrganises()).isEqualTo(3L);
+        assertThat(dto.getNbMatchsPasses()).isEqualTo(2L);
+        assertThat(dto.getNbMatchsFuturs()).isEqualTo(4L);
+        assertThat(dto.getNbMatchsAnnules()).isEqualTo(1L);
+        assertThat(dto.getMontantTotalPaye()).isEqualByComparingTo("42.00");
+        assertThat(dto.getDetteActuelle()).isEqualByComparingTo("12.50");
+
+        verify(matchPadelRepository).countDistinctLinkedPastMatchesByMatricule("G0001", now);
+        verify(matchPadelRepository).countDistinctLinkedFutureMatchesByMatricule("G0001", now);
+        verify(paiementRepository).sumMontantByParticipationJoueurMatriculeAndType("G0001", TypePaiement.ENCAISSEMENT);
+    }
+
+    @Test
+    void getCurrentUserStats_utilise_le_solde_courant_du_joueur() {
+        Joueur joueur = new Joueur("G0001", "Alice", TypeJoueur.GLOBAL);
+        joueur.setSolde(new BigDecimal("7.25"));
+
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
+        when(participationRepository.countByJoueur_Matricule("G0001")).thenReturn(0L);
+        when(matchPadelRepository.countByOrganisateur_Matricule("G0001")).thenReturn(0L);
+        when(matchPadelRepository.countDistinctLinkedPastMatchesByMatricule(eq("G0001"), eq(LocalDateTime.now(fixedClock))))
+                .thenReturn(0L);
+        when(matchPadelRepository.countDistinctLinkedFutureMatchesByMatricule(eq("G0001"), eq(LocalDateTime.now(fixedClock))))
+                .thenReturn(0L);
+        when(matchPadelRepository.countDistinctLinkedCancelledMatchesByMatricule("G0001")).thenReturn(0L);
+        when(paiementRepository.sumMontantByParticipationJoueurMatriculeAndType("G0001", TypePaiement.ENCAISSEMENT))
+                .thenReturn(BigDecimal.ZERO);
+
+        MeStatsDto dto = service.getCurrentUserStats();
+
+        assertThat(dto.getDetteActuelle()).isEqualByComparingTo("7.25");
+    }
+
+    @Test
+    void getCurrentUserStats_passe_et_futur_sont_bases_sur_clock() {
+        Joueur joueur = new Joueur("G0001", "Alice", TypeJoueur.GLOBAL);
+        LocalDateTime now = LocalDateTime.now(fixedClock);
+
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
+        when(participationRepository.countByJoueur_Matricule("G0001")).thenReturn(0L);
+        when(matchPadelRepository.countByOrganisateur_Matricule("G0001")).thenReturn(0L);
+        when(matchPadelRepository.countDistinctLinkedPastMatchesByMatricule("G0001", now)).thenReturn(1L);
+        when(matchPadelRepository.countDistinctLinkedFutureMatchesByMatricule("G0001", now)).thenReturn(2L);
+        when(matchPadelRepository.countDistinctLinkedCancelledMatchesByMatricule("G0001")).thenReturn(0L);
+        when(paiementRepository.sumMontantByParticipationJoueurMatriculeAndType("G0001", TypePaiement.ENCAISSEMENT))
+                .thenReturn(BigDecimal.ZERO);
+
+        MeStatsDto dto = service.getCurrentUserStats();
+
+        assertThat(dto.getNbMatchsPasses()).isEqualTo(1L);
+        assertThat(dto.getNbMatchsFuturs()).isEqualTo(2L);
+    }
+
+    @Test
+    void getCurrentUserStats_propage_forbidden_si_aucun_joueur_lie() {
+        when(currentUserFacade.getCurrentJoueur())
+                .thenThrow(new ForbiddenException("Aucun joueur lie a l'utilisateur authentifie."));
+
+        assertThatThrownBy(() -> service.getCurrentUserStats())
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Aucun joueur lie a l'utilisateur authentifie.");
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MeControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MeControllerTest.java
@@ -3,6 +3,7 @@ package be.ephec.padel.backend.web.controller;
 import be.ephec.padel.backend.config.SecurityConfig;
 import be.ephec.padel.backend.controller.MeController;
 import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
+import be.ephec.padel.backend.dto.response.MeStatsDto;
 import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
 import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
 import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
@@ -13,6 +14,7 @@ import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.service.JoueurService;
+import be.ephec.padel.backend.service.MeStatsService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -24,6 +26,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -42,6 +45,9 @@ class MeControllerTest {
 
     @MockitoBean
     JoueurService joueurService;
+
+    @MockitoBean
+    MeStatsService meStatsService;
 
     @Test
     @WithAnonymousUser
@@ -157,5 +163,46 @@ class MeControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.dette").value(true));
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getMyStats_sans_auth_401() throws Exception {
+        mvc.perform(get("/api/v1/me/stats"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getMyStats_ok_200() throws Exception {
+        when(meStatsService.getCurrentUserStats()).thenReturn(new MeStatsDto(
+                5L,
+                2L,
+                3L,
+                1L,
+                1L,
+                new BigDecimal("42.00"),
+                new BigDecimal("7.50")
+        ));
+
+        mvc.perform(get("/api/v1/me/stats"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.nbMatchsParticipes").value(5))
+                .andExpect(jsonPath("$.nbMatchsOrganises").value(2))
+                .andExpect(jsonPath("$.nbMatchsPasses").value(3))
+                .andExpect(jsonPath("$.nbMatchsFuturs").value(1))
+                .andExpect(jsonPath("$.nbMatchsAnnules").value(1))
+                .andExpect(jsonPath("$.montantTotalPaye").value(42.00))
+                .andExpect(jsonPath("$.detteActuelle").value(7.50));
+    }
+
+    @Test
+    void getMyStats_forbidden_si_aucun_joueur_lie() throws Exception {
+        when(meStatsService.getCurrentUserStats())
+                .thenThrow(new ForbiddenException("Aucun joueur lie a l'utilisateur authentifie."));
+
+        mvc.perform(get("/api/v1/me/stats"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("Aucun joueur lie a l'utilisateur authentifie."));
     }
 }


### PR DESCRIPTION
Ajout de GET /api/v1/me/stats avec DTO dédié, service MeStatsService et agrégats repository.

Statistiques implémentées :
- participations, organisation
- matchs passés / futurs / annulés (avec déduplication)
- montant total payé (ENCAISSEMENT uniquement)
- dette actuelle

Comportement aligné avec /api/v1/me (403 si aucun joueur lié). Tests unitaires, web et repository ajoutés.