### PR TITLE
feat(frontend): ajouter le layout principal et la navigation

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,11 +2,22 @@ import { Routes } from '@angular/router';
 import { authGuard } from './core/auth/auth.guard';
 import { LoginPageComponent } from './features/auth/login/login-page.component';
 import { HomePageComponent } from './features/home/home-page.component';
+import { AdminPageComponent } from './features/placeholders/admin-page.component';
+import { MatchsPageComponent } from './features/placeholders/matchs-page.component';
 import { EspacePrivePageComponent } from './features/test/espace-prive-page.component';
+import { MainLayoutComponent } from './layout/main-layout.component';
 
 export const routes: Routes = [
-  { path: '', component: HomePageComponent },
-  { path: 'login', component: LoginPageComponent },
-  { path: 'espace-prive', component: EspacePrivePageComponent, canActivate: [authGuard] },
+  {
+    path: '',
+    component: MainLayoutComponent,
+    children: [
+      { path: '', component: HomePageComponent },
+      { path: 'login', component: LoginPageComponent },
+      { path: 'espace-prive', component: EspacePrivePageComponent, canActivate: [authGuard] },
+      { path: 'matchs', component: MatchsPageComponent, canActivate: [authGuard] },
+      { path: 'admin', component: AdminPageComponent, canActivate: [authGuard] }
+    ]
+  },
   { path: '**', redirectTo: '' }
 ];

--- a/frontend/src/app/core/auth/auth.service.ts
+++ b/frontend/src/app/core/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import { computed, inject, Injectable, signal } from '@angular/core';
 import { Observable, tap } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { LoginRequest, LoginResponse } from './auth.models';
@@ -8,6 +8,9 @@ import { LoginRequest, LoginResponse } from './auth.models';
 export class AuthService {
   private readonly http = inject(HttpClient);
   private readonly tokenStorageKey = 'auth_token';
+  private readonly authToken = signal<string | null>(localStorage.getItem(this.tokenStorageKey));
+
+  readonly isAuthenticatedState = computed(() => this.authToken() !== null);
 
   login(payload: LoginRequest): Observable<LoginResponse> {
     return this.http
@@ -17,17 +20,19 @@ export class AuthService {
 
   storeToken(token: string): void {
     localStorage.setItem(this.tokenStorageKey, token);
+    this.authToken.set(token);
   }
 
   getToken(): string | null {
-    return localStorage.getItem(this.tokenStorageKey);
+    return this.authToken();
   }
 
   isAuthenticated(): boolean {
-    return this.getToken() !== null;
+    return this.isAuthenticatedState();
   }
 
   logout(): void {
     localStorage.removeItem(this.tokenStorageKey);
+    this.authToken.set(null);
   }
 }

--- a/frontend/src/app/features/home/home-page.component.css
+++ b/frontend/src/app/features/home/home-page.component.css
@@ -28,29 +28,6 @@ h1 {
 }
 
 p {
-  margin: 0;
+  margin: 0.75rem 0 0;
   color: #526277;
-}
-
-.actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 1.5rem;
-}
-
-a,
-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.85rem 1rem;
-  border: 0;
-  border-radius: 0.75rem;
-  background: #0f766e;
-  color: #ffffff;
-  font: inherit;
-  font-weight: 700;
-  text-decoration: none;
-  cursor: pointer;
 }

--- a/frontend/src/app/features/home/home-page.component.html
+++ b/frontend/src/app/features/home/home-page.component.html
@@ -2,19 +2,10 @@
   <div class="home-card">
     <p class="eyebrow">Padel Manager</p>
     <h1>Accueil</h1>
-
-    @if (authService.isAuthenticated()) {
-      <p>Connexion réussie. Le token JWT est stocké localement.</p>
-      <div class="actions">
-        <a routerLink="/espace-prive">Tester l'espace privé</a>
-        <button type="button" (click)="logout()">Se déconnecter</button>
-      </div>
-    } @else {
-      <p>Vous n'êtes pas connecte.</p>
-      <div class="actions">
-        <a routerLink="/espace-prive">Essayer l'espace privé</a>
-        <a routerLink="/login">Aller à la page de login</a>
-      </div>
-    }
+    <p>Frontend Angular de démonstration pour le projet PDW / SGBD padel.</p>
+    <p>
+      La navigation principale est maintenant portée par le layout global. Les pages métiers seront
+      branchées progressivement derrière cette structure.
+    </p>
   </div>
 </section>

--- a/frontend/src/app/features/home/home-page.component.ts
+++ b/frontend/src/app/features/home/home-page.component.ts
@@ -1,19 +1,10 @@
-import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
-import { RouterLink } from '@angular/router';
-import { AuthService } from '../../core/auth/auth.service';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-home-page',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [],
   templateUrl: './home-page.component.html',
   styleUrl: './home-page.component.css'
 })
-export class HomePageComponent {
-  protected readonly authService = inject(AuthService);
-
-  protected logout(): void {
-    this.authService.logout();
-  }
-}
+export class HomePageComponent {}

--- a/frontend/src/app/features/placeholders/admin-page.component.ts
+++ b/frontend/src/app/features/placeholders/admin-page.component.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-admin-page',
+  standalone: true,
+  template: `
+    <section class="placeholder-page">
+      <p class="eyebrow">Navigation</p>
+      <h1>Administration</h1>
+      <p>
+        Cette page est un placeholder pour la future zone d'administration. L'affichage précis par rôle
+        sera finalisé lorsque le backend exposera clairement cette information.
+      </p>
+    </section>
+  `,
+  styles: `
+    .placeholder-page {
+      width: min(100%, 38rem);
+      margin: 4rem auto;
+      padding: 2rem;
+      border: 1px solid #d7e0eb;
+      border-radius: 1rem;
+      background: #ffffff;
+      box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+    }
+
+    .eyebrow {
+      margin: 0 0 0.5rem;
+      color: #0f766e;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    h1 {
+      margin: 0 0 1rem;
+      font-size: 2rem;
+      color: #10233f;
+    }
+
+    p {
+      margin: 0;
+      color: #526277;
+    }
+  `
+})
+export class AdminPageComponent {}

--- a/frontend/src/app/features/placeholders/matchs-page.component.ts
+++ b/frontend/src/app/features/placeholders/matchs-page.component.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-matchs-page',
+  standalone: true,
+  template: `
+    <section class="placeholder-page">
+      <p class="eyebrow">Navigation</p>
+      <h1>Matchs</h1>
+      <p>
+        Cette page est un placeholder pour la future navigation frontend. Aucune logique métier n'est
+        implémentée ici pour l'instant.
+      </p>
+    </section>
+  `,
+  styles: `
+    .placeholder-page {
+      width: min(100%, 38rem);
+      margin: 4rem auto;
+      padding: 2rem;
+      border: 1px solid #d7e0eb;
+      border-radius: 1rem;
+      background: #ffffff;
+      box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+    }
+
+    .eyebrow {
+      margin: 0 0 0.5rem;
+      color: #0f766e;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    h1 {
+      margin: 0 0 1rem;
+      font-size: 2rem;
+      color: #10233f;
+    }
+
+    p {
+      margin: 0;
+      color: #526277;
+    }
+  `
+})
+export class MatchsPageComponent {}

--- a/frontend/src/app/features/test/espace-prive-page.component.html
+++ b/frontend/src/app/features/test/espace-prive-page.component.html
@@ -1,11 +1,10 @@
 <section class="private-page">
   <h1>Espace privé</h1>
-  <p>Accès autorisé. Vous êtes connectés.</p>
+  <p>Accès autorisé. Vous êtes connecté.</p>
 
   <div class="actions">
     <a routerLink="/">Retour à l'accueil</a>
     <button type="button" (click)="testBackendCall()">Tester appel backend</button>
-    <button type="button" (click)="logout()">Se déconnecter</button>
   </div>
 
   <p

--- a/frontend/src/app/features/test/espace-prive-page.component.ts
+++ b/frontend/src/app/features/test/espace-prive-page.component.ts
@@ -1,8 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, inject } from '@angular/core';
-import { Router, RouterLink } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { environment } from '../../../environments/environment';
-import { AuthService } from '../../core/auth/auth.service';
 
 type BackendTestStatus = 'idle' | 'loading' | 'success' | 'error';
 
@@ -14,9 +13,7 @@ type BackendTestStatus = 'idle' | 'loading' | 'success' | 'error';
   styleUrl: './espace-prive-page.component.css'
 })
 export class EspacePrivePageComponent {
-  private readonly authService = inject(AuthService);
   private readonly http = inject(HttpClient);
-  private readonly router = inject(Router);
 
   protected backendTestStatus: BackendTestStatus = 'idle';
   protected backendTestMessage = '';
@@ -30,17 +27,12 @@ export class EspacePrivePageComponent {
       .subscribe({
         next: () => {
           this.backendTestStatus = 'success';
-          this.backendTestMessage = 'Succés: appel backend effectué.';
+          this.backendTestMessage = 'Succès: appel backend effectué.';
         },
         error: () => {
           this.backendTestStatus = 'error';
           this.backendTestMessage = 'Échec: appel backend impossible.';
         }
       });
-  }
-
-  protected logout(): void {
-    this.authService.logout();
-    this.router.navigateByUrl('/');
   }
 }

--- a/frontend/src/app/layout/main-layout.component.css
+++ b/frontend/src/app/layout/main-layout.component.css
@@ -1,0 +1,126 @@
+.layout-shell {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(143, 211, 193, 0.2), transparent 24rem),
+    linear-gradient(180deg, #f8fbff 0%, #eef4fb 100%);
+}
+
+.main-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid #d7e0eb;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(12px);
+}
+
+.header-inner {
+  width: min(100%, 72rem);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.7rem 1.5rem;
+}
+
+.header-start {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  min-width: 0;
+}
+
+.brand {
+  color: #10233f;
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.main-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.main-nav a {
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  color: #526277;
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.main-nav a:hover,
+.main-nav a.is-active {
+  background: rgba(15, 118, 110, 0.1);
+  color: #0f766e;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  min-width: fit-content;
+}
+
+.session-badge {
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #075985;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.logout-button {
+  padding: 0.6rem 0.9rem;
+  border: 0;
+  border-radius: 0.75rem;
+  background: #10233f;
+  color: #ffffff;
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.main-content {
+  width: min(100%, 72rem);
+  margin: 0 auto;
+  padding: 0 1.5rem 3rem;
+}
+
+@media (max-width: 760px) {
+  .header-inner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .header-start {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .brand {
+    text-align: center;
+  }
+
+  .main-nav {
+    justify-content: flex-start;
+  }
+
+  .header-actions {
+    min-width: 0;
+    justify-content: space-between;
+  }
+}

--- a/frontend/src/app/layout/main-layout.component.html
+++ b/frontend/src/app/layout/main-layout.component.html
@@ -1,0 +1,31 @@
+<div class="layout-shell">
+  <header class="main-header">
+    <div class="header-inner">
+      <div class="header-start">
+        <a class="brand" routerLink="/">Padel Manager</a>
+
+        <nav class="main-nav" aria-label="Navigation principale">
+          <a routerLink="/" routerLinkActive="is-active" [routerLinkActiveOptions]="{ exact: true }">Accueil</a>
+
+          @if (authService.isAuthenticatedState()) {
+            <a routerLink="/espace-prive" routerLinkActive="is-active">Mon espace</a>
+            <a routerLink="/matchs" routerLinkActive="is-active">Matchs</a>
+          } @else {
+            <a routerLink="/login" routerLinkActive="is-active">Connexion</a>
+          }
+        </nav>
+      </div>
+
+      <div class="header-actions">
+        @if (authService.isAuthenticatedState()) {
+          <span class="session-badge">Connecté</span>
+          <button type="button" class="logout-button" (click)="logout()">Se déconnecter</button>
+        }
+      </div>
+    </div>
+  </header>
+
+  <main class="main-content">
+    <router-outlet />
+  </main>
+</div>

--- a/frontend/src/app/layout/main-layout.component.ts
+++ b/frontend/src/app/layout/main-layout.component.ts
@@ -1,0 +1,21 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { AuthService } from '../core/auth/auth.service';
+
+@Component({
+  selector: 'app-main-layout',
+  standalone: true,
+  imports: [CommonModule, RouterLink, RouterLinkActive, RouterOutlet],
+  templateUrl: './main-layout.component.html',
+  styleUrl: './main-layout.component.css'
+})
+export class MainLayoutComponent {
+  protected readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  protected logout(): void {
+    this.authService.logout();
+    this.router.navigateByUrl('/');
+  }
+}


### PR DESCRIPTION
- Création du `MainLayoutComponent`
- Ajout d’une navbar globale
- Routes enfants sous le layout
- Ajout des placeholders `/matchs` et `/admin`
- Bouton logout dans la navbar
- Home simplifiée
- Affichage connecté / déconnecté via `AuthService`