### PR TITLE
feat(frontend): afficher mes matchs

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { authGuard } from './core/auth/auth.guard';
 import { LoginPageComponent } from './features/auth/login/login-page.component';
 import { HomePageComponent } from './features/home/home-page.component';
+import { MyMatchesPageComponent } from './features/matches/my-matches/my-matches-page.component';
 import { PublicMatchesPageComponent } from './features/matches/public-matches/public-matches-page.component';
 import { AdminPageComponent } from './features/placeholders/admin-page.component';
 import { EspacePrivePageComponent } from './features/test/espace-prive-page.component';
@@ -15,6 +16,7 @@ export const routes: Routes = [
       { path: '', component: HomePageComponent },
       { path: 'login', component: LoginPageComponent },
       { path: 'espace-prive', component: EspacePrivePageComponent, canActivate: [authGuard] },
+      { path: 'me/matchs', component: MyMatchesPageComponent, canActivate: [authGuard] },
       { path: 'matchs', component: PublicMatchesPageComponent, canActivate: [authGuard] },
       { path: 'admin', component: AdminPageComponent, canActivate: [authGuard] }
     ]

--- a/frontend/src/app/core/matches/player-match-summary.models.ts
+++ b/frontend/src/app/core/matches/player-match-summary.models.ts
@@ -1,0 +1,18 @@
+export type PlayerMatchRole = 'ORGANISATEUR' | 'PARTICIPANT';
+
+export type MatchTemporalStatus = 'PASSE' | 'AUJOURD_HUI' | 'FUTUR';
+
+export interface PlayerMatchSummary {
+  id: number;
+  dateDebut: string;
+  siteId: number;
+  siteNom: string;
+  terrainId: number;
+  terrainNom: string;
+  visibilite: string;
+  statut: string;
+  roleJoueur: PlayerMatchRole;
+  statutTemporel: MatchTemporalStatus;
+  joursAvantMatch: number | null;
+  paiementJoueurEffectue: boolean;
+}

--- a/frontend/src/app/core/matches/player-matches.service.ts
+++ b/frontend/src/app/core/matches/player-matches.service.ts
@@ -1,0 +1,14 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { PlayerMatchSummary } from './player-match-summary.models';
+
+@Injectable({ providedIn: 'root' })
+export class PlayerMatchesService {
+  private readonly http = inject(HttpClient);
+
+  getMyMatches(): Observable<PlayerMatchSummary[]> {
+    return this.http.get<PlayerMatchSummary[]>(`${environment.apiBaseUrl}/me/matchs`);
+  }
+}

--- a/frontend/src/app/features/matches/my-matches/my-matches-page.component.css
+++ b/frontend/src/app/features/matches/my-matches/my-matches-page.component.css
@@ -1,0 +1,134 @@
+.my-matches-page {
+  padding: 3rem 0;
+}
+
+.page-header {
+  width: min(100%, 42rem);
+  margin-bottom: 2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #0f766e;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2.2rem;
+  color: #10233f;
+}
+
+.page-header p:last-child {
+  margin: 0;
+  color: #526277;
+}
+
+.state-message {
+  margin: 0;
+  padding: 1rem 1.2rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 1rem;
+  background: #ffffff;
+  color: #526277;
+}
+
+.state-message.is-error {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.match-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.match-card {
+  padding: 1.4rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.06);
+}
+
+.match-card-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.match-site {
+  margin: 0 0 0.25rem;
+  color: #0f766e;
+  font-weight: 700;
+}
+
+h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #10233f;
+}
+
+.status-badge {
+  flex-shrink: 0;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #075985;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.temporal-passe {
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.temporal-aujourd_hui {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.temporal-futur {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.match-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.9rem 1.2rem;
+  margin: 0;
+}
+
+.match-details div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+dt {
+  color: #526277;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+dd {
+  margin: 0;
+  color: #10233f;
+}
+
+@media (max-width: 680px) {
+  .my-matches-page {
+    padding: 2rem 0;
+  }
+
+  .match-card-top {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/app/features/matches/my-matches/my-matches-page.component.html
+++ b/frontend/src/app/features/matches/my-matches/my-matches-page.component.html
@@ -1,0 +1,65 @@
+<section class="my-matches-page">
+  <div class="page-header">
+    <p class="eyebrow">Mes matchs</p>
+    <h1>Mes matchs</h1>
+    <p>Retrouvez ici les matchs associés à votre compte joueur.</p>
+  </div>
+
+  @if (isLoading()) {
+    <p class="state-message">Chargement de vos matchs...</p>
+  } @else if (errorMessage()) {
+    <p class="state-message is-error">{{ errorMessage() }}</p>
+  } @else if (matches().length === 0) {
+    <p class="state-message">Vous n'avez aucun match pour le moment.</p>
+  } @else {
+    <div class="match-list">
+      @for (match of matches(); track match.id) {
+        <article class="match-card">
+          <div class="match-card-top">
+            <div>
+              <p class="match-site">{{ match.siteNom }}</p>
+              <h2>{{ match.terrainNom }}</h2>
+            </div>
+
+            <span class="status-badge temporal-{{ match.statutTemporel.toLowerCase() }}">
+              {{ match.statutTemporel }}
+            </span>
+          </div>
+
+          <dl class="match-details">
+            <div>
+              <dt>Date</dt>
+              <dd>{{ match.dateDebut | date:"dd/MM/yyyy 'à' HH:mm" }}</dd>
+            </div>
+            <div>
+              <dt>Visibilité</dt>
+              <dd>{{ match.visibilite }}</dd>
+            </div>
+            <div>
+              <dt>Statut</dt>
+              <dd>{{ match.statut }}</dd>
+            </div>
+            <div>
+              <dt>Rôle du joueur</dt>
+              <dd>{{ match.roleJoueur }}</dd>
+            </div>
+            <div>
+              <dt>Statut temporel</dt>
+              <dd>{{ match.statutTemporel }}</dd>
+            </div>
+            <div>
+              <dt>Paiement effectué</dt>
+              <dd>{{ match.paiementJoueurEffectue ? 'Oui' : 'Non' }}</dd>
+            </div>
+            @if (match.joursAvantMatch !== null) {
+              <div>
+                <dt>Jours avant match</dt>
+                <dd>{{ match.joursAvantMatch }}</dd>
+              </div>
+            }
+          </dl>
+        </article>
+      }
+    </div>
+  }
+</section>

--- a/frontend/src/app/features/matches/my-matches/my-matches-page.component.ts
+++ b/frontend/src/app/features/matches/my-matches/my-matches-page.component.ts
@@ -1,0 +1,47 @@
+import { CommonModule, DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { finalize } from 'rxjs';
+import { PlayerMatchSummary } from '../../../core/matches/player-match-summary.models';
+import { PlayerMatchesService } from '../../../core/matches/player-matches.service';
+
+@Component({
+  selector: 'app-my-matches-page',
+  standalone: true,
+  imports: [CommonModule, DatePipe],
+  templateUrl: './my-matches-page.component.html',
+  styleUrl: './my-matches-page.component.css'
+})
+export class MyMatchesPageComponent implements OnInit {
+  private readonly playerMatchesService = inject(PlayerMatchesService);
+
+  protected readonly matches = signal<PlayerMatchSummary[]>([]);
+  protected readonly isLoading = signal(true);
+  protected readonly errorMessage = signal('');
+
+  ngOnInit(): void {
+    this.loadMatches();
+  }
+
+  private loadMatches(): void {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+
+    this.playerMatchesService
+      .getMyMatches()
+      .pipe(finalize(() => this.isLoading.set(false)))
+      .subscribe({
+        next: (matches) => {
+          this.matches.set(matches);
+        },
+        error: (error: HttpErrorResponse) => {
+          if (error.status === 0) {
+            this.errorMessage.set('Backend inaccessible.');
+            return;
+          }
+
+          this.errorMessage.set('Impossible de charger vos matchs.');
+        }
+      });
+  }
+}

--- a/frontend/src/app/layout/main-layout.component.html
+++ b/frontend/src/app/layout/main-layout.component.html
@@ -9,6 +9,7 @@
 
           @if (authService.isAuthenticatedState()) {
             <a routerLink="/espace-prive" routerLinkActive="is-active">Mon espace</a>
+            <a routerLink="/me/matchs" routerLinkActive="is-active">Mes matchs</a>
             <a routerLink="/matchs" routerLinkActive="is-active">Matchs</a>
           } @else {
             <a routerLink="/login" routerLinkActive="is-active">Connexion</a>


### PR DESCRIPTION
- Création du modèle `PlayerMatchSummary`
- Création du service `PlayerMatchesService`
- Consommation de `GET /api/v1/me/matchs`
- Création de la page `/me/matchs`
- Ajout du lien `Mes matchs` dans la navbar
- Affichage des matchs du joueur connecté
- Gestion des états : chargement, erreur, liste vide, données chargées
- Formatage de la date
