### PR TITLE
feat(seed): ajout du seed dev/local avec données de démo et comptes utilisateurs

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 
 public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
 
+    Optional<MatchPadel> findByTerrain_IdAndDateDebut(Long terrainId, LocalDateTime dateDebut);
+
     @Query("select m from MatchPadel m where m.terrain.id = :terrainId")
     List<MatchPadel> findByTerrainId(@Param("terrainId") Long terrainId);
 

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/PaiementRepository.java
@@ -9,10 +9,12 @@ import org.springframework.data.repository.query.Param;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface PaiementRepository extends JpaRepository<Paiement, Long> {
 
     List<Paiement> findByParticipation_Id(Long participationId);
+    Optional<Paiement> findByParticipation_IdAndType(Long participationId, TypePaiement type);
 
     List<Paiement> findByParticipation_Joueur_Matricule(String matricule);
 

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/SiteRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/SiteRepository.java
@@ -3,6 +3,9 @@ package be.ephec.padel.backend.repository;
 import be.ephec.padel.backend.model.entities.Site;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SiteRepository extends JpaRepository<Site, Long> {
     boolean existsByNom(String nom);
+    Optional<Site> findByNom(String nom);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/TerrainRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/TerrainRepository.java
@@ -4,10 +4,12 @@ import be.ephec.padel.backend.model.entities.Terrain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TerrainRepository extends JpaRepository<Terrain, Long> {
 
     boolean existsByNomAndSiteId(String nom, Long siteId);
+    Optional<Terrain> findByNomAndSiteId(String nom, Long siteId);
 
     List<Terrain> findBySite_Id(Long siteId);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeedRunner.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeedRunner.java
@@ -1,0 +1,27 @@
+package be.ephec.padel.backend.seed;
+
+import be.ephec.padel.backend.service.UserBootstrapService;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile({"local", "dev"})
+@DependsOn(UserBootstrapService.BEAN_NAME)
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+public class DevDataSeedRunner implements ApplicationRunner {
+
+    private final DevDataSeeder devDataSeeder;
+
+    public DevDataSeedRunner(DevDataSeeder devDataSeeder) {
+        this.devDataSeeder = devDataSeeder;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        devDataSeeder.seed();
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeeder.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeeder.java
@@ -1,0 +1,372 @@
+package be.ephec.padel.backend.seed;
+
+import be.ephec.padel.backend.model.entities.HoraireSite;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Paiement;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.entities.User;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.model.enums.TypePaiement;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.UserStatus;
+import be.ephec.padel.backend.repository.HoraireSiteRepository;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Set;
+
+@Service
+public class DevDataSeeder {
+
+    private static final Logger log = LoggerFactory.getLogger(DevDataSeeder.class);
+
+    private static final String SEED_MARKER_LOGIN = "joueur.global.dev";
+    private static final String EXPECTED_ADMIN_SITE_MAPPING = "admin.site.nord.dev:1";
+    private static final String EXPECTED_ADMIN_SITE_LOGIN = "admin.site.nord.dev";
+    private static final String PLAYER_PASSWORD = "joueur123";
+    private static final BigDecimal PART = new BigDecimal("7.50");
+
+    private final SiteRepository siteRepository;
+    private final TerrainRepository terrainRepository;
+    private final HoraireSiteRepository horaireSiteRepository;
+    private final JoueurRepository joueurRepository;
+    private final UserRepository userRepository;
+    private final MatchPadelRepository matchPadelRepository;
+    private final ParticipationRepository participationRepository;
+    private final PaiementRepository paiementRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final Clock clock;
+    private final String adminGlobalUsername;
+    private final String adminSiteUsers;
+
+    public DevDataSeeder(SiteRepository siteRepository,
+                         TerrainRepository terrainRepository,
+                         HoraireSiteRepository horaireSiteRepository,
+                         JoueurRepository joueurRepository,
+                         UserRepository userRepository,
+                         MatchPadelRepository matchPadelRepository,
+                         ParticipationRepository participationRepository,
+                         PaiementRepository paiementRepository,
+                         PasswordEncoder passwordEncoder,
+                         Clock clock,
+                         @Value("${app.security.admin.global.username:}") String adminGlobalUsername,
+                         @Value("${app.security.admin.site.users:}") String adminSiteUsers) {
+        this.siteRepository = siteRepository;
+        this.terrainRepository = terrainRepository;
+        this.horaireSiteRepository = horaireSiteRepository;
+        this.joueurRepository = joueurRepository;
+        this.userRepository = userRepository;
+        this.matchPadelRepository = matchPadelRepository;
+        this.participationRepository = participationRepository;
+        this.paiementRepository = paiementRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.clock = clock;
+        this.adminGlobalUsername = adminGlobalUsername;
+        this.adminSiteUsers = adminSiteUsers;
+    }
+
+    @Transactional
+    public void seed() {
+        log.info("Seed dev actif: support garanti uniquement sur DB locale propre / vide.");
+
+        validateAdminBootstrapOrderAndConfiguration();
+
+        if (userRepository.existsByLogin(SEED_MARKER_LOGIN)) {
+            log.info("Seed dev deja present (marqueur detecte: {}). Aucun reseed des matchs et donnees metier.", SEED_MARKER_LOGIN);
+            return;
+        }
+
+        validateCleanDatabaseBeforeFirstSeed();
+
+        int currentYear = LocalDate.now(clock).getYear();
+
+        Site siteNord = ensureSite("Site Nord", "Bruxelles");
+        if (!Long.valueOf(1L).equals(siteNord.getId())) {
+            throw new IllegalStateException(
+                    "Seed dev incompatible avec cette base: Site Nord devrait obtenir l'id 1 mais a l'id "
+                            + siteNord.getId()
+                            + ". Support garanti uniquement sur une DB locale propre / vide."
+            );
+        }
+        Site siteSud = ensureSite("Site Sud", "Namur");
+
+        ensureHoraire(siteNord, currentYear);
+        ensureHoraire(siteNord, currentYear + 1);
+        ensureHoraire(siteSud, currentYear);
+        ensureHoraire(siteSud, currentYear + 1);
+
+        Terrain nordT1 = ensureTerrain(siteNord, "Nord T1");
+        Terrain nordT2 = ensureTerrain(siteNord, "Nord T2");
+        Terrain sudT1 = ensureTerrain(siteSud, "Sud T1");
+        Terrain sudT2 = ensureTerrain(siteSud, "Sud T2");
+
+        Joueur joueurGlobal = ensureJoueur("G9001", "Joueur Global Demo", TypeJoueur.GLOBAL, null, "0.00");
+        Joueur joueurSiteNord = ensureJoueur("S9001", "Joueur Site Nord Demo", TypeJoueur.SITE, siteNord, "0.00");
+        Joueur joueurLibre = ensureJoueur("L9001", "Joueur Libre Demo", TypeJoueur.LIBRE, null, "15.00");
+        Joueur joueurSiteSud = ensureJoueur("S9002", "Joueur Site Sud Demo", TypeJoueur.SITE, siteSud, "0.00");
+
+        ensurePlayerUser("joueur.global.dev", joueurGlobal);
+        ensurePlayerUser("joueur.site.dev", joueurSiteNord);
+        ensurePlayerUser("joueur.libre.dev", joueurLibre);
+        ensurePlayerUser("joueur.site.sud.dev", joueurSiteSud);
+
+        LocalDate today = LocalDate.now(clock);
+
+        MatchPadel publicFuturOuvert = ensureMatch(
+                nordT1,
+                joueurGlobal,
+                today.plusDays(1).atTime(18, 0),
+                MatchVisibilite.PUBLIC,
+                MatchStatut.PLANIFIE
+        );
+        ensureParticipation(publicFuturOuvert, joueurGlobal);
+        ensureParticipation(publicFuturOuvert, joueurSiteNord);
+        ensureEncaissement(publicFuturOuvert, joueurGlobal, PART);
+        ensureEncaissement(publicFuturOuvert, joueurSiteNord, PART);
+
+        MatchPadel publicFuturComplet = ensureMatch(
+                nordT2,
+                joueurSiteNord,
+                today.plusDays(2).atTime(19, 30),
+                MatchVisibilite.PUBLIC,
+                MatchStatut.PLANIFIE
+        );
+        ensureParticipation(publicFuturComplet, joueurSiteNord);
+        ensureParticipation(publicFuturComplet, joueurGlobal);
+        ensureParticipation(publicFuturComplet, joueurLibre);
+        ensureParticipation(publicFuturComplet, joueurSiteSud);
+        ensureEncaissement(publicFuturComplet, joueurSiteNord, PART);
+        ensureEncaissement(publicFuturComplet, joueurGlobal, PART);
+        ensureEncaissement(publicFuturComplet, joueurSiteSud, PART);
+
+        MatchPadel priveFutur = ensureMatch(
+                sudT1,
+                joueurSiteSud,
+                today.plusDays(3).atTime(20, 0),
+                MatchVisibilite.PRIVE,
+                MatchStatut.PLANIFIE
+        );
+        ensureParticipation(priveFutur, joueurSiteSud);
+        ensureParticipation(priveFutur, joueurLibre);
+        ensureEncaissement(priveFutur, joueurSiteSud, PART);
+
+        MatchPadel publicPasse = ensureMatch(
+                nordT1,
+                joueurGlobal,
+                today.minusDays(5).atTime(18, 30),
+                MatchVisibilite.PUBLIC,
+                MatchStatut.PLANIFIE
+        );
+        ensureParticipation(publicPasse, joueurGlobal);
+        ensureParticipation(publicPasse, joueurSiteNord);
+        ensureParticipation(publicPasse, joueurLibre);
+        ensureParticipation(publicPasse, joueurSiteSud);
+        ensureEncaissement(publicPasse, joueurGlobal, PART);
+        ensureEncaissement(publicPasse, joueurSiteNord, PART);
+        ensureEncaissement(publicPasse, joueurLibre, PART);
+        ensureEncaissement(publicPasse, joueurSiteSud, PART);
+
+        MatchPadel annule = ensureMatch(
+                sudT2,
+                joueurGlobal,
+                today.plusDays(4).atTime(17, 0),
+                MatchVisibilite.PUBLIC,
+                MatchStatut.ANNULE
+        );
+        ensureParticipation(annule, joueurGlobal);
+        ensureParticipation(annule, joueurSiteNord);
+        ensureEncaissement(annule, joueurGlobal, PART);
+        ensureEncaissement(annule, joueurSiteNord, PART);
+        ensureRemboursement(annule, joueurGlobal, PART.negate());
+        ensureRemboursement(annule, joueurSiteNord, PART.negate());
+
+        log.info("""
+                Seed dev initialise avec succes.
+                Comptes de demo :
+                - admin.global.dev / admin123
+                - admin.site.nord.dev / admin123
+                - joueur.global.dev / {}
+                - joueur.site.dev / {}
+                - joueur.libre.dev / {}
+                - joueur.site.sud.dev / {}
+                Support ADMIN_SITE garanti uniquement sur DB locale propre / vide.
+                """, PLAYER_PASSWORD, PLAYER_PASSWORD, PLAYER_PASSWORD, PLAYER_PASSWORD);
+    }
+
+    private void validateAdminBootstrapOrderAndConfiguration() {
+        if (adminSiteUsers == null || !adminSiteUsers.contains(EXPECTED_ADMIN_SITE_MAPPING)) {
+            throw new IllegalStateException(
+                    "Seed dev incompatible avec la configuration courante: la propriete app.security.admin.site.users doit contenir "
+                            + EXPECTED_ADMIN_SITE_MAPPING
+                            + "."
+            );
+        }
+
+        if (adminGlobalUsername == null || adminGlobalUsername.isBlank()) {
+            throw new IllegalStateException("Seed dev incompatible: app.security.admin.global.username est vide.");
+        }
+
+        if (userRepository.findByLogin(adminGlobalUsername).isEmpty()) {
+            throw new IllegalStateException(
+                    "Le bootstrap admin global n'a pas ete execute avant le seed (login attendu: "
+                            + adminGlobalUsername
+                            + ")."
+            );
+        }
+
+        if (userRepository.findByLogin(EXPECTED_ADMIN_SITE_LOGIN).isEmpty()) {
+            throw new IllegalStateException(
+                    "Le bootstrap ADMIN_SITE n'a pas ete execute avant le seed (login attendu: "
+                            + EXPECTED_ADMIN_SITE_LOGIN
+                            + ")."
+            );
+        }
+    }
+
+    private void validateCleanDatabaseBeforeFirstSeed() {
+        boolean dataExists = siteRepository.count() > 0
+                || terrainRepository.count() > 0
+                || horaireSiteRepository.count() > 0
+                || joueurRepository.count() > 0
+                || matchPadelRepository.count() > 0
+                || participationRepository.count() > 0
+                || paiementRepository.count() > 0;
+
+        if (dataExists) {
+            throw new IllegalStateException(
+                    "app.seed.enabled=true requiert une DB locale propre / vide avant le premier seed. "
+                            + "Des donnees metier existent deja, le seed dev one-shot est donc refuse."
+            );
+        }
+    }
+
+    private Site ensureSite(String nom, String ville) {
+        Site site = siteRepository.findByNom(nom).orElseGet(() -> siteRepository.save(new Site(nom, ville)));
+        site.setVille(ville);
+        site.setJoursFermeture(Set.of());
+        return siteRepository.save(site);
+    }
+
+    private void ensureHoraire(Site site, int year) {
+        if (horaireSiteRepository.existsBySiteIdAndAnnee(site.getId(), year)) {
+            return;
+        }
+
+        horaireSiteRepository.save(new HoraireSite(
+                site,
+                year,
+                LocalTime.of(8, 0),
+                LocalTime.of(23, 0)
+        ));
+    }
+
+    private Terrain ensureTerrain(Site site, String nom) {
+        return terrainRepository.findByNomAndSiteId(nom, site.getId())
+                .orElseGet(() -> terrainRepository.save(new Terrain(nom, site)));
+    }
+
+    private Joueur ensureJoueur(String matricule,
+                                String nom,
+                                TypeJoueur type,
+                                Site site,
+                                String solde) {
+        Joueur joueur = joueurRepository.findById(matricule)
+                .orElseGet(() -> site == null
+                        ? new Joueur(matricule, nom, type)
+                        : new Joueur(matricule, nom, type, site));
+
+        joueur.setNom(nom);
+        joueur.setType(type);
+        joueur.setSite(site);
+        joueur.setSolde(amount(solde));
+
+        return joueurRepository.save(joueur);
+    }
+
+    private void ensurePlayerUser(String login, Joueur joueur) {
+        User user = userRepository.findByLogin(login).orElseGet(User::new);
+        user.setLogin(login);
+        user.setPasswordHash(passwordEncoder.encode(PLAYER_PASSWORD));
+        user.setActive(true);
+        user.setStatus(UserStatus.ACTIVE);
+        user.setJoueur(joueur);
+        user.addRole(SecurityRole.ROLE_JOUEUR);
+        userRepository.save(user);
+    }
+
+    private MatchPadel ensureMatch(Terrain terrain,
+                                   Joueur organisateur,
+                                   LocalDateTime dateDebut,
+                                   MatchVisibilite visibilite,
+                                   MatchStatut statut) {
+        MatchPadel match = matchPadelRepository.findByTerrain_IdAndDateDebut(terrain.getId(), dateDebut)
+                .orElseGet(() -> matchPadelRepository.save(new MatchPadel(terrain, organisateur, dateDebut, visibilite)));
+
+        match.setTerrain(terrain);
+        match.setOrganisateur(organisateur);
+        match.setDateDebut(dateDebut);
+        match.setVisibilite(visibilite);
+        match.setStatut(statut);
+
+        return matchPadelRepository.save(match);
+    }
+
+    private Participation ensureParticipation(MatchPadel match, Joueur joueur) {
+        return participationRepository.findByMatch_IdAndJoueur_Matricule(match.getId(), joueur.getMatricule())
+                .orElseGet(() -> participationRepository.save(new Participation(match, joueur)));
+    }
+
+    private void ensureEncaissement(MatchPadel match, Joueur joueur, BigDecimal montant) {
+        Participation participation = ensureParticipation(match, joueur);
+        if (paiementRepository.findByParticipation_IdAndType(participation.getId(), TypePaiement.ENCAISSEMENT).isPresent()) {
+            return;
+        }
+
+        paiementRepository.save(new Paiement(
+                participation,
+                montant.setScale(2, RoundingMode.HALF_UP),
+                TypePaiement.ENCAISSEMENT,
+                match.getDateDebut().minusDays(2)
+        ));
+    }
+
+    private void ensureRemboursement(MatchPadel match, Joueur joueur, BigDecimal montant) {
+        Participation participation = ensureParticipation(match, joueur);
+        if (paiementRepository.findByParticipation_IdAndType(participation.getId(), TypePaiement.REMBOURSEMENT).isPresent()) {
+            return;
+        }
+
+        paiementRepository.save(new Paiement(
+                participation,
+                montant.setScale(2, RoundingMode.HALF_UP),
+                TypePaiement.REMBOURSEMENT,
+                match.getDateDebut().minusDays(1)
+        ));
+    }
+
+    private BigDecimal amount(String value) {
+        return new BigDecimal(value).setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/UserBootstrapService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/UserBootstrapService.java
@@ -9,8 +9,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-@Service
+@Service(UserBootstrapService.BEAN_NAME)
 public class UserBootstrapService {
+
+    public static final String BEAN_NAME = "userBootstrapService";
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;

--- a/backend/backend/src/main/resources/application-dev.properties
+++ b/backend/backend/src/main/resources/application-dev.properties
@@ -1,0 +1,6 @@
+app.seed.enabled=true
+
+app.security.admin.global.username=admin.global.dev
+app.security.admin.global.password=admin123
+app.security.admin.site.password=admin123
+app.security.admin.site.users=admin.site.nord.dev:1

--- a/backend/backend/src/main/resources/application-local.properties
+++ b/backend/backend/src/main/resources/application-local.properties
@@ -1,0 +1,6 @@
+app.seed.enabled=true
+
+app.security.admin.global.username=admin.global.dev
+app.security.admin.global.password=admin123
+app.security.admin.site.password=admin123
+app.security.admin.site.users=admin.site.nord.dev:1

--- a/backend/backend/src/main/resources/application.properties
+++ b/backend/backend/src/main/resources/application.properties
@@ -10,6 +10,8 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 spring.jpa.open-in-view=false
 
+app.seed.enabled=false
+
 
 app.security.admin.global.username=${ADMIN_GLOBAL_USERNAME}
 app.security.admin.global.password=${ADMIN_GLOBAL_PASSWORD}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/seed/DevDataSeederTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/seed/DevDataSeederTest.java
@@ -1,0 +1,120 @@
+package be.ephec.padel.backend.unit.seed;
+
+import be.ephec.padel.backend.repository.HoraireSiteRepository;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.MatchPadelRepository;
+import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.repository.UserRepository;
+import be.ephec.padel.backend.seed.DevDataSeeder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DevDataSeederTest {
+
+    @Mock
+    SiteRepository siteRepository;
+    @Mock
+    TerrainRepository terrainRepository;
+    @Mock
+    HoraireSiteRepository horaireSiteRepository;
+    @Mock
+    JoueurRepository joueurRepository;
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    MatchPadelRepository matchPadelRepository;
+    @Mock
+    ParticipationRepository participationRepository;
+    @Mock
+    PaiementRepository paiementRepository;
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    DevDataSeeder seeder;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(Instant.parse("2026-04-18T10:00:00Z"), ZoneId.of("Europe/Brussels"));
+        seeder = new DevDataSeeder(
+                siteRepository,
+                terrainRepository,
+                horaireSiteRepository,
+                joueurRepository,
+                userRepository,
+                matchPadelRepository,
+                participationRepository,
+                paiementRepository,
+                passwordEncoder,
+                clock,
+                "admin.global.dev",
+                "admin.site.nord.dev:1"
+        );
+    }
+
+    @Test
+    void seed_skip_si_marqueur_global_deja_present() {
+        when(userRepository.findByLogin("admin.global.dev")).thenReturn(Optional.of(new be.ephec.padel.backend.model.entities.User()));
+        when(userRepository.findByLogin("admin.site.nord.dev")).thenReturn(Optional.of(new be.ephec.padel.backend.model.entities.User()));
+        when(userRepository.existsByLogin("joueur.global.dev")).thenReturn(true);
+
+        seeder.seed();
+
+        verify(userRepository).existsByLogin("joueur.global.dev");
+        verify(siteRepository, never()).count();
+        verifyNoInteractions(terrainRepository, horaireSiteRepository, joueurRepository, matchPadelRepository, participationRepository, paiementRepository);
+    }
+
+    @Test
+    void seed_fail_fast_si_mapping_admin_site_invalide() {
+        Clock clock = Clock.fixed(Instant.parse("2026-04-18T10:00:00Z"), ZoneId.of("Europe/Brussels"));
+        DevDataSeeder invalidSeeder = new DevDataSeeder(
+                siteRepository,
+                terrainRepository,
+                horaireSiteRepository,
+                joueurRepository,
+                userRepository,
+                matchPadelRepository,
+                participationRepository,
+                paiementRepository,
+                passwordEncoder,
+                clock,
+                "admin.global.dev",
+                "admin.site.nord.dev:99"
+        );
+
+        assertThatThrownBy(invalidSeeder::seed)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("app.security.admin.site.users");
+    }
+
+    @Test
+    void seed_fail_fast_si_db_non_propre_avant_premier_seed() {
+        when(userRepository.findByLogin("admin.global.dev")).thenReturn(Optional.of(new be.ephec.padel.backend.model.entities.User()));
+        when(userRepository.findByLogin("admin.site.nord.dev")).thenReturn(Optional.of(new be.ephec.padel.backend.model.entities.User()));
+        when(userRepository.existsByLogin("joueur.global.dev")).thenReturn(false);
+        when(siteRepository.count()).thenReturn(1L);
+
+        assertThatThrownBy(seeder::seed)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("DB locale propre / vide");
+    }
+}


### PR DESCRIPTION
- seed activé via profil dev/local et app.seed.enabled
- exécution après UserBootstrapService (@DependsOn)
- création de comptes admin et joueurs de démo
- génération de sites, terrains et horaires
- création de matchs (publics, privés, passés, futurs, annulés)
- ajout de participations et paiements (dont remboursement)
- gestion d’un cas de dette joueur
- stratégie one-shot avec garde-fous (DB locale propre requise)
- aucun impact sur API publique ni DTO