### PR TITLE
feat(frontend): afficher les matchs organisés

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { authGuard } from './core/auth/auth.guard';
 import { LoginPageComponent } from './features/auth/login/login-page.component';
 import { HomePageComponent } from './features/home/home-page.component';
 import { MyMatchesPageComponent } from './features/matches/my-matches/my-matches-page.component';
+import { OrganizedMatchesPageComponent } from './features/matches/organized-matches/organized-matches-page.component';
 import { PublicMatchesPageComponent } from './features/matches/public-matches/public-matches-page.component';
 import { AdminPageComponent } from './features/placeholders/admin-page.component';
 import { EspacePrivePageComponent } from './features/test/espace-prive-page.component';
@@ -17,6 +18,7 @@ export const routes: Routes = [
       { path: 'login', component: LoginPageComponent },
       { path: 'espace-prive', component: EspacePrivePageComponent, canActivate: [authGuard] },
       { path: 'me/matchs', component: MyMatchesPageComponent, canActivate: [authGuard] },
+      { path: 'me/matchs/organises', component: OrganizedMatchesPageComponent, canActivate: [authGuard] },
       { path: 'matchs', component: PublicMatchesPageComponent, canActivate: [authGuard] },
       { path: 'admin', component: AdminPageComponent, canActivate: [authGuard] }
     ]

--- a/frontend/src/app/core/matches/organized-match-summary.models.ts
+++ b/frontend/src/app/core/matches/organized-match-summary.models.ts
@@ -1,0 +1,18 @@
+export type MatchTemporalStatus = 'PASSE' | 'AUJOURD_HUI' | 'FUTUR';
+
+export interface OrganizedMatchSummary {
+  id: number;
+  dateDebut: string;
+  siteId: number;
+  siteNom: string;
+  terrainId: number;
+  terrainNom: string;
+  visibilite: string;
+  statut: string;
+  nbParticipants: number;
+  placesRestantes: number;
+  complet: boolean;
+  statutTemporel: MatchTemporalStatus;
+  joursAvantMatch: number | null;
+  risquePenaliteJ1: boolean;
+}

--- a/frontend/src/app/core/matches/organized-matches.service.ts
+++ b/frontend/src/app/core/matches/organized-matches.service.ts
@@ -1,0 +1,16 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { OrganizedMatchSummary } from './organized-match-summary.models';
+
+@Injectable({ providedIn: 'root' })
+export class OrganizedMatchesService {
+  private readonly http = inject(HttpClient);
+
+  getMyOrganizedMatches(): Observable<OrganizedMatchSummary[]> {
+    return this.http.get<OrganizedMatchSummary[]>(
+      `${environment.apiBaseUrl}/me/matchs/organises`
+    );
+  }
+}

--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.css
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.css
@@ -1,0 +1,169 @@
+.organized-matches-page {
+  padding: 3rem 0;
+}
+
+.page-header {
+  width: min(100%, 42rem);
+  margin-bottom: 2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #0f766e;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2.2rem;
+  color: #10233f;
+}
+
+.page-header p:last-child {
+  margin: 0;
+  color: #526277;
+}
+
+.state-message {
+  margin: 0;
+  padding: 1rem 1.2rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 1rem;
+  background: #ffffff;
+  color: #526277;
+}
+
+.state-message.is-error {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.match-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.match-card {
+  padding: 1.4rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.06);
+}
+
+.match-card-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.match-site {
+  margin: 0 0 0.25rem;
+  color: #0f766e;
+  font-weight: 700;
+}
+
+h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #10233f;
+}
+
+.badge-group {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.status-badge {
+  flex-shrink: 0;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #075985;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.status-badge.is-full {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-badge.is-open {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.status-badge.is-cancelled {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.temporal-passe {
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.temporal-aujourd_hui {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.temporal-futur {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.match-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.9rem 1.2rem;
+  margin: 0;
+}
+
+.match-details div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+dt {
+  color: #526277;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+dd {
+  margin: 0;
+  color: #10233f;
+}
+
+.risk-message {
+  margin: 1rem 0 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.75rem;
+  background: #fff7ed;
+  color: #9a3412;
+  font-weight: 700;
+}
+
+@media (max-width: 680px) {
+  .organized-matches-page {
+    padding: 2rem 0;
+  }
+
+  .match-card-top {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .badge-group {
+    justify-content: flex-start;
+  }
+}

--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.html
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.html
@@ -1,0 +1,79 @@
+<section class="organized-matches-page">
+  <div class="page-header">
+    <p class="eyebrow">Matchs organisés</p>
+    <h1>Matchs organisés</h1>
+    <p>Retrouvez ici les matchs que vous organisez actuellement.</p>
+  </div>
+
+  @if (isLoading()) {
+    <p class="state-message">Chargement de vos matchs organisés...</p>
+  } @else if (errorMessage()) {
+    <p class="state-message is-error">{{ errorMessage() }}</p>
+  } @else if (matches().length === 0) {
+    <p class="state-message">Vous n'avez aucun match organisé pour le moment.</p>
+  } @else {
+    <div class="match-list">
+      @for (match of matches(); track match.id) {
+        <article class="match-card">
+          <div class="match-card-top">
+            <div>
+              <p class="match-site">{{ match.siteNom }}</p>
+              <h2>{{ match.terrainNom }}</h2>
+            </div>
+
+            <div class="badge-group">
+              <span class="status-badge temporal-{{ match.statutTemporel.toLowerCase() }}">
+                {{ match.statutTemporel }}
+              </span>
+              <span
+                class="status-badge"
+                [class.is-cancelled]="match.statut === 'ANNULE'"
+                [class.is-full]="match.statut !== 'ANNULE' && match.complet"
+                [class.is-open]="match.statut !== 'ANNULE' && !match.complet"
+              >
+                {{ match.statut === 'ANNULE' ? 'Annulé' : (match.complet ? 'Complet' : 'Incomplet') }}
+              </span>
+            </div>
+          </div>
+
+          <dl class="match-details">
+            <div>
+              <dt>Date</dt>
+              <dd>{{ match.dateDebut | date:"dd/MM/yyyy 'à' HH:mm" }}</dd>
+            </div>
+            <div>
+              <dt>Visibilité</dt>
+              <dd>{{ match.visibilite }}</dd>
+            </div>
+            <div>
+              <dt>Statut</dt>
+              <dd>{{ match.statut }}</dd>
+            </div>
+            <div>
+              <dt>Participants</dt>
+              <dd>{{ match.nbParticipants }}</dd>
+            </div>
+            <div>
+              <dt>Places restantes</dt>
+              <dd>{{ match.placesRestantes }}</dd>
+            </div>
+            <div>
+              <dt>Statut temporel</dt>
+              <dd>{{ match.statutTemporel }}</dd>
+            </div>
+            @if (match.joursAvantMatch !== null) {
+              <div>
+                <dt>Jours avant match</dt>
+                <dd>{{ match.joursAvantMatch }}</dd>
+              </div>
+            }
+          </dl>
+
+          @if (match.risquePenaliteJ1) {
+            <p class="risk-message">Risque de pénalité J-1</p>
+          }
+        </article>
+      }
+    </div>
+  }
+</section>

--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.ts
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.ts
@@ -1,0 +1,47 @@
+import { CommonModule, DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { finalize } from 'rxjs';
+import { OrganizedMatchSummary } from '../../../core/matches/organized-match-summary.models';
+import { OrganizedMatchesService } from '../../../core/matches/organized-matches.service';
+
+@Component({
+  selector: 'app-organized-matches-page',
+  standalone: true,
+  imports: [CommonModule, DatePipe],
+  templateUrl: './organized-matches-page.component.html',
+  styleUrl: './organized-matches-page.component.css'
+})
+export class OrganizedMatchesPageComponent implements OnInit {
+  private readonly organizedMatchesService = inject(OrganizedMatchesService);
+
+  protected readonly matches = signal<OrganizedMatchSummary[]>([]);
+  protected readonly isLoading = signal(true);
+  protected readonly errorMessage = signal('');
+
+  ngOnInit(): void {
+    this.loadMatches();
+  }
+
+  private loadMatches(): void {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+
+    this.organizedMatchesService
+      .getMyOrganizedMatches()
+      .pipe(finalize(() => this.isLoading.set(false)))
+      .subscribe({
+        next: (matches) => {
+          this.matches.set(matches);
+        },
+        error: (error: HttpErrorResponse) => {
+          if (error.status === 0) {
+            this.errorMessage.set('Backend inaccessible.');
+            return;
+          }
+
+          this.errorMessage.set('Impossible de charger vos matchs organisés.');
+        }
+      });
+  }
+}

--- a/frontend/src/app/layout/main-layout.component.html
+++ b/frontend/src/app/layout/main-layout.component.html
@@ -10,6 +10,7 @@
           @if (authService.isAuthenticatedState()) {
             <a routerLink="/espace-prive" routerLinkActive="is-active">Mon espace</a>
             <a routerLink="/me/matchs" routerLinkActive="is-active">Mes matchs</a>
+            <a routerLink="/me/matchs/organises" routerLinkActive="is-active">Matchs organisés</a>
             <a routerLink="/matchs" routerLinkActive="is-active">Matchs</a>
           } @else {
             <a routerLink="/login" routerLinkActive="is-active">Connexion</a>


### PR DESCRIPTION
- Création du modèle `OrganizedMatchSummary`
- Création du service `OrganizedMatchesService`
- Consommation de `GET /api/v1/me/matchs/organises`
- Création de la page `/me/matchs/organises`
- Ajout du lien `Matchs organisés` dans la navbar
- Affichage des matchs organisés sous forme de cartes
- Affichage des statuts Complet / Incomplet / Annulé
- Affichage conditionnel du risque de pénalité J-1
- Gestion des états : chargement, erreur, liste vide, données chargées