### PR TITLE
feat(frontend): implémenter la création de match (formulaire + services + gestion erreurs)

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { authGuard } from './core/auth/auth.guard';
 import { LoginPageComponent } from './features/auth/login/login-page.component';
 import { HomePageComponent } from './features/home/home-page.component';
+import { CreateMatchPageComponent } from './features/matches/create-match/create-match-page.component';
 import { MyMatchesPageComponent } from './features/matches/my-matches/my-matches-page.component';
 import { OrganizedMatchesPageComponent } from './features/matches/organized-matches/organized-matches-page.component';
 import { PublicMatchesPageComponent } from './features/matches/public-matches/public-matches-page.component';
@@ -17,6 +18,7 @@ export const routes: Routes = [
       { path: '', component: HomePageComponent },
       { path: 'login', component: LoginPageComponent },
       { path: 'espace-prive', component: EspacePrivePageComponent, canActivate: [authGuard] },
+      { path: 'matchs/creer', component: CreateMatchPageComponent, canActivate: [authGuard] },
       { path: 'me/matchs', component: MyMatchesPageComponent, canActivate: [authGuard] },
       { path: 'me/matchs/organises', component: OrganizedMatchesPageComponent, canActivate: [authGuard] },
       { path: 'matchs', component: PublicMatchesPageComponent, canActivate: [authGuard] },

--- a/frontend/src/app/core/matches/create-match.models.ts
+++ b/frontend/src/app/core/matches/create-match.models.ts
@@ -1,0 +1,22 @@
+export type MatchVisibility = 'PUBLIC' | 'PRIVE';
+
+export interface CreateMatchPayload {
+  terrainId: number;
+  dateDebut: string;
+  visibilite: MatchVisibility;
+}
+
+export interface CreatedMatch {
+  id: number;
+  terrainId: number;
+  terrainNom: string;
+  siteId: number;
+  organisateurMatricule: string;
+  dateDebut: string;
+  visibilite: string;
+  statut: string;
+  nbParticipants: number;
+  montantTotal: number;
+  montantPaye: number;
+  resteAPayer: number;
+}

--- a/frontend/src/app/core/matches/match-creation.service.ts
+++ b/frontend/src/app/core/matches/match-creation.service.ts
@@ -1,0 +1,14 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { CreateMatchPayload, CreatedMatch } from './create-match.models';
+
+@Injectable({ providedIn: 'root' })
+export class MatchCreationService {
+  private readonly http = inject(HttpClient);
+
+  createMatch(payload: CreateMatchPayload): Observable<CreatedMatch> {
+    return this.http.post<CreatedMatch>(`${environment.apiBaseUrl}/matchs`, payload);
+  }
+}

--- a/frontend/src/app/core/sites/site.models.ts
+++ b/frontend/src/app/core/sites/site.models.ts
@@ -1,0 +1,6 @@
+export interface SiteOption {
+  id: number;
+  nom: string;
+  ville: string;
+  joursFermeture: string[];
+}

--- a/frontend/src/app/core/sites/sites.service.ts
+++ b/frontend/src/app/core/sites/sites.service.ts
@@ -1,0 +1,14 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { SiteOption } from './site.models';
+
+@Injectable({ providedIn: 'root' })
+export class SitesService {
+  private readonly http = inject(HttpClient);
+
+  getSites(): Observable<SiteOption[]> {
+    return this.http.get<SiteOption[]>(`${environment.apiBaseUrl}/sites`);
+  }
+}

--- a/frontend/src/app/core/terrains/terrain.models.ts
+++ b/frontend/src/app/core/terrains/terrain.models.ts
@@ -1,0 +1,5 @@
+export interface TerrainOption {
+  id: number;
+  nom: string;
+  siteId: number;
+}

--- a/frontend/src/app/core/terrains/terrains.service.ts
+++ b/frontend/src/app/core/terrains/terrains.service.ts
@@ -1,0 +1,20 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { TerrainOption } from './terrain.models';
+
+@Injectable({ providedIn: 'root' })
+export class TerrainsService {
+  private readonly http = inject(HttpClient);
+
+  getTerrains(siteId?: number): Observable<TerrainOption[]> {
+    let params = new HttpParams();
+
+    if (siteId != null) {
+      params = params.set('siteId', siteId);
+    }
+
+    return this.http.get<TerrainOption[]>(`${environment.apiBaseUrl}/terrains`, { params });
+  }
+}

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.css
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.css
@@ -1,0 +1,206 @@
+.create-match-page {
+  padding: 3rem 0;
+}
+
+.page-header {
+  width: min(100%, 42rem);
+  margin-bottom: 2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #0f766e;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2.2rem;
+  color: #10233f;
+}
+
+.page-header p:last-child {
+  margin: 0;
+  color: #526277;
+}
+
+.state-message,
+.form-card {
+  padding: 1.4rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.06);
+}
+
+.state-message {
+  color: #526277;
+}
+
+.feedback-box {
+  margin-bottom: 1.2rem;
+  padding: 1rem 1.1rem;
+  border-radius: 0.9rem;
+}
+
+.feedback-box.is-error {
+  background: linear-gradient(180deg, #fff1f2 0%, #fee2e2 100%);
+  border: 1px solid #fca5a5;
+  border-left: 6px solid #dc2626;
+}
+
+.feedback-box.is-success {
+  background: #ecfdf5;
+  border: 1px solid #a7f3d0;
+}
+
+.feedback-title {
+  margin: 0 0 0.9rem;
+  color: #166534;
+  font-weight: 700;
+}
+
+.feedback-title.is-error {
+  margin-bottom: 0.35rem;
+  color: #991b1b;
+  font-size: 1.08rem;
+}
+
+.feedback-message {
+  margin: 0;
+  font-weight: 700;
+}
+
+.feedback-message.is-error {
+  color: #b91c1c;
+  font-size: 1rem;
+  line-height: 1.45;
+}
+
+.feedback-details {
+  margin: 0.9rem 0 0;
+  padding-left: 1.2rem;
+  color: #991b1b;
+}
+
+.feedback-details li + li {
+  margin-top: 0.35rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.9rem 1.2rem;
+  margin: 0 0 1rem;
+}
+
+.summary-grid div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.summary-link {
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.summary-link:hover {
+  text-decoration: underline;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 1rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.field span {
+  color: #526277;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.field input,
+.field select {
+  width: 100%;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid #c3d0de;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  color: #10233f;
+  font: inherit;
+}
+
+.field input:disabled,
+.field select:disabled {
+  background: #f8fafc;
+  color: #94a3b8;
+}
+
+.field-error {
+  color: #b91c1c;
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  margin-top: 1.4rem;
+}
+
+.submit-button {
+  padding: 0.85rem 1.15rem;
+  border: 0;
+  border-radius: 0.85rem;
+  background: #94a3b8;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 700;
+  cursor: not-allowed;
+  transition: background-color 160ms ease;
+}
+
+.submit-button.is-ready {
+  background: #0f766e;
+  cursor: pointer;
+}
+
+.submit-button:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+  opacity: 1;
+}
+
+.submit-hints {
+  margin: 0.9rem 0 0;
+  padding-left: 1.1rem;
+  color: #7c2d12;
+  font-size: 0.92rem;
+}
+
+.submit-hints li + li {
+  margin-top: 0.25rem;
+}
+
+dt {
+  color: #526277;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+dd {
+  margin: 0;
+  color: #10233f;
+}
+
+@media (max-width: 680px) {
+  .create-match-page {
+    padding: 2rem 0;
+  }
+}

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.html
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.html
@@ -1,0 +1,157 @@
+<section class="create-match-page">
+  <div class="page-header">
+    <p class="eyebrow">Création</p>
+    <h1>Créer un match</h1>
+    <p>Choisissez un site, un terrain, une date, une heure et une visibilité.</p>
+  </div>
+
+  @if (isLoadingSites()) {
+    <p class="state-message">Chargement des sites...</p>
+  } @else {
+    <div class="form-card">
+      @if (globalErrorMessage()) {
+        <div class="feedback-box is-error" role="alert" aria-live="assertive">
+          <p class="feedback-title is-error">Création impossible</p>
+          <p class="feedback-message is-error">{{ globalErrorMessage() }}</p>
+
+          @if (backendErrorDetails().length > 0) {
+            <ul class="feedback-details">
+              @for (detail of backendErrorDetails(); track detail[0]) {
+                <li><strong>{{ detail[0] }}</strong> : {{ detail[1] }}</li>
+              }
+            </ul>
+          }
+        </div>
+      }
+
+      @if (successMessage()) {
+        <div class="feedback-box is-success">
+          <p class="feedback-title">{{ successMessage() }}</p>
+
+          @if (createdMatch(); as match) {
+            <dl class="summary-grid">
+              <div>
+                <dt>Terrain</dt>
+                <dd>{{ match.terrainNom }}</dd>
+              </div>
+              <div>
+                <dt>Date</dt>
+                <dd>{{ match.dateDebut | date:"dd/MM/yyyy 'à' HH:mm" }}</dd>
+              </div>
+              <div>
+                <dt>Visibilité</dt>
+                <dd>{{ match.visibilite }}</dd>
+              </div>
+              <div>
+                <dt>Statut</dt>
+                <dd>{{ match.statut }}</dd>
+              </div>
+              <div>
+                <dt>Participants</dt>
+                <dd>{{ match.nbParticipants }}</dd>
+              </div>
+              <div>
+                <dt>Reste à payer</dt>
+                <dd>{{ match.resteAPayer | currency:'EUR' }}</dd>
+              </div>
+            </dl>
+          }
+
+          <a routerLink="/me/matchs/organises" class="summary-link">Voir mes matchs organisés</a>
+        </div>
+      }
+
+      <form [formGroup]="form" (ngSubmit)="submit()" novalidate>
+        <div class="form-grid">
+          <label class="field">
+            <span>Site</span>
+            <select formControlName="siteId">
+              <option [ngValue]="null">Sélectionner un site</option>
+              @for (site of sites(); track site.id) {
+                <option [ngValue]="site.id">{{ siteLabel(site) }}</option>
+              }
+            </select>
+            @if (getFieldError('siteId')) {
+              <small class="field-error">{{ getFieldError('siteId') }}</small>
+            }
+          </label>
+
+          <label class="field">
+            <span>Terrain</span>
+            <select formControlName="terrainId">
+              <option [ngValue]="null">
+                @if (isLoadingTerrains()) { Chargement des terrains... } @else { Sélectionner un terrain }
+              </option>
+              @for (terrain of terrains(); track terrain.id) {
+                <option [ngValue]="terrain.id">{{ terrain.nom }}</option>
+              }
+            </select>
+            @if (getFieldError('terrainId')) {
+              <small class="field-error">{{ getFieldError('terrainId') }}</small>
+            }
+            @if (backendFieldErrors()['terrainId']) {
+              <small class="field-error">{{ backendFieldErrors()['terrainId'] }}</small>
+            }
+          </label>
+
+          <label class="field">
+            <span>Date</span>
+            <input type="date" formControlName="date" />
+            @if (getFieldError('date')) {
+              <small class="field-error">{{ getFieldError('date') }}</small>
+            }
+          </label>
+
+          <label class="field">
+            <span>Heure</span>
+            <select formControlName="heure">
+              <option value="">Sélectionner une heure</option>
+              @for (slot of timeSlots; track slot) {
+                <option [value]="slot">{{ slot }}</option>
+              }
+            </select>
+            @if (getFieldError('heure')) {
+              <small class="field-error">{{ getFieldError('heure') }}</small>
+            }
+            @if (dateDebutFieldError()) {
+              <small class="field-error">{{ dateDebutFieldError() }}</small>
+            }
+          </label>
+
+          <label class="field">
+            <span>Visibilité</span>
+            <select formControlName="visibilite">
+              <option value="PUBLIC">PUBLIC</option>
+              <option value="PRIVE">PRIVE</option>
+            </select>
+            @if (getFieldError('visibilite')) {
+              <small class="field-error">{{ getFieldError('visibilite') }}</small>
+            }
+            @if (backendFieldErrors()['visibilite']) {
+              <small class="field-error">{{ backendFieldErrors()['visibilite'] }}</small>
+            }
+          </label>
+        </div>
+
+        <div class="form-actions">
+          <button
+            type="submit"
+            class="submit-button"
+            [class.is-ready]="canSubmit()"
+            [disabled]="!canSubmit()"
+          >
+            {{ isSubmitting() ? 'Création en cours...' : 'Créer le match' }}
+          </button>
+
+          @if (!canSubmit() && getSubmitHints().length > 0) {
+            <ul class="submit-hints">
+              @for (reason of getSubmitHints(); track reason) {
+                <li>{{ reason }}</li>
+              }
+            </ul>
+          }
+        </div>
+      </form>
+    </div>
+  }
+</section>

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.ts
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.ts
@@ -1,0 +1,318 @@
+import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { finalize } from 'rxjs';
+import { CreatedMatch, CreateMatchPayload, MatchVisibility } from '../../../core/matches/create-match.models';
+import { MatchCreationService } from '../../../core/matches/match-creation.service';
+import { SiteOption } from '../../../core/sites/site.models';
+import { SitesService } from '../../../core/sites/sites.service';
+import { TerrainOption } from '../../../core/terrains/terrain.models';
+import { TerrainsService } from '../../../core/terrains/terrains.service';
+
+interface ApiErrorBody {
+  message?: string;
+  details?: Record<string, string>;
+}
+
+@Component({
+  selector: 'app-create-match-page',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, DatePipe, CurrencyPipe],
+  templateUrl: './create-match-page.component.html',
+  styleUrl: './create-match-page.component.css'
+})
+export class CreateMatchPageComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly matchCreationService = inject(MatchCreationService);
+  private readonly sitesService = inject(SitesService);
+  private readonly terrainsService = inject(TerrainsService);
+
+  protected readonly sites = signal<SiteOption[]>([]);
+  protected readonly terrains = signal<TerrainOption[]>([]);
+  protected readonly isLoadingSites = signal(true);
+  protected readonly isLoadingTerrains = signal(false);
+  protected readonly isSubmitting = signal(false);
+  protected readonly globalErrorMessage = signal('');
+  protected readonly successMessage = signal('');
+  protected readonly createdMatch = signal<CreatedMatch | null>(null);
+  protected readonly backendFieldErrors = signal<Record<string, string>>({});
+  protected readonly timeSlots = this.buildTimeSlots();
+
+  protected readonly form = this.fb.nonNullable.group({
+    siteId: [null as number | null, Validators.required],
+    terrainId: [{ value: null as number | null, disabled: true }, Validators.required],
+    date: ['', Validators.required],
+    heure: ['', Validators.required],
+    visibilite: ['PUBLIC' as MatchVisibility, Validators.required]
+  });
+
+  ngOnInit(): void {
+    this.loadSites();
+
+    this.form.controls.siteId.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((siteId) => {
+        this.form.controls.terrainId.reset(null);
+        this.backendFieldErrors.set({});
+
+        if (siteId == null) {
+          this.form.controls.terrainId.disable();
+          this.terrains.set([]);
+          return;
+        }
+
+        this.form.controls.terrainId.disable();
+        this.loadTerrains(siteId);
+      });
+  }
+
+  protected canSubmit(): boolean {
+    return (
+      this.form.valid &&
+      !this.isLoadingSites() &&
+      !this.isLoadingTerrains() &&
+      !this.isSubmitting()
+    );
+  }
+
+  protected submit(): void {
+    this.form.markAllAsTouched();
+    this.globalErrorMessage.set('');
+    this.successMessage.set('');
+    this.createdMatch.set(null);
+    this.backendFieldErrors.set({});
+
+    if (this.isLoadingSites() || this.isLoadingTerrains() || this.isSubmitting()) {
+      return;
+    }
+
+    if (this.form.invalid) {
+      return;
+    }
+
+    const payload = this.buildPayload();
+    if (!payload) {
+      this.globalErrorMessage.set('Le formulaire est incomplet.');
+      return;
+    }
+
+    this.isSubmitting.set(true);
+
+    this.matchCreationService
+      .createMatch(payload)
+      .pipe(finalize(() => this.isSubmitting.set(false)))
+      .subscribe({
+        next: (createdMatch) => {
+          this.createdMatch.set(createdMatch);
+          this.successMessage.set('Match créé avec succès.');
+          this.form.controls.date.reset('');
+          this.form.controls.heure.reset('');
+          this.form.controls.visibilite.setValue('PUBLIC');
+          this.form.controls.terrainId.reset(null);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.handleSubmitError(error);
+        }
+      });
+  }
+
+  protected siteLabel(site: SiteOption): string {
+    return `${site.nom} - ${site.ville}`;
+  }
+
+  protected getFieldError(field: 'siteId' | 'terrainId' | 'date' | 'heure' | 'visibilite'): string {
+    const control = this.form.controls[field];
+
+    if ((control.touched || control.dirty) && control.hasError('required')) {
+      switch (field) {
+        case 'siteId':
+          return 'Le site est obligatoire.';
+        case 'terrainId':
+          return 'Le terrain est obligatoire.';
+        case 'date':
+          return 'La date est obligatoire.';
+        case 'heure':
+          return "L'heure est obligatoire.";
+        case 'visibilite':
+          return 'La visibilité est obligatoire.';
+      }
+    }
+
+    return '';
+  }
+
+  protected getSubmitHints(): string[] {
+    const hints: string[] = [];
+
+    if (this.isLoadingSites()) {
+      hints.push('Chargement des sites en cours.');
+    }
+
+    if (this.isLoadingTerrains()) {
+      hints.push('Chargement des terrains en cours.');
+    }
+
+    if (this.isSubmitting()) {
+      hints.push('Création en cours...');
+    }
+
+    if (this.form.controls.siteId.hasError('required')) {
+      hints.push('Sélectionnez un site.');
+    }
+
+    if (
+      this.form.controls.siteId.value != null &&
+      this.form.controls.terrainId.disabled &&
+      !this.isLoadingTerrains()
+    ) {
+      hints.push('Sélectionnez un terrain disponible.');
+    } else if (this.form.controls.terrainId.hasError('required')) {
+      hints.push('Sélectionnez un terrain.');
+    }
+
+    if (this.form.controls.date.hasError('required')) {
+      hints.push('Sélectionnez une date.');
+    }
+
+    if (this.form.controls.heure.hasError('required')) {
+      hints.push('Sélectionnez une heure.');
+    }
+
+    if (this.form.controls.visibilite.hasError('required')) {
+      hints.push('Sélectionnez une visibilité.');
+    }
+
+    return Array.from(new Set(hints));
+  }
+
+  protected dateDebutFieldError(): string {
+    return this.backendFieldErrors()['dateDebut'] ?? '';
+  }
+
+  protected backendErrorDetails(): Array<[string, string]> {
+    return Object.entries(this.backendFieldErrors());
+  }
+
+  private loadSites(): void {
+    this.isLoadingSites.set(true);
+    this.globalErrorMessage.set('');
+
+    this.sitesService
+      .getSites()
+      .pipe(finalize(() => this.isLoadingSites.set(false)))
+      .subscribe({
+        next: (sites) => {
+          this.sites.set(sites);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.globalErrorMessage.set(
+            error.status === 0 ? 'Backend inaccessible.' : 'Impossible de charger les sites.'
+          );
+        }
+      });
+  }
+
+  private loadTerrains(siteId: number): void {
+    this.isLoadingTerrains.set(true);
+    this.globalErrorMessage.set('');
+
+    this.terrainsService
+      .getTerrains(siteId)
+      .pipe(finalize(() => this.isLoadingTerrains.set(false)))
+      .subscribe({
+        next: (terrains) => {
+          this.terrains.set(terrains);
+
+          if (terrains.length > 0) {
+            this.form.controls.terrainId.enable();
+          } else {
+            this.form.controls.terrainId.disable();
+          }
+        },
+        error: (error: HttpErrorResponse) => {
+          this.globalErrorMessage.set(
+            error.status === 0 ? 'Backend inaccessible.' : 'Impossible de charger les terrains.'
+          );
+          this.terrains.set([]);
+          this.form.controls.terrainId.disable();
+        }
+      });
+  }
+
+  private buildPayload(): CreateMatchPayload | null {
+    const { terrainId, date, heure, visibilite } = this.form.getRawValue();
+
+    if (terrainId == null || !date || !heure) {
+      return null;
+    }
+
+    return {
+      terrainId,
+      dateDebut: `${date}T${heure}:00`,
+      visibilite
+    };
+  }
+
+  private handleSubmitError(error: HttpErrorResponse): void {
+    const apiError = this.normalizeApiErrorBody(error.error);
+
+    if (error.status === 0) {
+      this.globalErrorMessage.set('Backend inaccessible.');
+      return;
+    }
+
+    if (apiError.details) {
+      this.backendFieldErrors.set(apiError.details);
+    }
+
+    if (apiError.message) {
+      this.globalErrorMessage.set(apiError.message);
+      return;
+    }
+
+    if (error.status === 404) {
+      this.globalErrorMessage.set('Terrain introuvable.');
+      return;
+    }
+
+    this.globalErrorMessage.set('Impossible de créer le match.');
+  }
+
+  private normalizeApiErrorBody(raw: unknown): ApiErrorBody {
+    if (typeof raw === 'string') {
+      try {
+        return JSON.parse(raw) as ApiErrorBody;
+      } catch {
+        return { message: raw };
+      }
+    }
+
+    if (raw && typeof raw === 'object') {
+      return raw as ApiErrorBody;
+    }
+
+    return {};
+  }
+
+  private buildTimeSlots(): string[] {
+    const slots: string[] = [];
+    const openingHour = 8;
+    const closingHour = 22;
+
+    for (let hour = openingHour; hour < closingHour; hour += 1) {
+      for (let minute = 0; minute < 60; minute += 15) {
+        const hh = hour.toString().padStart(2, '0');
+        const mm = minute.toString().padStart(2, '0');
+        slots.push(`${hh}:${mm}`);
+      }
+    }
+
+    slots.push(`${closingHour.toString().padStart(2, '0')}:00`);
+
+    return slots;
+  }
+}

--- a/frontend/src/app/layout/main-layout.component.html
+++ b/frontend/src/app/layout/main-layout.component.html
@@ -9,6 +9,7 @@
 
           @if (authService.isAuthenticatedState()) {
             <a routerLink="/espace-prive" routerLinkActive="is-active">Mon espace</a>
+            <a routerLink="/matchs/creer" routerLinkActive="is-active">Créer un match</a>
             <a routerLink="/me/matchs" routerLinkActive="is-active">Mes matchs</a>
             <a routerLink="/me/matchs/organises" routerLinkActive="is-active">Matchs organisés</a>
             <a routerLink="/matchs" routerLinkActive="is-active">Matchs</a>


### PR DESCRIPTION
- Nouvelle route `/matchs/creer` (protégée)
- Formulaire Angular (Reactive Forms) :
  - site, terrain, date, heure, visibilité
- Chargement dynamique :
  - sites (`GET /sites`)
  - terrains par site (`GET /terrains?siteId=...`)
- Sélection d’heure via créneaux (08:00–22:00)
