### PR TITLE
feat(frontend): ajout AuthGuard et routing protégé avec returnUrl

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,9 +1,12 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './core/auth/auth.guard';
 import { LoginPageComponent } from './features/auth/login/login-page.component';
 import { HomePageComponent } from './features/home/home-page.component';
+import { EspacePrivePageComponent } from './features/test/espace-prive-page.component';
 
 export const routes: Routes = [
   { path: '', component: HomePageComponent },
   { path: 'login', component: LoginPageComponent },
+  { path: 'espace-prive', component: EspacePrivePageComponent, canActivate: [authGuard] },
   { path: '**', redirectTo: '' }
 ];

--- a/frontend/src/app/core/auth/auth.guard.ts
+++ b/frontend/src/app/core/auth/auth.guard.ts
@@ -1,0 +1,16 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = (route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/login'], {
+    queryParams: { returnUrl: state.url }
+  });
+};

--- a/frontend/src/app/features/auth/login/login-page.component.ts
+++ b/frontend/src/app/features/auth/login/login-page.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ApiErrorResponse, LoginRequest } from '../../../core/auth/auth.models';
 import { AuthService } from '../../../core/auth/auth.service';
 
@@ -15,6 +15,7 @@ import { AuthService } from '../../../core/auth/auth.service';
 })
 export class LoginPageComponent {
   private readonly fb = inject(FormBuilder);
+  private readonly route = inject(ActivatedRoute);
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
 
@@ -39,7 +40,7 @@ export class LoginPageComponent {
 
     this.authService.login(payload).subscribe({
       next: () => {
-        this.router.navigateByUrl('/');
+        this.router.navigateByUrl(this.getTargetUrl());
       },
       error: (error: HttpErrorResponse) => {
         this.isSubmitting = false;
@@ -66,9 +67,19 @@ export class LoginPageComponent {
         return Object.values(details).join(' ');
       }
 
-      return apiError?.message ?? 'Requete invalide.';
+      return apiError?.message ?? 'Requête invalide.';
     }
 
     return 'Backend inaccessible ou erreur inattendue.';
+  }
+
+  private getTargetUrl(): string {
+    const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl');
+
+    if (returnUrl?.startsWith('/')) {
+      return returnUrl;
+    }
+
+    return '/';
   }
 }

--- a/frontend/src/app/features/home/home-page.component.html
+++ b/frontend/src/app/features/home/home-page.component.html
@@ -4,14 +4,16 @@
     <h1>Accueil</h1>
 
     @if (authService.isAuthenticated()) {
-      <p>Connexion reussie. Le token JWT est stocke localement.</p>
+      <p>Connexion réussie. Le token JWT est stocké localement.</p>
       <div class="actions">
-        <button type="button" (click)="logout()">Se deconnecter</button>
+        <a routerLink="/espace-prive">Tester l'espace prive</a>
+        <button type="button" (click)="logout()">Se déconnecter</button>
       </div>
     } @else {
-      <p>Vous n'etes pas connecte.</p>
+      <p>Vous n'êtes pas connecte.</p>
       <div class="actions">
-        <a routerLink="/login">Aller a la page de login</a>
+        <a routerLink="/espace-prive">Essayer l'espace prive</a>
+        <a routerLink="/login">Aller à la page de login</a>
       </div>
     }
   </div>

--- a/frontend/src/app/features/test/espace-prive-page.component.css
+++ b/frontend/src/app/features/test/espace-prive-page.component.css
@@ -1,11 +1,6 @@
-.home-page {
-  display: flex;
-  justify-content: center;
-  padding: 4rem 1.5rem;
-}
-
-.home-card {
+.private-page {
   width: min(100%, 34rem);
+  margin: 4rem auto;
   padding: 2rem;
   border: 1px solid #d7e0eb;
   border-radius: 1rem;
@@ -13,21 +8,13 @@
   box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
 }
 
-.eyebrow {
-  margin: 0 0 0.5rem;
-  color: #0f766e;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-h1 {
+.private-page h1 {
   margin: 0 0 1rem;
   font-size: 2rem;
   color: #10233f;
 }
 
-p {
+.private-page p {
   margin: 0;
   color: #526277;
 }
@@ -39,11 +26,12 @@ p {
   margin-top: 1.5rem;
 }
 
-a,
-button {
+.actions a,
+.actions button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-width: 11rem;
   padding: 0.85rem 1rem;
   border: 0;
   border-radius: 0.75rem;
@@ -53,4 +41,13 @@ button {
   font-weight: 700;
   text-decoration: none;
   cursor: pointer;
+}
+
+.actions a {
+  background: #1d4ed8;
+}
+
+.actions a:hover,
+.actions button:hover {
+  filter: brightness(0.95);
 }

--- a/frontend/src/app/features/test/espace-prive-page.component.html
+++ b/frontend/src/app/features/test/espace-prive-page.component.html
@@ -1,0 +1,9 @@
+<section class="private-page">
+  <h1>Espace privé</h1>
+  <p>Accès autorise. Vous êtes connectés.</p>
+
+<div class="actions">
+  <a routerLink="/">Retour à l'accueil</a>
+  <button type="button" (click)="logout()"> Se déconnecter</button>
+</div>
+</section>

--- a/frontend/src/app/features/test/espace-prive-page.component.ts
+++ b/frontend/src/app/features/test/espace-prive-page.component.ts
@@ -1,0 +1,20 @@
+import { Component, inject } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { AuthService } from '../../core/auth/auth.service';
+
+@Component({
+  selector: 'app-espace-prive-page',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './espace-prive-page.component.html',
+  styleUrl: './espace-prive-page.component.css'
+})
+export class EspacePrivePageComponent {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  protected logout(): void {
+    this.authService.logout();
+    this.router.navigateByUrl('/');
+  }
+}


### PR DESCRIPTION
- ajout auth.guard fonctionnel
- protection de la route /espace-prive
- redirection vers /login avec returnUrl
- redirection après login vers page demandée
- ajout d’un composant de test privé
- amélioration UX minimale (navigation + logout)