### PR TITLE
feat(frontend): afficher le détail d'un match

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { authGuard } from './core/auth/auth.guard';
 import { LoginPageComponent } from './features/auth/login/login-page.component';
 import { HomePageComponent } from './features/home/home-page.component';
 import { CreateMatchPageComponent } from './features/matches/create-match/create-match-page.component';
+import { MatchDetailPageComponent } from './features/matches/match-detail/match-detail-page.component';
 import { MyMatchesPageComponent } from './features/matches/my-matches/my-matches-page.component';
 import { OrganizedMatchesPageComponent } from './features/matches/organized-matches/organized-matches-page.component';
 import { PublicMatchesPageComponent } from './features/matches/public-matches/public-matches-page.component';
@@ -19,6 +20,7 @@ export const routes: Routes = [
       { path: 'login', component: LoginPageComponent },
       { path: 'espace-prive', component: EspacePrivePageComponent, canActivate: [authGuard] },
       { path: 'matchs/creer', component: CreateMatchPageComponent, canActivate: [authGuard] },
+      { path: 'matchs/:id', component: MatchDetailPageComponent, canActivate: [authGuard] },
       { path: 'me/matchs', component: MyMatchesPageComponent, canActivate: [authGuard] },
       { path: 'me/matchs/organises', component: OrganizedMatchesPageComponent, canActivate: [authGuard] },
       { path: 'matchs', component: PublicMatchesPageComponent, canActivate: [authGuard] },

--- a/frontend/src/app/core/matches/match-detail.models.ts
+++ b/frontend/src/app/core/matches/match-detail.models.ts
@@ -1,0 +1,26 @@
+export interface MatchParticipant {
+  matricule: string;
+  nom: string;
+}
+
+export interface MatchDetail {
+  id: number;
+  dateDebut: string;
+  heureDebut: string;
+  siteId: number;
+  siteNom: string;
+  terrainId: number;
+  terrainNom: string;
+  organisateurMatricule: string;
+  organisateurNom: string;
+  visibilite: string;
+  statut: string;
+  nbParticipants: number;
+  placesRestantes: number;
+  complet: boolean;
+  montantTotal: number;
+  montantPaye: number;
+  resteAPayer: number;
+  montantRembourse: number;
+  participants: MatchParticipant[];
+}

--- a/frontend/src/app/core/matches/match-detail.service.ts
+++ b/frontend/src/app/core/matches/match-detail.service.ts
@@ -1,0 +1,14 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { MatchDetail } from './match-detail.models';
+
+@Injectable({ providedIn: 'root' })
+export class MatchDetailService {
+  private readonly http = inject(HttpClient);
+
+  getMatchDetail(id: number): Observable<MatchDetail> {
+    return this.http.get<MatchDetail>(`${environment.apiBaseUrl}/matchs/${id}`);
+  }
+}

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.css
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.css
@@ -1,0 +1,191 @@
+.match-detail-page {
+  padding: 3rem 0;
+}
+
+.page-header {
+  width: 100%;
+  margin-bottom: 2rem;
+}
+
+.page-header-text {
+  width: 100%;
+  max-width: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.title-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.back-button {
+  flex-shrink: 0;
+  background: #e2e8f0;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 0.75rem;
+  color: #10233f;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.back-button:hover {
+  background: #cbd5f5;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #0f766e;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+h1 {
+  flex: 1;
+  margin: 0 0 0.75rem;
+  font-size: 2.2rem;
+  color: #10233f;
+}
+
+.page-header p:last-child {
+  margin: 0;
+  color: #526277;
+}
+
+.state-message {
+  margin: 0;
+  padding: 1rem 1.2rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 1rem;
+  background: #ffffff;
+  color: #526277;
+}
+
+.state-message.is-error {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.state-message.is-error p {
+  margin: 0;
+}
+
+.back-link {
+  display: inline-flex;
+  margin-top: 0.85rem;
+  color: #991b1b;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.detail-layout {
+  display: grid;
+  gap: 1rem;
+}
+
+.detail-card {
+  padding: 1.4rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.06);
+}
+
+.detail-card h2 {
+  margin: 0 0 1rem;
+  font-size: 1.35rem;
+  color: #10233f;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.9rem 1.2rem;
+  margin: 0;
+}
+
+.detail-grid div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+dt {
+  color: #526277;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+dd {
+  margin: 0;
+  color: #10233f;
+}
+
+.badge-row {
+  margin-bottom: 1rem;
+}
+
+.status-badge {
+  display: inline-flex;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: #fee2e2;
+  color: #991b1b;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.status-badge.is-full {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-badge.is-open {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.participants-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.participants-list li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.85rem;
+  background: #f8fbff;
+  color: #10233f;
+}
+
+.empty-participants {
+  margin: 0;
+  color: #526277;
+}
+
+@media (max-width: 680px) {
+  .match-detail-page {
+    padding: 2rem 0;
+  }
+
+  .title-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.html
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.html
@@ -1,0 +1,114 @@
+<section class="match-detail-page">
+  <div class="page-header">
+    <div class="page-header-text">
+      <p class="eyebrow">Matchs</p>
+      <div class="title-row">
+        <h1>Détail du match</h1>
+        <button type="button" class="back-button" (click)="goBack()">&larr; Retour</button>
+      </div>
+      <p>Consultez les informations disponibles pour ce match.</p>
+    </div>
+  </div>
+
+  @if (isLoading()) {
+    <p class="state-message">Chargement du détail du match...</p>
+  } @else if (errorMessage()) {
+    <div class="state-message is-error" role="alert" aria-live="polite">
+      <p>{{ errorMessage() }}</p>
+      <a routerLink="/matchs" class="back-link">Retour aux matchs</a>
+    </div>
+  } @else if (match(); as detail) {
+    <div class="detail-layout">
+      <article class="detail-card">
+        <h2>Informations générales</h2>
+        <dl class="detail-grid">
+          <div>
+            <dt>Site</dt>
+            <dd>{{ detail.siteNom }}</dd>
+          </div>
+          <div>
+            <dt>Terrain</dt>
+            <dd>{{ detail.terrainNom }}</dd>
+          </div>
+          <div>
+            <dt>Date</dt>
+            <dd>{{ detail.dateDebut | date:'dd/MM/yyyy' }}</dd>
+          </div>
+          <div>
+            <dt>Heure</dt>
+            <dd>{{ detail.heureDebut }}</dd>
+          </div>
+          <div>
+            <dt>Visibilité</dt>
+            <dd>{{ detail.visibilite }}</dd>
+          </div>
+          <div>
+            <dt>Statut</dt>
+            <dd>{{ detail.statut }}</dd>
+          </div>
+          <div>
+            <dt>Organisateur</dt>
+            <dd>{{ detail.organisateurMatricule }} - {{ detail.organisateurNom }}</dd>
+          </div>
+        </dl>
+      </article>
+
+      <article class="detail-card">
+        <h2>État du match</h2>
+        <div class="badge-row">
+          <span class="status-badge" [class.is-full]="detail.complet" [class.is-open]="!detail.complet">
+            {{ detail.complet ? 'Complet' : 'Incomplet' }}
+          </span>
+        </div>
+        <dl class="detail-grid">
+          <div>
+            <dt>Participants</dt>
+            <dd>{{ detail.nbParticipants }}</dd>
+          </div>
+          <div>
+            <dt>Places restantes</dt>
+            <dd>{{ detail.placesRestantes }}</dd>
+          </div>
+        </dl>
+      </article>
+
+      <article class="detail-card">
+        <h2>Montants</h2>
+        <dl class="detail-grid">
+          <div>
+            <dt>Montant total</dt>
+            <dd>{{ detail.montantTotal | currency:'EUR' }}</dd>
+          </div>
+          <div>
+            <dt>Montant payé</dt>
+            <dd>{{ detail.montantPaye | currency:'EUR' }}</dd>
+          </div>
+          <div>
+            <dt>Reste à payer</dt>
+            <dd>{{ detail.resteAPayer | currency:'EUR' }}</dd>
+          </div>
+          <div>
+            <dt>Montant remboursé</dt>
+            <dd>{{ detail.montantRembourse | currency:'EUR' }}</dd>
+          </div>
+        </dl>
+      </article>
+
+      <article class="detail-card">
+        <h2>Participants</h2>
+        @if (detail.participants.length === 0) {
+          <p class="empty-participants">Aucun participant à afficher.</p>
+        } @else {
+          <ul class="participants-list">
+            @for (participant of detail.participants; track participant.matricule) {
+              <li>
+                <strong>{{ participant.matricule }}</strong>
+                <span>{{ participant.nom }}</span>
+              </li>
+            }
+          </ul>
+        }
+      </article>
+    </div>
+  }
+</section>

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts
@@ -1,0 +1,105 @@
+import { CommonModule, CurrencyPipe, DatePipe, Location } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { finalize } from 'rxjs';
+import { MatchDetail } from '../../../core/matches/match-detail.models';
+import { MatchDetailService } from '../../../core/matches/match-detail.service';
+
+interface ApiErrorBody {
+  message?: string;
+}
+
+@Component({
+  selector: 'app-match-detail-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink, DatePipe, CurrencyPipe],
+  templateUrl: './match-detail-page.component.html',
+  styleUrl: './match-detail-page.component.css'
+})
+export class MatchDetailPageComponent implements OnInit {
+  private readonly location = inject(Location);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly matchDetailService = inject(MatchDetailService);
+
+  protected readonly match = signal<MatchDetail | null>(null);
+  protected readonly isLoading = signal(true);
+  protected readonly errorMessage = signal('');
+
+  ngOnInit(): void {
+    const idParam = this.route.snapshot.paramMap.get('id');
+    const id = idParam ? Number(idParam) : Number.NaN;
+
+    if (Number.isNaN(id) || id <= 0) {
+      this.isLoading.set(false);
+      this.errorMessage.set('Identifiant de match invalide.');
+      return;
+    }
+
+    this.loadMatchDetail(id);
+  }
+
+  protected goBack(): void {
+    if (window.history.length > 1) {
+      this.location.back();
+      return;
+    }
+
+    this.router.navigateByUrl('/matchs');
+  }
+
+  private loadMatchDetail(id: number): void {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+
+    this.matchDetailService
+      .getMatchDetail(id)
+      .pipe(finalize(() => this.isLoading.set(false)))
+      .subscribe({
+        next: (match) => {
+          this.match.set(match);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.handleLoadError(error);
+        }
+      });
+  }
+
+  private handleLoadError(error: HttpErrorResponse): void {
+    const apiError = this.normalizeApiErrorBody(error.error);
+
+    if (error.status === 0) {
+      this.errorMessage.set('Backend inaccessible.');
+      return;
+    }
+
+    if (error.status === 403) {
+      this.errorMessage.set(apiError.message ?? 'Accès refusé à ce match.');
+      return;
+    }
+
+    if (error.status === 404) {
+      this.errorMessage.set('Match introuvable.');
+      return;
+    }
+
+    this.errorMessage.set(apiError.message ?? 'Impossible de charger le détail du match.');
+  }
+
+  private normalizeApiErrorBody(raw: unknown): ApiErrorBody {
+    if (typeof raw === 'string') {
+      try {
+        return JSON.parse(raw) as ApiErrorBody;
+      } catch {
+        return { message: raw };
+      }
+    }
+
+    if (raw && typeof raw === 'object') {
+      return raw as ApiErrorBody;
+    }
+
+    return {};
+  }
+}

--- a/frontend/src/app/features/matches/my-matches/my-matches-page.component.css
+++ b/frontend/src/app/features/matches/my-matches/my-matches-page.component.css
@@ -122,6 +122,18 @@ dd {
   color: #10233f;
 }
 
+.detail-link {
+  display: inline-flex;
+  margin-top: 1rem;
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.detail-link:hover {
+  text-decoration: underline;
+}
+
 @media (max-width: 680px) {
   .my-matches-page {
     padding: 2rem 0;

--- a/frontend/src/app/features/matches/my-matches/my-matches-page.component.html
+++ b/frontend/src/app/features/matches/my-matches/my-matches-page.component.html
@@ -58,6 +58,8 @@
               </div>
             }
           </dl>
+
+          <a [routerLink]="['/matchs', match.id]" class="detail-link">Voir le détail</a>
         </article>
       }
     </div>

--- a/frontend/src/app/features/matches/my-matches/my-matches-page.component.ts
+++ b/frontend/src/app/features/matches/my-matches/my-matches-page.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule, DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { finalize } from 'rxjs';
 import { PlayerMatchSummary } from '../../../core/matches/player-match-summary.models';
 import { PlayerMatchesService } from '../../../core/matches/player-matches.service';
@@ -8,7 +9,7 @@ import { PlayerMatchesService } from '../../../core/matches/player-matches.servi
 @Component({
   selector: 'app-my-matches-page',
   standalone: true,
-  imports: [CommonModule, DatePipe],
+  imports: [CommonModule, RouterLink, DatePipe],
   templateUrl: './my-matches-page.component.html',
   styleUrl: './my-matches-page.component.css'
 })

--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.css
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.css
@@ -153,6 +153,18 @@ dd {
   font-weight: 700;
 }
 
+.detail-link {
+  display: inline-flex;
+  margin-top: 1rem;
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.detail-link:hover {
+  text-decoration: underline;
+}
+
 @media (max-width: 680px) {
   .organized-matches-page {
     padding: 2rem 0;

--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.html
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.html
@@ -72,6 +72,8 @@
           @if (match.risquePenaliteJ1) {
             <p class="risk-message">Risque de pénalité J-1</p>
           }
+
+          <a [routerLink]="['/matchs', match.id]" class="detail-link">Voir le détail</a>
         </article>
       }
     </div>

--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.ts
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule, DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { finalize } from 'rxjs';
 import { OrganizedMatchSummary } from '../../../core/matches/organized-match-summary.models';
 import { OrganizedMatchesService } from '../../../core/matches/organized-matches.service';
@@ -8,7 +9,7 @@ import { OrganizedMatchesService } from '../../../core/matches/organized-matches
 @Component({
   selector: 'app-organized-matches-page',
   standalone: true,
-  imports: [CommonModule, DatePipe],
+  imports: [CommonModule, RouterLink, DatePipe],
   templateUrl: './organized-matches-page.component.html',
   styleUrl: './organized-matches-page.component.css'
 })

--- a/frontend/src/app/features/matches/public-matches/public-matches-page.component.css
+++ b/frontend/src/app/features/matches/public-matches/public-matches-page.component.css
@@ -155,6 +155,18 @@ dd {
   color: #10233f;
 }
 
+.detail-link {
+  display: inline-flex;
+  margin-top: 1rem;
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.detail-link:hover {
+  text-decoration: underline;
+}
+
 @media (max-width: 680px) {
   .matches-page {
     padding: 2rem 0;

--- a/frontend/src/app/features/matches/public-matches/public-matches-page.component.html
+++ b/frontend/src/app/features/matches/public-matches/public-matches-page.component.html
@@ -84,6 +84,8 @@
               <dd>{{ match.montantParJoueur | currency:'EUR' }}</dd>
             </div>
           </dl>
+
+          <a [routerLink]="['/matchs', match.id]" class="detail-link">Voir le détail</a>
         </article>
       }
     </div>

--- a/frontend/src/app/features/matches/public-matches/public-matches-page.component.ts
+++ b/frontend/src/app/features/matches/public-matches/public-matches-page.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule, CurrencyPipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { finalize } from 'rxjs';
 import { PublicMatch } from '../../../core/matches/public-match.models';
 import { PublicMatchesService } from '../../../core/matches/public-matches.service';
@@ -8,7 +9,7 @@ import { PublicMatchesService } from '../../../core/matches/public-matches.servi
 @Component({
   selector: 'app-public-matches-page',
   standalone: true,
-  imports: [CommonModule, CurrencyPipe],
+  imports: [CommonModule, RouterLink, CurrencyPipe],
   templateUrl: './public-matches-page.component.html',
   styleUrl: './public-matches-page.component.css'
 })


### PR DESCRIPTION
- Création du modèle `MatchDetail`
- Création du service `MatchDetailService`
- Ajout de la route `/matchs/:id`
- Création de la page `MatchDetailPageComponent`
- Ajout des liens `Voir le détail` depuis :
  - matchs publics
  - mes matchs
  - matchs organisés
- Affichage des informations générales, état du match, montants et participants
- Gestion des états chargement / erreur / détail
- Gestion des erreurs 403, 404 et backend inaccessible
- Ajout d’un bouton Retour