### PR TITLE
feat(frontend): ajout gestion globale des erreurs HTTP

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -3,12 +3,13 @@ import { provideRouter } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
+import { httpErrorInterceptor } from './core/http-error.interceptor';
 import { jwtInterceptor } from './core/auth/jwt.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes),
-    provideHttpClient(withInterceptors([jwtInterceptor]))
+    provideHttpClient(withInterceptors([jwtInterceptor, httpErrorInterceptor]))
   ]
 };

--- a/frontend/src/app/app.css
+++ b/frontend/src/app/app.css
@@ -1,0 +1,20 @@
+.app-message {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: #fde68a;
+  color: #7c2d12;
+  border-bottom: 1px solid #f59e0b;
+}
+
+.app-message-close {
+  border: 0;
+  padding: 0.4rem 0.75rem;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,1 +1,10 @@
+@if (uiMessageService.message(); as message) {
+  <div class="app-message" role="alert" aria-live="polite">
+    <span>{{ message }}</span>
+    <button type="button" class="app-message-close" (click)="clearMessage()" aria-label="Fermer le message">
+      Fermer
+    </button>
+  </div>
+}
+
 <router-outlet />

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { UiMessageService } from './core/ui-message.service';
 
 @Component({
   selector: 'app-root',
@@ -8,4 +9,9 @@ import { RouterOutlet } from '@angular/router';
   styleUrl: './app.css'
 })
 export class App {
+  protected readonly uiMessageService = inject(UiMessageService);
+
+  protected clearMessage(): void {
+    this.uiMessageService.clear();
+  }
 }

--- a/frontend/src/app/core/http-error.interceptor.ts
+++ b/frontend/src/app/core/http-error.interceptor.ts
@@ -1,0 +1,36 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, throwError } from 'rxjs';
+import { AuthService } from './auth/auth.service';
+import { UiMessageService } from './ui-message.service';
+
+export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+  const uiMessageService = inject(UiMessageService);
+
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status === 401 && !isLoginRequest(req.url)) {
+        authService.logout();
+        uiMessageService.show('Votre session a expiré. Veuillez vous reconnecter.');
+        void router.navigateByUrl('/login');
+      } else if (error.status === 403) {
+        uiMessageService.show('Accès refusé.');
+      } else if (error.status === 500) {
+        uiMessageService.show('Une erreur serveur est survenue.');
+      }
+
+      return throwError(() => error);
+    })
+  );
+};
+
+function isLoginRequest(url: string): boolean {
+  try {
+    return new URL(url, 'http://localhost').pathname.endsWith('/auth/login');
+  } catch {
+    return url.endsWith('/auth/login');
+  }
+}

--- a/frontend/src/app/core/ui-message.service.ts
+++ b/frontend/src/app/core/ui-message.service.ts
@@ -1,0 +1,14 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class UiMessageService {
+  readonly message = signal<string | null>(null);
+
+  show(message: string): void {
+    this.message.set(message);
+  }
+
+  clear(): void {
+    this.message.set(null);
+  }
+}

--- a/frontend/src/app/features/auth/login/login-page.component.css
+++ b/frontend/src/app/features/auth/login/login-page.component.css
@@ -33,6 +33,12 @@ h1 {
   font-weight: 600;
 }
 
+.password-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
 input {
   width: 100%;
   padding: 0.8rem 0.9rem;
@@ -41,12 +47,16 @@ input {
   font: inherit;
 }
 
+.password-field input {
+  padding-right: 3rem;
+}
+
 input:focus {
   outline: 2px solid #8fd3c1;
   outline-offset: 2px;
 }
 
-button {
+.submit-button {
   padding: 0.9rem 1rem;
   border: 0;
   border-radius: 0.75rem;
@@ -57,9 +67,36 @@ button {
   cursor: pointer;
 }
 
-button:disabled {
+.submit-button:disabled {
   opacity: 0.7;
   cursor: wait;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: #526277;
+  font: inherit;
+  cursor: pointer;
+}
+
+.password-toggle:hover {
+  background: rgba(15, 118, 110, 0.08);
+  color: #10233f;
+}
+
+.password-toggle:focus-visible {
+  outline: 2px solid #8fd3c1;
+  outline-offset: 2px;
 }
 
 .error-message {

--- a/frontend/src/app/features/auth/login/login-page.component.html
+++ b/frontend/src/app/features/auth/login/login-page.component.html
@@ -1,7 +1,7 @@
 <section class="login-page">
   <form class="login-card" [formGroup]="form" (ngSubmit)="onSubmit()">
     <h1>Connexion</h1>
-    <p class="login-subtitle">Connectez-vous pour accedér à3 votre espace padel.</p>
+    <p class="login-subtitle">Connectez-vous pour accedér à votre espace padel.</p>
 
     <label class="field">
       <span>Username</span>
@@ -10,15 +10,29 @@
 
     <label class="field">
       <span>Password</span>
-      <input type="password" formControlName="password" autocomplete="current-password" />
+      <div class="password-field">
+        <input
+          [type]="showPassword() ? 'text' : 'password'"
+          formControlName="password"
+          autocomplete="current-password"
+        />
+        <button
+          type="button"
+          class="password-toggle"
+          [attr.aria-label]="showPassword() ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+          (click)="togglePasswordVisibility()"
+        >
+          &#128065;
+        </button>
+      </div>
     </label>
 
-    @if (errorMessage) {
-      <p class="error-message">{{ errorMessage }}</p>
+    @if (errorMessage()) {
+      <p class="error-message">{{ errorMessage() }}</p>
     }
 
-    <button type="submit" [disabled]="isSubmitting">
-      {{ isSubmitting ? 'Connexion...' : 'Se connecter' }}
+    <button type="submit" class="submit-button" [disabled]="isSubmitting()">
+      {{ isSubmitting() ? 'Connexion...' : 'Se connecter' }}
     </button>
   </form>
 </section>

--- a/frontend/src/app/features/auth/login/login-page.component.ts
+++ b/frontend/src/app/features/auth/login/login-page.component.ts
@@ -1,8 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { finalize } from 'rxjs';
 import { ApiErrorResponse, LoginRequest } from '../../../core/auth/auth.models';
 import { AuthService } from '../../../core/auth/auth.service';
 
@@ -19,8 +20,9 @@ export class LoginPageComponent {
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
 
-  protected isSubmitting = false;
-  protected errorMessage = '';
+  protected readonly isSubmitting = signal(false);
+  protected readonly errorMessage = signal('');
+  protected readonly showPassword = signal(false);
 
   protected readonly form = this.fb.nonNullable.group({
     username: ['', Validators.required],
@@ -33,27 +35,37 @@ export class LoginPageComponent {
       return;
     }
 
-    this.isSubmitting = true;
-    this.errorMessage = '';
+    this.isSubmitting.set(true);
+    this.errorMessage.set('');
 
     const payload: LoginRequest = this.form.getRawValue();
 
-    this.authService.login(payload).subscribe({
-      next: () => {
-        this.router.navigateByUrl(this.getTargetUrl());
-      },
-      error: (error: HttpErrorResponse) => {
-        this.isSubmitting = false;
-        this.errorMessage = this.buildErrorMessage(error);
-      }
-    });
+    this.authService
+      .login(payload)
+      .pipe(finalize(() => this.isSubmitting.set(false)))
+      .subscribe({
+        next: () => {
+          this.router.navigateByUrl(this.getTargetUrl());
+        },
+        error: (error: HttpErrorResponse) => {
+          this.errorMessage.set(this.buildErrorMessage(error));
+        }
+      });
+  }
+
+  protected togglePasswordVisibility(): void {
+    this.showPassword.update((value) => !value);
   }
 
   private buildErrorMessage(error: HttpErrorResponse): string {
     const apiError = error.error as ApiErrorResponse | null;
 
+    if (error.status === 0) {
+      return 'Backend inaccessible.';
+    }
+
     if (error.status === 401) {
-      return 'Identifiants invalides.';
+      return 'Identifiant ou mot de passe invalide.';
     }
 
     if (error.status === 403 && apiError?.message) {

--- a/frontend/src/app/features/home/home-page.component.html
+++ b/frontend/src/app/features/home/home-page.component.html
@@ -6,13 +6,13 @@
     @if (authService.isAuthenticated()) {
       <p>Connexion réussie. Le token JWT est stocké localement.</p>
       <div class="actions">
-        <a routerLink="/espace-prive">Tester l'espace prive</a>
+        <a routerLink="/espace-prive">Tester l'espace privé</a>
         <button type="button" (click)="logout()">Se déconnecter</button>
       </div>
     } @else {
       <p>Vous n'êtes pas connecte.</p>
       <div class="actions">
-        <a routerLink="/espace-prive">Essayer l'espace prive</a>
+        <a routerLink="/espace-prive">Essayer l'espace privé</a>
         <a routerLink="/login">Aller à la page de login</a>
       </div>
     }


### PR DESCRIPTION
- ajout d’un interceptor dédié aux erreurs HTTP
- gestion globale des 401 hors login avec logout et redirection
- affichage d’un message global via UiMessageService
- gestion simple des erreurs 403 et 500
- conservation du traitement local des erreurs de login
- correction du reset de chargement avec finalize
- ajout du toggle d’affichage du mot de passe