### PR TITLE
feat(frontend): rejoindre un match public + améliorations UX

### DIFF
--- a/frontend/src/app/core/matches/public-match.models.ts
+++ b/frontend/src/app/core/matches/public-match.models.ts
@@ -2,6 +2,8 @@ export interface PublicMatch {
   id: number;
   dateDebut: string;
   heureDebut: string;
+  statut?: string;
+  statutTemporel?: string;
   siteId: number;
   siteNom: string;
   terrainId: number;

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.css
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.css
@@ -132,17 +132,57 @@ dd {
 }
 
 .badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   margin-bottom: 1rem;
+}
+
+.action-message {
+  margin: 0 0 1rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.9rem;
+}
+
+.action-message p {
+  margin: 0;
+}
+
+.action-message.is-success {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.action-message.is-error {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.action-details {
+  margin: 0.7rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.action-details li + li {
+  margin-top: 0.3rem;
 }
 
 .status-badge {
   display: inline-flex;
   padding: 0.4rem 0.75rem;
   border-radius: 999px;
-  background: #fee2e2;
-  color: #991b1b;
+  background: #e0f2fe;
+  color: #075985;
   font-size: 0.9rem;
   font-weight: 700;
+}
+
+.status-badge.is-cancelled {
+  background: #fee2e2;
+  color: #991b1b;
 }
 
 .status-badge.is-full {
@@ -151,8 +191,44 @@ dd {
 }
 
 .status-badge.is-open {
-  background: #fee2e2;
-  color: #991b1b;
+  background: #dcfce7;
+  color: #166534;
+}
+
+.temporal-passe {
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.temporal-aujourd_hui {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.temporal-futur {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.join-button {
+  margin-top: 1rem;
+  border: none;
+  border-radius: 0.85rem;
+  background: #0f766e;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 700;
+  padding: 0.8rem 1.2rem;
+  cursor: pointer;
+}
+
+.join-button:hover:not(:disabled) {
+  background: #115e59;
+}
+
+.join-button:disabled {
+  opacity: 0.7;
+  cursor: wait;
 }
 
 .participants-list {

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.html
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.html
@@ -3,7 +3,7 @@
     <div class="page-header-text">
       <p class="eyebrow">Matchs</p>
       <div class="title-row">
-        <h1>Détail du match</h1>
+        <h1>D&eacute;tail du match</h1>
         <button type="button" class="back-button" (click)="goBack()">&larr; Retour</button>
       </div>
       <p>Consultez les informations disponibles pour ce match.</p>
@@ -11,7 +11,7 @@
   </div>
 
   @if (isLoading()) {
-    <p class="state-message">Chargement du détail du match...</p>
+    <p class="state-message">Chargement du d&eacute;tail du match...</p>
   } @else if (errorMessage()) {
     <div class="state-message is-error" role="alert" aria-live="polite">
       <p>{{ errorMessage() }}</p>
@@ -20,7 +20,7 @@
   } @else if (match(); as detail) {
     <div class="detail-layout">
       <article class="detail-card">
-        <h2>Informations générales</h2>
+        <h2>Informations g&eacute;n&eacute;rales</h2>
         <dl class="detail-grid">
           <div>
             <dt>Site</dt>
@@ -36,15 +36,15 @@
           </div>
           <div>
             <dt>Heure</dt>
-            <dd>{{ detail.heureDebut }}</dd>
+            <dd>{{ detail.heureDebut | slice:0:5 }}</dd>
           </div>
           <div>
-            <dt>Visibilité</dt>
+            <dt>Visibilit&eacute;</dt>
             <dd>{{ detail.visibilite }}</dd>
           </div>
           <div>
             <dt>Statut</dt>
-            <dd>{{ detail.statut }}</dd>
+            <dd>{{ getDisplayStatusLabel(detail) }}</dd>
           </div>
           <div>
             <dt>Organisateur</dt>
@@ -54,12 +54,46 @@
       </article>
 
       <article class="detail-card">
-        <h2>État du match</h2>
+        <h2>&Eacute;tat du match</h2>
+
+        @if (joinSuccessMessage()) {
+          <div class="action-message is-success" role="status" aria-live="polite">
+            <p>{{ joinSuccessMessage() }}</p>
+          </div>
+        }
+
+        @if (joinErrorMessage()) {
+          <div class="action-message is-error" role="alert" aria-live="polite">
+            <p>{{ joinErrorMessage() }}</p>
+
+            @if (joinErrorDetails(); as details) {
+              <ul class="action-details">
+                @for (detailEntry of details | keyvalue; track detailEntry.key) {
+                  <li>{{ detailEntry.value }}</li>
+                }
+              </ul>
+            }
+          </div>
+        }
+
         <div class="badge-row">
-          <span class="status-badge" [class.is-full]="detail.complet" [class.is-open]="!detail.complet">
-            {{ detail.complet ? 'Complet' : 'Incomplet' }}
+          <span
+            class="status-badge"
+            [class.is-cancelled]="isCancelled(detail)"
+            [class.temporal-passe]="!isCancelled(detail) && getDisplayStatusLabel(detail) === 'D\u00e9j\u00e0 jou\u00e9'"
+            [class.temporal-aujourd_hui]="!isCancelled(detail) && getDisplayStatusLabel(detail) === 'Aujourd\u2019hui'"
+            [class.temporal-futur]="!isCancelled(detail) && getDisplayStatusLabel(detail) === '\u00c0 venir'"
+          >
+            {{ getDisplayStatusLabel(detail) }}
           </span>
+
+          @if (!isCancelled(detail) && getDisplayStatusLabel(detail) !== 'D\u00e9j\u00e0 jou\u00e9') {
+            <span class="status-badge" [class.is-full]="detail.complet" [class.is-open]="!detail.complet">
+              {{ detail.complet ? 'Complet' : 'Places disponibles' }}
+            </span>
+          }
         </div>
+
         <dl class="detail-grid">
           <div>
             <dt>Participants</dt>
@@ -70,6 +104,17 @@
             <dd>{{ detail.placesRestantes }}</dd>
           </div>
         </dl>
+
+        @if (canShowJoinButton()) {
+          <button
+            type="button"
+            class="join-button"
+            [disabled]="isJoining()"
+            (click)="joinPublicMatch()"
+          >
+            {{ isJoining() ? 'Inscription en cours...' : 'Rejoindre le match' }}
+          </button>
+        }
       </article>
 
       <article class="detail-card">
@@ -80,15 +125,15 @@
             <dd>{{ detail.montantTotal | currency:'EUR' }}</dd>
           </div>
           <div>
-            <dt>Montant payé</dt>
+            <dt>Montant pay&eacute;</dt>
             <dd>{{ detail.montantPaye | currency:'EUR' }}</dd>
           </div>
           <div>
-            <dt>Reste à payer</dt>
+            <dt>Reste &agrave; payer</dt>
             <dd>{{ detail.resteAPayer | currency:'EUR' }}</dd>
           </div>
           <div>
-            <dt>Montant remboursé</dt>
+            <dt>Montant rembours&eacute;</dt>
             <dd>{{ detail.montantRembourse | currency:'EUR' }}</dd>
           </div>
         </dl>
@@ -97,7 +142,7 @@
       <article class="detail-card">
         <h2>Participants</h2>
         @if (detail.participants.length === 0) {
-          <p class="empty-participants">Aucun participant à afficher.</p>
+          <p class="empty-participants">Aucun participant &agrave; afficher.</p>
         } @else {
           <ul class="participants-list">
             @for (participant of detail.participants; track participant.matricule) {

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts
@@ -1,13 +1,15 @@
 import { CommonModule, CurrencyPipe, DatePipe, Location } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { finalize } from 'rxjs';
+import { MatchParticipationService } from '../../../core/matches/match-participation.service';
 import { MatchDetail } from '../../../core/matches/match-detail.models';
 import { MatchDetailService } from '../../../core/matches/match-detail.service';
 
 interface ApiErrorBody {
   message?: string;
+  details?: Record<string, string> | null;
 }
 
 @Component({
@@ -22,10 +24,23 @@ export class MatchDetailPageComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly matchDetailService = inject(MatchDetailService);
+  private readonly matchParticipationService = inject(MatchParticipationService);
 
   protected readonly match = signal<MatchDetail | null>(null);
   protected readonly isLoading = signal(true);
   protected readonly errorMessage = signal('');
+  protected readonly isJoining = signal(false);
+  protected readonly joinSuccessMessage = signal('');
+  protected readonly joinErrorMessage = signal('');
+  protected readonly joinErrorDetails = signal<Record<string, string> | null>(null);
+  protected readonly canShowJoinButton = computed(() => {
+    const detail = this.match();
+
+    return !!detail
+      && detail.visibilite === 'PUBLIC'
+      && detail.statut === 'PLANIFIE'
+      && detail.complet === false;
+  });
 
   ngOnInit(): void {
     const idParam = this.route.snapshot.paramMap.get('id');
@@ -47,6 +62,54 @@ export class MatchDetailPageComponent implements OnInit {
     }
 
     this.router.navigateByUrl('/matchs');
+  }
+
+  protected joinPublicMatch(): void {
+    const detail = this.match();
+    if (!detail || !this.canShowJoinButton() || this.isJoining()) {
+      return;
+    }
+
+    this.joinSuccessMessage.set('');
+    this.joinErrorMessage.set('');
+    this.joinErrorDetails.set(null);
+    this.isJoining.set(true);
+
+    this.matchParticipationService
+      .rejoindreMatchPublic(detail.id)
+      .pipe(finalize(() => this.isJoining.set(false)))
+      .subscribe({
+        next: () => {
+          this.joinSuccessMessage.set('Vous avez rejoint le match avec succès.');
+          this.loadMatchDetail(detail.id);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.handleJoinError(error);
+        }
+      });
+  }
+
+  protected getDisplayStatusLabel(detail: MatchDetail): string {
+    if (detail.statut === 'ANNULE') {
+      return 'Annul\u00e9';
+    }
+
+    const matchDay = this.getDayTimestamp(detail.dateDebut);
+    const today = this.getCurrentDayTimestamp();
+
+    if (matchDay < today) {
+      return 'D\u00e9j\u00e0 jou\u00e9';
+    }
+
+    if (matchDay > today) {
+      return '\u00c0 venir';
+    }
+
+    return 'Aujourd\u2019hui';
+  }
+
+  protected isCancelled(detail: MatchDetail): boolean {
+    return detail.statut === 'ANNULE';
   }
 
   private loadMatchDetail(id: number): void {
@@ -87,6 +150,18 @@ export class MatchDetailPageComponent implements OnInit {
     this.errorMessage.set(apiError.message ?? 'Impossible de charger le détail du match.');
   }
 
+  private handleJoinError(error: HttpErrorResponse): void {
+    const apiError = this.normalizeApiErrorBody(error.error);
+
+    if (error.status === 0) {
+      this.joinErrorMessage.set('Backend inaccessible.');
+      return;
+    }
+
+    this.joinErrorMessage.set(apiError.message ?? 'Impossible de rejoindre le match.');
+    this.joinErrorDetails.set(apiError.details ?? null);
+  }
+
   private normalizeApiErrorBody(raw: unknown): ApiErrorBody {
     if (typeof raw === 'string') {
       try {
@@ -101,5 +176,17 @@ export class MatchDetailPageComponent implements OnInit {
     }
 
     return {};
+  }
+
+  private getCurrentDayTimestamp(): number {
+    const now = new Date();
+
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  }
+
+  private getDayTimestamp(dateValue: string): number {
+    const [year, month, day] = dateValue.split('-').map((value) => Number(value));
+
+    return new Date(year, month - 1, day).getTime();
   }
 }

--- a/frontend/src/app/features/matches/my-matches/my-matches-page.component.css
+++ b/frontend/src/app/features/matches/my-matches/my-matches-page.component.css
@@ -84,6 +84,11 @@ h2 {
   font-weight: 700;
 }
 
+.status-badge.is-cancelled {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
 .temporal-passe {
   background: #e5e7eb;
   color: #374151;

--- a/frontend/src/app/features/matches/my-matches/my-matches-page.component.html
+++ b/frontend/src/app/features/matches/my-matches/my-matches-page.component.html
@@ -2,7 +2,7 @@
   <div class="page-header">
     <p class="eyebrow">Mes matchs</p>
     <h1>Mes matchs</h1>
-    <p>Retrouvez ici les matchs associés à votre compte joueur.</p>
+    <p>Retrouvez ici les matchs associ&eacute;s &agrave; votre compte joueur.</p>
   </div>
 
   @if (isLoading()) {
@@ -21,34 +21,40 @@
               <h2>{{ match.terrainNom }}</h2>
             </div>
 
-            <span class="status-badge temporal-{{ match.statutTemporel.toLowerCase() }}">
-              {{ match.statutTemporel }}
+            <span
+              class="status-badge"
+              [class.is-cancelled]="match.statut === 'ANNULE'"
+              [class.temporal-passe]="match.statut !== 'ANNULE' && match.statutTemporel === 'PASSE'"
+              [class.temporal-aujourd_hui]="match.statut !== 'ANNULE' && match.statutTemporel === 'AUJOURD_HUI'"
+              [class.temporal-futur]="match.statut !== 'ANNULE' && match.statutTemporel === 'FUTUR'"
+            >
+              {{ getDisplayStatusLabel(match) }}
             </span>
           </div>
 
           <dl class="match-details">
             <div>
               <dt>Date</dt>
-              <dd>{{ match.dateDebut | date:"dd/MM/yyyy 'à' HH:mm" }}</dd>
+              <dd>{{ match.dateDebut | date:'dd/MM/yyyy' }}</dd>
             </div>
             <div>
-              <dt>Visibilité</dt>
+              <dt>Heure</dt>
+              <dd>{{ match.dateDebut | date:'HH:mm' }}</dd>
+            </div>
+            <div>
+              <dt>Visibilit&eacute;</dt>
               <dd>{{ match.visibilite }}</dd>
             </div>
             <div>
               <dt>Statut</dt>
-              <dd>{{ match.statut }}</dd>
+              <dd>{{ getDisplayStatusLabel(match) }}</dd>
             </div>
             <div>
-              <dt>Rôle du joueur</dt>
+              <dt>R&ocirc;le du joueur</dt>
               <dd>{{ match.roleJoueur }}</dd>
             </div>
             <div>
-              <dt>Statut temporel</dt>
-              <dd>{{ match.statutTemporel }}</dd>
-            </div>
-            <div>
-              <dt>Paiement effectué</dt>
+              <dt>Paiement effectu&eacute;</dt>
               <dd>{{ match.paiementJoueurEffectue ? 'Oui' : 'Non' }}</dd>
             </div>
             @if (match.joursAvantMatch !== null) {
@@ -59,7 +65,7 @@
             }
           </dl>
 
-          <a [routerLink]="['/matchs', match.id]" class="detail-link">Voir le détail</a>
+          <a [routerLink]="['/matchs', match.id]" class="detail-link">Voir le d&eacute;tail</a>
         </article>
       }
     </div>

--- a/frontend/src/app/features/matches/my-matches/my-matches-page.component.ts
+++ b/frontend/src/app/features/matches/my-matches/my-matches-page.component.ts
@@ -24,6 +24,22 @@ export class MyMatchesPageComponent implements OnInit {
     this.loadMatches();
   }
 
+  protected getDisplayStatusLabel(match: PlayerMatchSummary): string {
+    if (match.statut === 'ANNULE') {
+      return 'Annul\u00e9';
+    }
+
+    switch (match.statutTemporel) {
+      case 'PASSE':
+        return 'D\u00e9j\u00e0 jou\u00e9';
+      case 'AUJOURD_HUI':
+        return 'Aujourd\u2019hui';
+      case 'FUTUR':
+      default:
+        return '\u00c0 venir';
+    }
+  }
+
   private loadMatches(): void {
     this.isLoading.set(true);
     this.errorMessage.set('');

--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.css
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.css
@@ -97,8 +97,8 @@ h2 {
 }
 
 .status-badge.is-open {
-  background: #fee2e2;
-  color: #991b1b;
+  background: #dcfce7;
+  color: #166534;
 }
 
 .status-badge.is-cancelled {

--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.html
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.html
@@ -1,16 +1,16 @@
 <section class="organized-matches-page">
   <div class="page-header">
-    <p class="eyebrow">Matchs organisés</p>
-    <h1>Matchs organisés</h1>
+    <p class="eyebrow">Matchs organis&eacute;s</p>
+    <h1>Matchs organis&eacute;s</h1>
     <p>Retrouvez ici les matchs que vous organisez actuellement.</p>
   </div>
 
   @if (isLoading()) {
-    <p class="state-message">Chargement de vos matchs organisés...</p>
+    <p class="state-message">Chargement de vos matchs organis&eacute;s...</p>
   } @else if (errorMessage()) {
     <p class="state-message is-error">{{ errorMessage() }}</p>
   } @else if (matches().length === 0) {
-    <p class="state-message">Vous n'avez aucun match organisé pour le moment.</p>
+    <p class="state-message">Vous n'avez aucun match organis&eacute; pour le moment.</p>
   } @else {
     <div class="match-list">
       @for (match of matches(); track match.id) {
@@ -22,32 +22,44 @@
             </div>
 
             <div class="badge-group">
-              <span class="status-badge temporal-{{ match.statutTemporel.toLowerCase() }}">
-                {{ match.statutTemporel }}
-              </span>
               <span
                 class="status-badge"
                 [class.is-cancelled]="match.statut === 'ANNULE'"
-                [class.is-full]="match.statut !== 'ANNULE' && match.complet"
-                [class.is-open]="match.statut !== 'ANNULE' && !match.complet"
+                [class.temporal-passe]="match.statut !== 'ANNULE' && match.statutTemporel === 'PASSE'"
+                [class.temporal-aujourd_hui]="match.statut !== 'ANNULE' && match.statutTemporel === 'AUJOURD_HUI'"
+                [class.temporal-futur]="match.statut !== 'ANNULE' && match.statutTemporel === 'FUTUR'"
               >
-                {{ match.statut === 'ANNULE' ? 'Annulé' : (match.complet ? 'Complet' : 'Incomplet') }}
+                {{ getDisplayStatusLabel(match) }}
               </span>
+
+              @if (match.statut !== 'ANNULE' && match.statutTemporel !== 'PASSE') {
+                <span
+                  class="status-badge"
+                  [class.is-full]="match.complet"
+                  [class.is-open]="!match.complet"
+                >
+                  {{ match.complet ? 'Complet' : 'Places disponibles' }}
+                </span>
+              }
             </div>
           </div>
 
           <dl class="match-details">
             <div>
               <dt>Date</dt>
-              <dd>{{ match.dateDebut | date:"dd/MM/yyyy 'à' HH:mm" }}</dd>
+              <dd>{{ match.dateDebut | date:'dd/MM/yyyy' }}</dd>
             </div>
             <div>
-              <dt>Visibilité</dt>
+              <dt>Heure</dt>
+              <dd>{{ match.dateDebut | date:'HH:mm' }}</dd>
+            </div>
+            <div>
+              <dt>Visibilit&eacute;</dt>
               <dd>{{ match.visibilite }}</dd>
             </div>
             <div>
               <dt>Statut</dt>
-              <dd>{{ match.statut }}</dd>
+              <dd>{{ getDisplayStatusLabel(match) }}</dd>
             </div>
             <div>
               <dt>Participants</dt>
@@ -56,10 +68,6 @@
             <div>
               <dt>Places restantes</dt>
               <dd>{{ match.placesRestantes }}</dd>
-            </div>
-            <div>
-              <dt>Statut temporel</dt>
-              <dd>{{ match.statutTemporel }}</dd>
             </div>
             @if (match.joursAvantMatch !== null) {
               <div>
@@ -70,10 +78,10 @@
           </dl>
 
           @if (match.risquePenaliteJ1) {
-            <p class="risk-message">Risque de pénalité J-1</p>
+            <p class="risk-message">Risque de p&eacute;nalit&eacute; J-1</p>
           }
 
-          <a [routerLink]="['/matchs', match.id]" class="detail-link">Voir le détail</a>
+          <a [routerLink]="['/matchs', match.id]" class="detail-link">Voir le d&eacute;tail</a>
         </article>
       }
     </div>

--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.ts
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.ts
@@ -24,6 +24,22 @@ export class OrganizedMatchesPageComponent implements OnInit {
     this.loadMatches();
   }
 
+  protected getDisplayStatusLabel(match: OrganizedMatchSummary): string {
+    if (match.statut === 'ANNULE') {
+      return 'Annul\u00e9';
+    }
+
+    switch (match.statutTemporel) {
+      case 'PASSE':
+        return 'D\u00e9j\u00e0 jou\u00e9';
+      case 'AUJOURD_HUI':
+        return 'Aujourd\u2019hui';
+      case 'FUTUR':
+      default:
+        return '\u00c0 venir';
+    }
+  }
+
   private loadMatches(): void {
     this.isLoading.set(true);
     this.errorMessage.set('');

--- a/frontend/src/app/features/matches/public-matches/public-matches-page.component.css
+++ b/frontend/src/app/features/matches/public-matches/public-matches-page.component.css
@@ -50,6 +50,37 @@
   cursor: pointer;
 }
 
+.display-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.display-filter-button {
+  min-width: 8.5rem;
+  padding: 0.7rem 1rem;
+  border: 1px solid #c3d0de;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #526277;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+
+.display-filter-button:hover {
+  border-color: #0f766e;
+  color: #0f766e;
+}
+
+.display-filter-button.is-active {
+  border-color: #0f766e;
+  background: #0f766e;
+  color: #ffffff;
+}
+
 .eyebrow {
   margin: 0 0 0.5rem;
   color: #0f766e;
@@ -127,9 +158,24 @@ h2 {
   font-weight: 700;
 }
 
+.status.is-open {
+  background: #dcfce7;
+  color: #166534;
+}
+
 .status.is-full {
   background: #fee2e2;
   color: #991b1b;
+}
+
+.status.is-cancelled {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.status.is-past {
+  background: #e5e7eb;
+  color: #374151;
 }
 
 .match-details {

--- a/frontend/src/app/features/matches/public-matches/public-matches-page.component.html
+++ b/frontend/src/app/features/matches/public-matches/public-matches-page.component.html
@@ -37,15 +37,28 @@
     <button type="submit" class="filters-submit">Charger</button>
   </form>
 
+  <div class="display-filters" aria-label="Filtrer les matchs publics">
+    @for (filter of displayFilterOptions; track filter.value) {
+      <button
+        type="button"
+        class="display-filter-button"
+        [class.is-active]="isFilterSelected(filter.value)"
+        (click)="selectDisplayFilter(filter.value)"
+      >
+        {{ filter.label }}
+      </button>
+    }
+  </div>
+
   @if (isLoading()) {
     <p class="state-message">Chargement des matchs...</p>
   } @else if (errorMessage()) {
     <p class="state-message is-error">{{ errorMessage() }}</p>
-  } @else if (matches().length === 0) {
-    <p class="state-message">Aucun match public disponible pour le moment.</p>
+  } @else if (filteredMatches().length === 0) {
+    <p class="state-message">{{ emptyStateMessage() }}</p>
   } @else {
     <div class="match-list">
-      @for (match of matches(); track match.id) {
+      @for (match of filteredMatches(); track match.id) {
         <article class="match-card">
           <div class="match-card-top">
             <div>
@@ -53,19 +66,19 @@
               <h2>{{ match.terrainNom }}</h2>
             </div>
 
-            <span class="status" [class.is-full]="match.complet">
-              {{ match.complet ? 'Complet' : 'Places disponibles' }}
+            <span class="status" [class]=" 'status ' + getMatchBadgeClass(match) ">
+              {{ getMatchBadgeLabel(match) }}
             </span>
           </div>
 
           <dl class="match-details">
             <div>
               <dt>Date</dt>
-              <dd>{{ match.dateDebut }}</dd>
+              <dd>{{ match.dateDebut | date:'dd/MM/yyyy' }}</dd>
             </div>
             <div>
               <dt>Heure</dt>
-              <dd>{{ match.heureDebut }}</dd>
+              <dd>{{ match.heureDebut | slice:0:5 }}</dd>
             </div>
             <div>
               <dt>Organisateur</dt>
@@ -85,7 +98,7 @@
             </div>
           </dl>
 
-          <a [routerLink]="['/matchs', match.id]" class="detail-link">Voir le détail</a>
+          <a [routerLink]="['/matchs', match.id]" class="detail-link">{{ getDetailLinkLabel(match) }}</a>
         </article>
       }
     </div>

--- a/frontend/src/app/features/matches/public-matches/public-matches-page.component.ts
+++ b/frontend/src/app/features/matches/public-matches/public-matches-page.component.ts
@@ -1,15 +1,29 @@
-import { CommonModule, CurrencyPipe } from '@angular/common';
+import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { finalize } from 'rxjs';
 import { PublicMatch } from '../../../core/matches/public-match.models';
 import { PublicMatchesService } from '../../../core/matches/public-matches.service';
 
+type PublicMatchDisplayFilter = 'TOUS' | 'DISPONIBLES' | 'COMPLETS' | 'DEJA_JOUES';
+
+interface PublicMatchFilterOption {
+  value: PublicMatchDisplayFilter;
+  label: string;
+}
+
+const DISPLAY_FILTER_OPTIONS: PublicMatchFilterOption[] = [
+  { value: 'TOUS', label: 'Tous' },
+  { value: 'DISPONIBLES', label: 'Disponibles' },
+  { value: 'COMPLETS', label: 'Complets' },
+  { value: 'DEJA_JOUES', label: 'D\u00e9j\u00e0 jou\u00e9s' }
+];
+
 @Component({
   selector: 'app-public-matches-page',
   standalone: true,
-  imports: [CommonModule, RouterLink, CurrencyPipe],
+  imports: [CommonModule, RouterLink, CurrencyPipe, DatePipe],
   templateUrl: './public-matches-page.component.html',
   styleUrl: './public-matches-page.component.css'
 })
@@ -19,10 +33,46 @@ export class PublicMatchesPageComponent implements OnInit {
   protected readonly matches = signal<PublicMatch[]>([]);
   protected readonly isLoading = signal(true);
   protected readonly errorMessage = signal('');
+  protected readonly displayFilterOptions = DISPLAY_FILTER_OPTIONS;
   protected readonly filters = signal({
     from: '2026-01-01',
     to: '2026-04-30',
     siteId: '1'
+  });
+  protected readonly selectedDisplayFilter = signal<PublicMatchDisplayFilter>('TOUS');
+  protected readonly filteredMatches = computed(() => {
+    const selectedFilter = this.selectedDisplayFilter();
+
+    return this.matches().filter((match) => {
+      switch (selectedFilter) {
+        case 'DISPONIBLES':
+          return this.isMatchJoinable(match);
+        case 'COMPLETS':
+          return match.complet;
+        case 'DEJA_JOUES':
+          return this.isPastMatch(match);
+        case 'TOUS':
+        default:
+          return true;
+      }
+    });
+  });
+  protected readonly emptyStateMessage = computed(() => {
+    if (this.matches().length === 0) {
+      return 'Aucun match public disponible pour le moment.';
+    }
+
+    switch (this.selectedDisplayFilter()) {
+      case 'DISPONIBLES':
+        return 'Aucun match public disponible \u00e0 afficher pour ce filtre.';
+      case 'COMPLETS':
+        return 'Aucun match complet \u00e0 afficher pour ce filtre.';
+      case 'DEJA_JOUES':
+        return 'Aucun match d\u00e9j\u00e0 jou\u00e9 \u00e0 afficher pour ce filtre.';
+      case 'TOUS':
+      default:
+        return 'Aucun match public disponible pour le moment.';
+    }
   });
 
   ngOnInit(): void {
@@ -39,6 +89,69 @@ export class PublicMatchesPageComponent implements OnInit {
   protected submitFilters(event: Event): void {
     event.preventDefault();
     this.loadMatches();
+  }
+
+  protected selectDisplayFilter(filter: PublicMatchDisplayFilter): void {
+    this.selectedDisplayFilter.set(filter);
+  }
+
+  protected isFilterSelected(filter: PublicMatchDisplayFilter): boolean {
+    return this.selectedDisplayFilter() === filter;
+  }
+
+  protected getDetailLinkLabel(match: PublicMatch): string {
+    return this.isMatchJoinable(match) ? 'Voir le d\u00e9tail / rejoindre' : 'Voir le d\u00e9tail';
+  }
+
+  protected getMatchBadgeLabel(match: PublicMatch): string {
+    if (match.statut === 'ANNULE') {
+      return 'Annul\u00e9';
+    }
+
+    if (this.isPastMatch(match)) {
+      return 'D\u00e9j\u00e0 jou\u00e9';
+    }
+
+    return match.complet ? 'Complet' : 'Places disponibles';
+  }
+
+  protected getMatchBadgeClass(match: PublicMatch): string {
+    if (match.statut === 'ANNULE') {
+      return 'is-cancelled';
+    }
+
+    if (this.isPastMatch(match)) {
+      return 'is-past';
+    }
+
+    return match.complet ? 'is-full' : 'is-open';
+  }
+
+  private isMatchJoinable(match: PublicMatch): boolean {
+    if (match.complet || this.isPastMatch(match)) {
+      return false;
+    }
+
+    if (match.statut) {
+      return match.statut === 'PLANIFIE';
+    }
+
+    return true;
+  }
+
+  private isPastMatch(match: PublicMatch): boolean {
+    if (match.statutTemporel) {
+      return match.statutTemporel === 'PASSE';
+    }
+
+    return this.getMatchStartDate(match).getTime() < Date.now();
+  }
+
+  private getMatchStartDate(match: PublicMatch): Date {
+    const [year, month, day] = match.dateDebut.split('-').map((value) => Number(value));
+    const [hours = 0, minutes = 0] = match.heureDebut.split(':').map((value) => Number(value));
+
+    return new Date(year, month - 1, day, hours, minutes);
   }
 
   private loadMatches(): void {


### PR DESCRIPTION
- ajout de la fonctionnalité pour rejoindre un match public depuis la page détail
- intégration de l’appel POST /api/v1/matchs/{id}/participants/public (sans modification backend)
- ajout d’un filtre local sur /matchs (tous, disponibles, complets, déjà joués)
- affichage conditionnel du lien Voir le détail / rejoindre
- suppression des actions incohérentes (matchs complets ou déjà joués)
- harmonisation des statuts (Déjà joué, À venir, Aujourd’hui, Annulé)
- amélioration des badges et de leur cohérence
- uniformisation des dates (dd/MM/yyyy) et heures (HH:mm)

Interface plus claire, cohérente et conforme aux règles métier existantes.