### PR TITLE
feat(frontend): ajout interceptor JWT

### DIFF
--- a/backend/backend/.run/BackendApplication.run.xml
+++ b/backend/backend/.run/BackendApplication.run.xml
@@ -1,9 +1,14 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="BackendApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
+    <option name="ACTIVE_PROFILES" value="dev" />
     <envs>
       <env name="DB_USER" value="padel_app" />
-      <env name="DB_PASSWORD" value="Pass1419" />
+      <env name="DB_PASSWORD" value="PadelApp2026!" />
       <env name="SERVER_PORT" value="8081" />
+      <env name="ADMIN_GLOBAL_USERNAME" value="adminGlobal" />
+      <env name="ADMIN_GLOBAL_PASSWORD" value="admin123" />
+      <env name="ADMIN_SITE_PASSWORD" value="admin123" />
+      <env name="ADMIN_SITE_USERS" value="adminSite1:1,adminSite2:2" />
     </envs>
     <module name="backend" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="be.ephec.padel.backend.BackendApplication" />

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,13 +1,14 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
+import { jwtInterceptor } from './core/auth/jwt.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes),
-    provideHttpClient()
+    provideHttpClient(withInterceptors([jwtInterceptor]))
   ]
 };

--- a/frontend/src/app/core/auth/jwt.interceptor.ts
+++ b/frontend/src/app/core/auth/jwt.interceptor.ts
@@ -1,0 +1,20 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from './auth.service';
+
+export const jwtInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(AuthService);
+  const token = authService.getToken();
+
+  if (!token) {
+    return next(req);
+  }
+
+  const authReq = req.clone({
+    setHeaders: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+
+  return next(authReq);
+};

--- a/frontend/src/app/features/auth/login/login-page.component.html
+++ b/frontend/src/app/features/auth/login/login-page.component.html
@@ -1,7 +1,7 @@
 <section class="login-page">
   <form class="login-card" [formGroup]="form" (ngSubmit)="onSubmit()">
     <h1>Connexion</h1>
-    <p class="login-subtitle">Connectez-vous pour acceder a votre espace padel.</p>
+    <p class="login-subtitle">Connectez-vous pour accedér à3 votre espace padel.</p>
 
     <label class="field">
       <span>Username</span>

--- a/frontend/src/app/features/test/espace-prive-page.component.css
+++ b/frontend/src/app/features/test/espace-prive-page.component.css
@@ -51,3 +51,20 @@
 .actions button:hover {
   filter: brightness(0.95);
 }
+
+.test-status {
+  margin: 1rem 0 0;
+  font-weight: 600;
+}
+
+.test-status.is-loading {
+  color: #9a6700;
+}
+
+.test-status.is-success {
+  color: #15803d;
+}
+
+.test-status.is-error {
+  color: #b91c1c;
+}

--- a/frontend/src/app/features/test/espace-prive-page.component.html
+++ b/frontend/src/app/features/test/espace-prive-page.component.html
@@ -1,9 +1,20 @@
 <section class="private-page">
   <h1>Espace privé</h1>
-  <p>Accès autorise. Vous êtes connectés.</p>
+  <p>Accès autorisé. Vous êtes connectés.</p>
 
-<div class="actions">
-  <a routerLink="/">Retour à l'accueil</a>
-  <button type="button" (click)="logout()"> Se déconnecter</button>
-</div>
+  <div class="actions">
+    <a routerLink="/">Retour à l'accueil</a>
+    <button type="button" (click)="testBackendCall()">Tester appel backend</button>
+    <button type="button" (click)="logout()">Se déconnecter</button>
+  </div>
+
+  <p
+    class="test-status"
+    [hidden]="backendTestStatus === 'idle'"
+    [class.is-loading]="backendTestStatus === 'loading'"
+    [class.is-success]="backendTestStatus === 'success'"
+    [class.is-error]="backendTestStatus === 'error'"
+  >
+    {{ backendTestMessage }}
+  </p>
 </section>

--- a/frontend/src/app/features/test/espace-prive-page.component.ts
+++ b/frontend/src/app/features/test/espace-prive-page.component.ts
@@ -1,6 +1,10 @@
+import { HttpClient } from '@angular/common/http';
 import { Component, inject } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
+import { environment } from '../../../environments/environment';
 import { AuthService } from '../../core/auth/auth.service';
+
+type BackendTestStatus = 'idle' | 'loading' | 'success' | 'error';
 
 @Component({
   selector: 'app-espace-prive-page',
@@ -11,7 +15,29 @@ import { AuthService } from '../../core/auth/auth.service';
 })
 export class EspacePrivePageComponent {
   private readonly authService = inject(AuthService);
+  private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
+
+  protected backendTestStatus: BackendTestStatus = 'idle';
+  protected backendTestMessage = '';
+
+  protected testBackendCall(): void {
+    this.backendTestStatus = 'loading';
+    this.backendTestMessage = 'Appel backend en cours...';
+
+    this.http
+      .get(`${environment.apiBaseUrl}/ping`, { responseType: 'text' })
+      .subscribe({
+        next: () => {
+          this.backendTestStatus = 'success';
+          this.backendTestMessage = 'Succés: appel backend effectué.';
+        },
+        error: () => {
+          this.backendTestStatus = 'error';
+          this.backendTestMessage = 'Échec: appel backend impossible.';
+        }
+      });
+  }
 
   protected logout(): void {
     this.authService.logout();


### PR DESCRIPTION
- ajout d’un interceptor fonctionnel Angular
- injection automatique du header Authorization avec le JWT
- configuration globale via app.config.ts
- ajout d’un test manuel temporaire depuis /espace-prive
- validation avec appel authentifié GET /api/v1/ping