### PR TITLE
feat(matchs): ajouter un joueur à un match privé

### DIFF
--- a/frontend/docs/ajouter-joueur-match-prive-analyse.md
+++ b/frontend/docs/ajouter-joueur-match-prive-analyse.md
@@ -1,0 +1,438 @@
+# Analyse - Issue 12 Ajouter joueur a match prive
+
+## Contexte
+
+Projet :
+
+- PDW / SGBD gestion de matchs de padel
+
+Issue etudiee :
+
+- Issue 12 - Ajouter joueur a match prive
+
+Contraintes de l'analyse :
+
+- ne rien coder pour l'instant
+- ne modifier aucun fichier applicatif
+- ne pas changer le scope
+- ne pas ajouter de logique metier dans le frontend
+- laisser le backend responsable des regles et autorisations
+
+Decision validee pour preparer l'implementation :
+
+- une legere modification backend est acceptee
+- ajout cible dans le DTO de detail match :
+  - `peutAjouterJoueurPrive: boolean`
+- ce champ sert uniquement a l'affichage frontend
+- il ne remplace pas les verifications backend de l'endpoint POST prive
+
+Rappel fonctionnel SGBD :
+
+- pour un match prive, le responsable qui a fait la reservation ajoute lui-meme les autres joueurs
+- pour un match public, l'organisateur ne peut pas reserver pour un autre joueur
+- l'ajout manuel de joueur concerne donc uniquement les matchs prives
+
+---
+
+## Constat du code existant
+
+### Frontend
+
+Le frontend Angular dispose deja de :
+
+- login JWT
+- `AuthGuard`
+- `jwtInterceptor`
+- `httpErrorInterceptor`
+- `/matchs`
+- `/matchs/:id`
+- `/me/matchs`
+- `/me/matchs/organises`
+
+Fonctionnalites deja en place autour des matchs :
+
+- liste des matchs publics
+- detail de match
+- rejoindre un match public
+- gestion des erreurs backend
+- filtres frontend
+- affichage conditionnel des liens vers le detail
+- corrections UX sur badges, statuts, dates
+
+### Backend
+
+Le backend contient deja une logique de participation centralisee dans :
+
+- [ParticipationController.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/controller/ParticipationController.java:1)
+- [ParticipationService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java:1)
+
+Le detail de match est expose via :
+
+- [MatchDetailDto.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDetailDto.java:1)
+
+Le modele frontend correspondant existe deja :
+
+- [match-detail.models.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-detail.models.ts:1)
+
+Le frontend a deja un service pour les participations publiques :
+
+- [match-participation.service.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-participation.service.ts:1)
+
+Le flux de detail match est le point d'injection le plus cible pour la modification validee :
+
+- [MatchController.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java:1)
+- [MatchPadelService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java:1)
+- [MatchDetailMapper.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchDetailMapper.java:1)
+
+---
+
+## Endpoint backend trouve
+
+Oui, l'endpoint existe deja.
+
+Endpoint :
+
+- `POST /api/v1/matchs/{matchId}/participants/prive`
+
+Reference :
+
+- [ParticipationController.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/controller/ParticipationController.java:1)
+
+Signature backend :
+
+```java
+@PostMapping("/{matchId}/participants/prive")
+public ResponseEntity<ParticipationDto> ajouterJoueurPrive(
+        @PathVariable Long matchId,
+        @Valid @RequestBody AddPlayerToPrivateMatchRequest req)
+```
+
+Body attendu :
+
+```json
+{
+  "joueurMatriculeAAjouter": "..."
+}
+```
+
+Request DTO :
+
+- [AddPlayerToPrivateMatchRequest.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/dto/request/AddPlayerToPrivateMatchRequest.java:1)
+
+Retour :
+
+- `ParticipationDto`
+
+Conclusion :
+
+- aucun endpoint backend supplementaire n'est necessaire pour respecter l'enonce
+
+---
+
+## Verifications backend utiles
+
+Le backend gere deja les regles metier et les autorisations dans :
+
+- [ParticipationService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java:1)
+
+La methode utile est :
+
+- `ajouterJoueurParOrganisateur(Long matchId, String joueurMatriculeAAjouter)`
+
+Regles deja prises en charge par le backend :
+
+- match introuvable
+- match annule
+- refus si le match est public
+- refus si l'utilisateur courant n'est ni organisateur ni admin
+- refus si le joueur a ajouter n'existe pas
+- refus si le joueur est deja inscrit
+- refus si le match est complet
+
+Conclusion :
+
+- il ne faut pas reimplementer ces controles dans le frontend
+
+---
+
+## Service frontend de participation
+
+Etat actuel :
+
+- le frontend possede deja `MatchParticipationService`
+- il couvre seulement `rejoindreMatchPublic(matchId)`
+
+Reference :
+
+- [match-participation.service.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-participation.service.ts:1)
+
+Conclusion :
+
+- le service est partiellement adapte
+- il manque seulement une methode pour l'appel prive
+- il n'est pas necessaire de creer un nouveau service
+
+---
+
+## Le frontend peut-il savoir proprement que l'utilisateur connecte est l'organisateur ?
+
+### Reponse courte
+
+Non, pas proprement avec les donnees actuelles.
+
+### Pourquoi
+
+Le detail du match expose :
+
+- `organisateurMatricule`
+
+References :
+
+- [MatchDetailDto.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDetailDto.java:1)
+- [match-detail.models.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-detail.models.ts:1)
+
+Mais le frontend d'authentification ne stocke que :
+
+- le JWT
+- un bool d'authentification
+
+References :
+
+- [auth.service.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/auth/auth.service.ts:1)
+- [auth.models.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/auth/auth.models.ts:1)
+
+La reponse de login ne contient pas :
+
+- le matricule du joueur
+- l'id du joueur
+- un flag "est organisateur"
+
+Le JWT porte comme subject :
+
+- le `login` utilisateur
+
+Reference :
+
+- [JwtService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/security/JwtService.java:1)
+
+Or, dans le modele backend :
+
+- `User.login` et `Joueur.matricule` sont deux donnees distinctes
+
+References :
+
+- [User.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/User.java:1)
+- [Joueur.java](/C:/Users\fanoa\PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/model/entities/Joueur.java:1)
+
+### Conclusion
+
+Le frontend ne peut pas comparer de facon fiable :
+
+- l'utilisateur connecte
+- et `organisateurMatricule`
+
+Donc il ne peut pas savoir proprement, avec les donnees existantes, que l'utilisateur courant est l'organisateur.
+
+---
+
+## Decision retenue
+
+Pour resoudre proprement ce point sans ajouter de logique metier cote Angular, la decision retenue est :
+
+- enrichir le DTO de detail match avec `peutAjouterJoueurPrive`
+- calculer ce boolen cote backend
+- l'utiliser uniquement pour afficher ou masquer l'action frontend
+
+Ce boolen :
+
+- ne remplace pas l'autorisation backend
+- ne remplace pas les controles de visibilite, statut, places ou organisateur
+- ne change pas l'endpoint POST existant
+
+---
+
+## Comment calculer `peutAjouterJoueurPrive`
+
+Le calcul doit etre fait dans le backend, dans le flux de detail match, idealement dans :
+
+- [MatchPadelService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java:1)
+
+Regle prudente proposee pour `true` :
+
+- match `PRIVE`
+- match non `ANNULE`
+- match non complet
+- utilisateur courant = organisateur ou admin
+
+En pratique, le calcul doit s'aligner sur les regles deja appliquees dans :
+
+- [ParticipationService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java:1)
+
+mais seulement pour la partie qui ne depend pas encore du joueur a ajouter.
+
+Important :
+
+- je n'ajouterais pas de regle supplementaire "match passe" si elle n'existe pas deja dans l'endpoint POST
+- le boolen d'affichage doit rester coherent avec le comportement backend reel
+
+---
+
+## Solution prudente retenue
+
+- le backend renvoie `peutAjouterJoueurPrive`
+- le frontend affiche le formulaire uniquement si `peutAjouterJoueurPrive === true`
+- le submit appelle l'endpoint POST prive existant
+- apres succes, le detail du match est recharge
+- en cas d'erreur, le message backend est affiche proprement
+
+Cette approche :
+
+- respecte le scope
+- evite de reconstituer l'autorisation cote Angular
+- garde le backend comme source de verite
+- reste ciblee sur le detail match
+
+---
+
+## Proposition d'implementation courte et prudente
+
+Sans coder pour l'instant, l'implementation la plus sure serait :
+
+1. Ajouter `peutAjouterJoueurPrive` a `MatchDetailDto`
+2. Calculer ce champ dans le backend au moment de construire le detail match
+3. Reutiliser la page detail existante `/matchs/:id`
+4. Etendre `MatchParticipationService` avec une methode pour :
+   - `POST /api/v1/matchs/{id}/participants/prive`
+5. Ajouter dans le detail du match prive un petit formulaire simple :
+   - un champ texte `joueurMatriculeAAjouter`
+   - un bouton `Ajouter le joueur`
+6. Au submit :
+   - envoyer `{ joueurMatriculeAAjouter }`
+   - afficher le message backend si erreur
+   - afficher un message de succes si OK
+   - recharger le detail du match
+7. Ne pas ajouter d'autocomplete, de recherche joueur, ni de logique supplementaire hors scope
+
+Ce que le frontend ne ferait pas :
+
+- verifier que le joueur existe
+- verifier qu'il reste une place
+- verifier qu'il n'est pas deja inscrit
+- verifier que l'utilisateur est bien organisateur
+
+Tout cela resterait cote backend.
+
+---
+
+## Fichiers probablement concernes
+
+### Frontend
+
+- [match-detail.models.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-detail.models.ts:1)
+- [match-participation.service.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-participation.service.ts:1)
+- [match-participation.models.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-participation.models.ts:1)  
+  Reutilisable tel quel pour la reponse. Un type request optionnel pourrait etre ajoute si souhaite, sans obligation.
+- [match-detail-page.component.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts:1)
+- [match-detail-page.component.html](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/features/matches/match-detail/match-detail-page.component.html:1)
+- [match-detail-page.component.css](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/features/matches/match-detail/match-detail-page.component.css:1)
+
+### Backend
+
+- [MatchDetailDto.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDetailDto.java:1)
+- [MatchDetailMapper.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchDetailMapper.java:1)
+- [MatchPadelService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java:1)
+- [MatchControllerTest.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java:1)
+
+---
+
+## Risques
+
+1. Coherence entre affichage et backend
+
+Le boolen `peutAjouterJoueurPrive` doit rester strictement coherent avec les regles backend reelles.
+
+Si on ajoute une condition d'affichage qui n'est pas verifiee par le POST prive, on cree une divergence.
+
+2. Ambiguite entre organisateur et admin
+
+Le backend autorise :
+
+- l'organisateur
+- ou un admin
+
+Alors que l'enonce parle surtout du responsable / organisateur.
+
+Il faut valider si cette difference est acceptable cote UX ou simplement assumee comme comportement backend existant.
+
+3. Saisie par matricule
+
+Le backend attend :
+
+- `joueurMatriculeAAjouter`
+
+Donc la version la plus prudente est un simple champ texte.
+
+Si le besoin produit attend une recherche utilisateur ou une liste deroulante, ce serait un scope plus large.
+
+4. Tests backend a adapter
+
+`MatchDetailDto` est instancie explicitement dans les tests controleur.
+
+Donc l'ajout du nouveau champ imposera une mise a jour ciblee des fixtures et assertions.
+
+5. Visibilite du match prive
+
+Il faut verifier en pratique que l'acces a `/matchs/:id` pour un match prive est deja conforme aux autorisations attendues.
+
+---
+
+## Points a valider avant codage
+
+1. Le mode de saisie attendu
+
+- un simple champ `matricule joueur` est-il acceptable pour l'issue 12 ?
+
+2. La semantique exacte de `peutAjouterJoueurPrive`
+
+- doit-il etre `true` pour l'admin aussi ?
+- la reponse prudente est oui, puisque le backend l'autorise deja
+
+3. L'alignement avec le POST prive
+
+- faut-il rester strictement aligne sur les regles deja appliquees par le backend
+- la reponse prudente est oui
+
+4. Le perimetre UX
+
+- faut-il rester sur un simple formulaire minimal
+- sans recherche joueur
+- sans liste de joueurs disponibles
+
+5. Le pattern d'integration
+
+- reutiliser le meme schema que "rejoindre un match public" :
+  - etat de chargement
+  - message succes
+  - message erreur backend
+  - reload du detail apres succes
+
+---
+
+## Conclusion
+
+Le backend fournit deja l'endpoint et les regles necessaires pour l'issue 12.
+
+Le frontend ne peut pas savoir proprement aujourd'hui, avec les donnees existantes, que l'utilisateur connecte est l'organisateur du match prive, car :
+
+- il connait le login JWT
+- mais pas le matricule joueur courant
+- alors que le detail expose seulement `organisateurMatricule`
+
+La modification ciblee backend validee permet de lever proprement cette limite :
+
+- le detail match renverra `peutAjouterJoueurPrive`
+- le frontend affichera l'action uniquement si ce champ vaut `true`
+- le backend continuera a verifier toutes les regles au moment du POST prive
+- le frontend se limitera a appeler l'API, afficher le succes ou l'erreur, puis recharger le detail
+
+Cette approche est la plus sure avant codage.

--- a/frontend/docs/ajouter-joueur-match-prive-implementation.md
+++ b/frontend/docs/ajouter-joueur-match-prive-implementation.md
@@ -1,0 +1,368 @@
+# Implementation - Issue 12 Ajouter joueur a match prive
+
+## Objectif
+
+Permettre l'ajout manuel d'un joueur a un match prive depuis la page detail `/matchs/:id`, sans deplacer la logique metier dans Angular.
+
+Le backend reste responsable :
+
+- des autorisations
+- des validations business
+- des refus fonctionnels
+
+Le frontend :
+
+- affiche l'action uniquement si le detail du match l'autorise
+- envoie la demande au backend
+- affiche le succes ou l'erreur
+- recharge le detail apres succes
+
+---
+
+## Perimetre implemente
+
+Cette implementation couvre :
+
+- l'ajout du champ `peutAjouterJoueurPrive` dans le detail match
+- le calcul backend de ce champ
+- l'alignement du POST prive sur la condition `PLANIFIE`
+- l'ajout du formulaire minimal dans la page detail
+- l'appel frontend vers l'endpoint prive existant
+- le rechargement du detail apres succes
+
+Cette implementation ne couvre pas :
+
+- recherche joueur
+- autocomplete
+- liste deroulante de joueurs
+- nouvelle page
+- refactor global
+
+---
+
+## Backend
+
+### 1. DTO de detail match
+
+Le DTO de detail match expose maintenant :
+
+- `peutAjouterJoueurPrive: boolean`
+
+Fichier :
+
+- [MatchDetailDto.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDetailDto.java:33)
+
+Ce champ sert uniquement a l'affichage frontend.
+
+---
+
+### 2. Mapping du detail
+
+Le mapper du detail transporte maintenant ce boolen vers la reponse JSON.
+
+Fichier :
+
+- [MatchDetailMapper.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchDetailMapper.java:16)
+
+---
+
+### 3. Calcul de `peutAjouterJoueurPrive`
+
+Le calcul est fait dans le service de detail match.
+
+Fichier :
+
+- [MatchPadelService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java:349)
+
+Regle implemente :
+
+`peutAjouterJoueurPrive = true` uniquement si :
+
+- le match est `PRIVE`
+- le match est `PLANIFIE`
+- le match n'est pas complet
+- l'utilisateur courant est :
+  - organisateur
+  - ou `ADMIN_GLOBAL`
+  - ou `ADMIN_SITE` avec un perimetre correspondant au site du match
+
+Le calcul reste donc coherent avec l'action backend reelle.
+
+---
+
+### 3bis. Correction de coherence `ADMIN_SITE`
+
+Une correction backend ciblee a ete ajoutee avant validation finale de l'issue.
+
+Probleme detecte :
+
+- un `ADMIN_SITE` etait auparavant autorise trop largement via un simple test `isAdmin()`
+- cela permettait a un `ADMIN_SITE` hors perimetre :
+  - de voir l'action
+  - et d'executer le POST prive
+
+Correction appliquee :
+
+- reutilisation du service existant [ServiceAutorisationAdmin.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/security/ServiceAutorisationAdmin.java:1)
+- ajout d'une methode booleenne :
+  - `peutAdministrerSite(siteId)`
+
+Reference :
+
+- [ServiceAutorisationAdmin.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/security/ServiceAutorisationAdmin.java:46)
+
+Semantique :
+
+- `true` pour `ADMIN_GLOBAL`
+- `true` pour `ADMIN_SITE` uniquement si son site autorise correspond au site du match
+- `false` sinon
+
+Cette methode permet :
+
+- d'autoriser ou refuser le POST prive
+- de calculer `peutAjouterJoueurPrive`
+- sans faire echouer le GET detail quand l'utilisateur n'a simplement pas le droit d'ajouter un joueur
+
+---
+
+### 4. Endpoint prive existant conserve
+
+L'endpoint utilise reste :
+
+- `POST /api/v1/matchs/{matchId}/participants/prive`
+
+Fichier :
+
+- [ParticipationController.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/controller/ParticipationController.java:1)
+
+Body envoye :
+
+```json
+{
+  "joueurMatriculeAAjouter": "G0002"
+}
+```
+
+---
+
+### 5. Alignement du POST prive
+
+Le service backend d'ajout prive refuse maintenant aussi l'ajout si le match n'est pas `PLANIFIE`.
+
+Fichier :
+
+- [ParticipationService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java:103)
+
+But :
+
+- eviter une divergence entre
+  - ce que le detail affiche
+  - et ce que le POST accepte reellement
+
+La logique finale d'autorisation du POST prive est maintenant :
+
+- organisateur du match
+- ou `ADMIN_GLOBAL`
+- ou `ADMIN_SITE` du bon site
+
+Reference :
+
+- [ParticipationService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java:110)
+
+Les controles backend existants restent en place :
+
+- match introuvable
+- match annule
+- refus si match public
+- refus si non organisateur et non admin
+- refus si joueur introuvable
+- refus si joueur deja inscrit
+- refus si match complet
+
+---
+
+## Frontend
+
+### 1. Modele detail match
+
+Le modele TypeScript du detail match expose maintenant :
+
+- `peutAjouterJoueurPrive: boolean`
+
+Fichier :
+
+- [match-detail.models.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-detail.models.ts:21)
+
+---
+
+### 2. Service de participation
+
+Le service existant a ete etendu.
+
+Fichier :
+
+- [match-participation.service.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-participation.service.ts:18)
+
+Nouvelle methode :
+
+- `ajouterJoueurPrive(matchId, joueurMatriculeAAjouter)`
+
+Elle appelle :
+
+- `POST /matchs/{matchId}/participants/prive`
+
+Le service existant de participation publique n'a pas ete remplace.
+
+---
+
+### 3. Affichage conditionnel dans le detail
+
+La page detail utilise maintenant directement :
+
+- `detail.peutAjouterJoueurPrive`
+
+Fichier :
+
+- [match-detail-page.component.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts:49)
+
+Computed utilise :
+
+- `canShowPrivateAddForm`
+
+Le frontend ne deduit pas lui-meme si l'utilisateur est organisateur.
+Le frontend ne deduit pas non plus le perimetre `ADMIN_SITE`.
+
+---
+
+### 4. Formulaire minimal ajoute
+
+Le formulaire apparait uniquement si `peutAjouterJoueurPrive === true`.
+
+Fichier :
+
+- [match-detail-page.component.html](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/features/matches/match-detail/match-detail-page.component.html:146)
+
+Contenu :
+
+- un champ texte `Matricule du joueur`
+- un bouton `Ajouter le joueur`
+
+Le formulaire reste volontairement simple :
+
+- pas d'autocomplete
+- pas de recherche joueur
+- pas de select
+
+---
+
+### 5. Gestion du submit
+
+Le composant detail gere maintenant :
+
+- l'etat de chargement de l'ajout prive
+- le message de succes
+- le message d'erreur backend
+- les details d'erreur backend si presents
+
+Fichier :
+
+- [match-detail-page.component.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts:103)
+
+Comportement :
+
+1. l'utilisateur saisit un matricule
+2. Angular appelle `ajouterJoueurPrive(...)`
+3. si succes :
+   - message de succes
+   - reset du champ
+   - rechargement du detail match
+4. si erreur :
+   - le champ n'est pas reset
+   - le message backend est affiche
+
+---
+
+### 6. Styles
+
+Un style minimal a ete ajoute pour :
+
+- le bloc de formulaire
+- le champ texte
+- le bouton d'action
+
+Fichier :
+
+- [match-detail-page.component.css](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/features/matches/match-detail/match-detail-page.component.css:160)
+
+---
+
+## Fichiers modifies
+
+### Backend
+
+- [MatchDetailDto.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MatchDetailDto.java:1)
+- [MatchDetailMapper.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/mapper/MatchDetailMapper.java:1)
+- [ServiceAutorisationAdmin.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/security/ServiceAutorisationAdmin.java:1)
+- [MatchPadelService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java:1)
+- [ParticipationService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java:1)
+- [MatchControllerTest.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java:1)
+- [MatchPadelServiceTest.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java:1)
+- [ParticipationServiceTest.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceTest.java:1)
+- [ParticipationServiceMontantAttenduTest.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceMontantAttenduTest.java:1)
+- [ParticipationServiceRejoindrePublicTest.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceRejoindrePublicTest.java:1)
+
+### Frontend
+
+- [match-detail.models.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-detail.models.ts:1)
+- [match-participation.service.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/core/matches/match-participation.service.ts:1)
+- [match-detail-page.component.ts](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts:1)
+- [match-detail-page.component.html](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/features/matches/match-detail/match-detail-page.component.html:1)
+- [match-detail-page.component.css](/C:/Users/fanoa/PDW-SGBD-padel-examen/frontend/src/app/features/matches/match-detail/match-detail-page.component.css:1)
+
+---
+
+## Verifications realisees
+
+Backend :
+
+- `.\mvnw.cmd "-Dtest=MatchControllerTest,MatchPadelServiceTest,ParticipationServiceTest" test` OK
+- `.\mvnw.cmd "-Dtest=ParticipationServiceTest,MatchPadelServiceTest,MatchControllerTest" test` OK
+- `.\mvnw.cmd -DskipTests package` OK
+
+Frontend :
+
+- `npm.cmd run build` OK
+
+Points verifies :
+
+- le detail match expose `peutAjouterJoueurPrive`
+- le formulaire apparait uniquement si ce champ vaut `true`
+- l'appel passe bien par l'endpoint prive existant
+- le detail est recharge apres succes
+- le flux existant `Rejoindre le match` public reste en place
+- `ADMIN_GLOBAL` est autorise
+- l'organisateur est autorise
+- `ADMIN_SITE` du bon site est autorise
+- `ADMIN_SITE` hors perimetre ne voit plus l'action via `peutAjouterJoueurPrive`
+- `ADMIN_SITE` hors perimetre ne peut plus reussir le POST prive
+
+---
+
+## Resultat
+
+Le detail match prive peut maintenant afficher proprement l'action `Ajouter le joueur` sans reconstituer les autorisations cote Angular.
+
+Le backend reste la source de verite :
+
+- pour savoir si l'action doit etre visible
+- pour accepter ou refuser l'ajout
+- pour renvoyer le message fonctionnel a afficher
+
+Le frontend continue simplement a lire :
+
+- `peutAjouterJoueurPrive`
+
+Il ne reconstitue ni :
+
+- l'identite de l'organisateur
+- ni le perimetre `ADMIN_SITE`

--- a/frontend/docs/ajouter-joueur-match-prive-verification-coherence-backend.md
+++ b/frontend/docs/ajouter-joueur-match-prive-verification-coherence-backend.md
@@ -1,0 +1,343 @@
+# Verification backend - coherence de `peutAjouterJoueurPrive`
+
+## Objet
+
+Verifier que le champ backend `peutAjouterJoueurPrive` expose dans le detail match est coherent avec l'autorisation reelle utilisee par l'endpoint :
+
+- `POST /api/v1/matchs/{matchId}/participants/prive`
+
+Le point sensible a controler est le suivant :
+
+- ne pas afficher l'action si le backend refusera de toute facon pour une raison d'autorisation deja previsible
+
+---
+
+## Ou est calcule `peutAjouterJoueurPrive`
+
+Le champ est calcule dans :
+
+- [MatchPadelService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java:349)
+
+La methode cible est :
+
+- `private boolean peutAjouterJoueurPrive(MatchPadel match)`
+
+Reference precise :
+
+- [MatchPadelService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java:366)
+
+---
+
+## Logique utilisee pour `peutAjouterJoueurPrive`
+
+Le boolen vaut `true` uniquement si :
+
+- le match est `PRIVE`
+- le match est `PLANIFIE`
+- le match n'est pas complet
+- l'utilisateur courant est :
+  - organisateur du match
+  - ou `admin` selon `currentUserFacade.isAdmin()`
+
+Le test admin utilise :
+
+- [CurrentUserFacade.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/security/CurrentUserFacade.java:69)
+
+Definition actuelle :
+
+- `ROLE_ADMIN_GLOBAL`
+- `ROLE_ADMIN_SITE`
+
+Donc `isAdmin()` retourne `true` pour les deux profils.
+
+---
+
+## Logique utilisee par le POST prive
+
+L'endpoint utilise le service :
+
+- [ParticipationService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java:93)
+
+Dans `ajouterJoueurParOrganisateur(...)`, la logique actuelle est :
+
+- refus si match public
+- refus si match non `PLANIFIE`
+- autorise si :
+  - `currentUserFacade.isAdmin()` vaut `true`
+  - ou le joueur courant est l'organisateur
+
+Puis le backend continue les autres controles :
+
+- joueur existe
+- joueur deja inscrit
+- place disponible
+
+---
+
+## Alignement entre detail et POST
+
+### 1. Organisateur
+
+Oui, c'est aligne.
+
+Le detail et le POST autorisent :
+
+- l'organisateur du match
+
+### 2. Admin global
+
+Oui, c'est aligne.
+
+Le detail et le POST autorisent :
+
+- `ROLE_ADMIN_GLOBAL`
+
+### 3. Statut du match
+
+Oui, c'est aligne.
+
+Le detail exige :
+
+- `PLANIFIE`
+
+Le POST exige aussi :
+
+- `PLANIFIE`
+
+### 4. Match complet
+
+Oui, c'est aligne pour l'affichage principal.
+
+Le detail masque l'action si le match est complet.
+Le POST refuse aussi ensuite si le match est complet.
+
+---
+
+## Divergence metier identifiee : `ADMIN_SITE`
+
+### Constat
+
+Il existe un point important a signaler.
+
+Aujourd'hui :
+
+- `peutAjouterJoueurPrive` donne `true` a tout utilisateur pour lequel `currentUserFacade.isAdmin()` vaut `true`
+- le POST prive accepte lui aussi tout utilisateur pour lequel `currentUserFacade.isAdmin()` vaut `true`
+
+Or `isAdmin()` couvre :
+
+- `ROLE_ADMIN_GLOBAL`
+- `ROLE_ADMIN_SITE`
+
+sans verifier le perimetre de site.
+
+### Consequence
+
+Un `ADMIN_SITE` hors perimetre peut actuellement :
+
+- voir l'action `Ajouter le joueur`
+- et executer le POST prive avec succes
+
+si aucune autre regle ne le bloque.
+
+### Verification du controle de perimetre
+
+Le projet possede bien un service de controle de perimetre :
+
+- [ServiceAutorisationAdmin.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/security/ServiceAutorisationAdmin.java:23)
+
+Ce service :
+
+- autorise `ADMIN_GLOBAL`
+- autorise `ADMIN_SITE` uniquement si son site autorise correspond au site demande
+
+Mais ce service n'est pas utilise dans :
+
+- `MatchPadelService.peutAjouterJoueurPrive(...)`
+- `ParticipationService.ajouterJoueurParOrganisateur(...)`
+
+### Conclusion sur `ADMIN_SITE`
+
+Le boolen et le POST sont coherents entre eux, mais pas avec l'exigence metier suivante :
+
+- ne pas donner `true` a un admin site hors perimetre
+
+En l'etat actuel :
+
+- un `ADMIN_SITE` hors site est trop largement autorise
+
+---
+
+## Statuts backend existants
+
+L'enum actuelle est :
+
+- [MatchStatut.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/model/enums/MatchStatut.java:1)
+
+Valeurs presentes :
+
+- `PLANIFIE`
+- `ANNULE`
+
+Conclusion :
+
+- le refus du POST prive si le match n'est pas `PLANIFIE` est coherent avec l'etat actuel du modele
+- aucun autre statut n'a ete trouve dans l'enum actuelle
+
+---
+
+## Conclusion finale
+
+### Ce qui est correct
+
+- organisateur : aligne
+- admin global : aligne
+- statut `PLANIFIE` : aligne
+- match complet : aligne
+
+### Ce qui n'est pas correct au regard du besoin precise
+
+- `ADMIN_SITE` n'est pas limite aujourd'hui au site du match
+
+### Formulation precise
+
+Il n'y a pas de divergence entre :
+
+- le calcul de `peutAjouterJoueurPrive`
+- et le POST prive
+
+Mais il existe une divergence entre :
+
+- le comportement actuel du backend
+- et l'attendu fonctionnel si l'on veut restreindre `ADMIN_SITE` a son perimetre de site
+
+### Impact
+
+Avant validation definitive de l'issue, il faut decider si :
+
+1. le comportement actuel est accepte tel quel
+2. ou une correction backend ciblee est necessaire pour brancher le controle de perimetre `ADMIN_SITE`
+
+Ce document est un constat de verification.
+Aucune modification supplementaire n'a ete appliquee.
+
+---
+
+## Decision de suite
+
+La verification a conduit a la decision suivante :
+
+- l'issue 12 ne peut pas etre validee definitivement avec un `ADMIN_SITE` autorise hors perimetre
+- la correction doit etre faite dans cette issue
+- le frontend ne doit pas contourner ce probleme
+- le backend doit rester la source de verite pour l'autorisation
+
+Objectif de la correction :
+
+- un `ADMIN_SITE` ne doit pouvoir ajouter un joueur a un match prive que si le match appartient a son site autorise
+- un `ADMIN_SITE` hors perimetre ne doit pas voir l'action via `peutAjouterJoueurPrive`
+- un `ADMIN_SITE` hors perimetre ne doit pas pouvoir executer le `POST /participants/prive` avec succes
+
+---
+
+## Fichiers et methodes impactes
+
+### Backend
+
+- [ParticipationService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/ParticipationService.java:93)
+  - methode `ajouterJoueurParOrganisateur(...)`
+- [MatchPadelService.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java:366)
+  - methode `peutAjouterJoueurPrive(...)`
+- [ServiceAutorisationAdmin.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/main/java/be/ephec/padel/backend/security/ServiceAutorisationAdmin.java:23)
+  - service existant a reutiliser pour le perimetre `ADMIN_SITE`
+
+### Tests
+
+- [ParticipationServiceTest.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/ParticipationServiceTest.java:1)
+- [MatchPadelServiceTest.java](/C:/Users/fanoa/PDW-SGBD-padel-examen/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java:1)
+
+---
+
+## Proposition de resolution
+
+### Regle cible
+
+L'action `Ajouter un joueur` doit etre autorisee si :
+
+- l'utilisateur courant est l'organisateur du match
+- ou l'utilisateur courant est `ADMIN_GLOBAL`
+- ou l'utilisateur courant est `ADMIN_SITE` et son perimetre correspond au site du match
+
+### Strategie proposee
+
+1. Corriger `ParticipationService.ajouterJoueurParOrganisateur(...)`
+
+- remplacer le simple test `currentUserFacade.isAdmin()`
+- distinguer explicitement :
+  - organisateur
+  - `ADMIN_GLOBAL`
+  - `ADMIN_SITE` du bon site
+- refuser un `ADMIN_SITE` hors perimetre
+
+2. Corriger `MatchPadelService.peutAjouterJoueurPrive(...)`
+
+- reutiliser exactement la meme logique d'autorisation
+- garder le meme filtre metier d'affichage :
+  - match `PRIVE`
+  - match `PLANIFIE`
+  - match non complet
+- si l'utilisateur n'est pas autorise, retourner simplement `false`
+- ne pas faire echouer le `GET /matchs/:id` juste parce qu'il ne peut pas ajouter un joueur
+
+3. Reutiliser `ServiceAutorisationAdmin`
+
+- ne pas dupliquer la logique de perimetre si le service existant peut etre reutilise proprement
+- si besoin, ajouter une methode ciblee de type boolenne pour tester le perimetre sans lever d'exception
+- conserver la methode actuelle qui leve une exception pour les cas ou elle reste utile ailleurs
+
+### Forme prudente de l'implementation
+
+La resolution la plus propre serait de centraliser une decision backend du type :
+
+- organisateur
+- ou admin autorise sur le site du match
+
+Puis :
+
+- l'utiliser dans `ParticipationService` pour autoriser ou refuser le POST
+- l'utiliser dans `MatchPadelService` pour calculer `peutAjouterJoueurPrive`
+
+Ainsi :
+
+- le detail et le POST restent strictement alignes
+- `ADMIN_GLOBAL` reste autorise
+- `ADMIN_SITE` est limite au bon perimetre
+- le frontend continue simplement a lire `peutAjouterJoueurPrive`
+
+---
+
+## Tests a couvrir apres correction
+
+Tests attendus :
+
+- `ADMIN_GLOBAL` peut ajouter
+- organisateur peut ajouter
+- `ADMIN_SITE` du bon site peut ajouter
+- `ADMIN_SITE` hors perimetre ne peut pas ajouter
+- `peutAjouterJoueurPrive = true` pour `ADMIN_SITE` du bon site
+- `peutAjouterJoueurPrive = false` pour `ADMIN_SITE` hors perimetre
+
+---
+
+## Portee de la correction
+
+Cette correction reste dans le scope de l'issue 12 car elle concerne directement :
+
+- l'autorisation reelle de l'action `Ajouter un joueur a un match prive`
+- la coherence entre le detail match et l'endpoint prive
+
+Elle ne demande pas :
+
+- de changement frontend de contournement
+- de refactor global
+- d'extension fonctionnelle hors issue

--- a/frontend/src/app/core/matches/match-detail.models.ts
+++ b/frontend/src/app/core/matches/match-detail.models.ts
@@ -18,6 +18,7 @@ export interface MatchDetail {
   nbParticipants: number;
   placesRestantes: number;
   complet: boolean;
+  peutAjouterJoueurPrive: boolean;
   montantTotal: number;
   montantPaye: number;
   resteAPayer: number;

--- a/frontend/src/app/core/matches/match-participation.models.ts
+++ b/frontend/src/app/core/matches/match-participation.models.ts
@@ -1,0 +1,9 @@
+export interface MatchParticipation {
+  id: number;
+  matchId: number;
+  joueurMatricule: string;
+}
+
+export interface AddPrivatePlayerToMatchRequest {
+  joueurMatriculeAAjouter: string;
+}

--- a/frontend/src/app/core/matches/match-participation.service.ts
+++ b/frontend/src/app/core/matches/match-participation.service.ts
@@ -1,0 +1,29 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { AddPrivatePlayerToMatchRequest, MatchParticipation } from './match-participation.models';
+
+@Injectable({ providedIn: 'root' })
+export class MatchParticipationService {
+  private readonly http = inject(HttpClient);
+
+  rejoindreMatchPublic(matchId: number): Observable<MatchParticipation> {
+    return this.http.post<MatchParticipation>(
+      `${environment.apiBaseUrl}/matchs/${matchId}/participants/public`,
+      {}
+    );
+  }
+
+  ajouterJoueurPrive(
+    matchId: number,
+    joueurMatriculeAAjouter: string
+  ): Observable<MatchParticipation> {
+    const body: AddPrivatePlayerToMatchRequest = { joueurMatriculeAAjouter };
+
+    return this.http.post<MatchParticipation>(
+      `${environment.apiBaseUrl}/matchs/${matchId}/participants/prive`,
+      body
+    );
+  }
+}

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.css
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.css
@@ -231,6 +231,68 @@ dd {
   cursor: wait;
 }
 
+.private-add-section {
+  margin-bottom: 1rem;
+}
+
+.private-add-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: end;
+  margin-bottom: 1rem;
+}
+
+.private-add-field {
+  display: grid;
+  gap: 0.4rem;
+  min-width: min(18rem, 100%);
+  flex: 1 1 16rem;
+  color: #10233f;
+  font-weight: 700;
+}
+
+.private-add-field span {
+  font-size: 0.92rem;
+}
+
+.private-add-field input {
+  width: 100%;
+  min-height: 2.9rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.85rem;
+  font: inherit;
+  color: #10233f;
+  background: #ffffff;
+}
+
+.private-add-field input:disabled {
+  background: #f8fafc;
+  cursor: wait;
+}
+
+.secondary-action-button {
+  min-height: 2.9rem;
+  border: none;
+  border-radius: 0.85rem;
+  background: #10233f;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 700;
+  padding: 0.8rem 1.2rem;
+  cursor: pointer;
+}
+
+.secondary-action-button:hover:not(:disabled) {
+  background: #1f3b63;
+}
+
+.secondary-action-button:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
 .participants-list {
   display: grid;
   gap: 0.75rem;

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.html
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.html
@@ -141,6 +141,53 @@
 
       <article class="detail-card">
         <h2>Participants</h2>
+
+        @if (canShowPrivateAddForm()) {
+          <div class="private-add-section">
+            @if (addPrivateSuccessMessage()) {
+              <div class="action-message is-success" role="status" aria-live="polite">
+                <p>{{ addPrivateSuccessMessage() }}</p>
+              </div>
+            }
+
+            @if (addPrivateErrorMessage()) {
+              <div class="action-message is-error" role="alert" aria-live="polite">
+                <p>{{ addPrivateErrorMessage() }}</p>
+
+                @if (addPrivateErrorDetails(); as details) {
+                  <ul class="action-details">
+                    @for (detailEntry of details | keyvalue; track detailEntry.key) {
+                      <li>{{ detailEntry.value }}</li>
+                    }
+                  </ul>
+                }
+              </div>
+            }
+
+            <div class="private-add-form">
+              <label class="private-add-field">
+                <span>Matricule du joueur</span>
+                <input
+                  type="text"
+                  [value]="privatePlayerMatricule()"
+                  (input)="updatePrivatePlayerMatricule($event)"
+                  [disabled]="isAddingPrivatePlayer()"
+                  placeholder="Ex. G0002"
+                />
+              </label>
+
+              <button
+                type="button"
+                class="secondary-action-button"
+                [disabled]="isAddingPrivatePlayer()"
+                (click)="addPrivatePlayer()"
+              >
+                {{ isAddingPrivatePlayer() ? 'Ajout en cours...' : 'Ajouter le joueur' }}
+              </button>
+            </div>
+          </div>
+        }
+
         @if (detail.participants.length === 0) {
           <p class="empty-participants">Aucun participant &agrave; afficher.</p>
         } @else {

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts
@@ -33,6 +33,11 @@ export class MatchDetailPageComponent implements OnInit {
   protected readonly joinSuccessMessage = signal('');
   protected readonly joinErrorMessage = signal('');
   protected readonly joinErrorDetails = signal<Record<string, string> | null>(null);
+  protected readonly privatePlayerMatricule = signal('');
+  protected readonly isAddingPrivatePlayer = signal(false);
+  protected readonly addPrivateSuccessMessage = signal('');
+  protected readonly addPrivateErrorMessage = signal('');
+  protected readonly addPrivateErrorDetails = signal<Record<string, string> | null>(null);
   protected readonly canShowJoinButton = computed(() => {
     const detail = this.match();
 
@@ -41,6 +46,7 @@ export class MatchDetailPageComponent implements OnInit {
       && detail.statut === 'PLANIFIE'
       && detail.complet === false;
   });
+  protected readonly canShowPrivateAddForm = computed(() => this.match()?.peutAjouterJoueurPrive === true);
 
   ngOnInit(): void {
     const idParam = this.route.snapshot.paramMap.get('id');
@@ -80,11 +86,50 @@ export class MatchDetailPageComponent implements OnInit {
       .pipe(finalize(() => this.isJoining.set(false)))
       .subscribe({
         next: () => {
-          this.joinSuccessMessage.set('Vous avez rejoint le match avec succès.');
+          this.joinSuccessMessage.set('Vous avez rejoint le match avec succ\u00e8s.');
           this.loadMatchDetail(detail.id);
         },
         error: (error: HttpErrorResponse) => {
           this.handleJoinError(error);
+        }
+      });
+  }
+
+  protected updatePrivatePlayerMatricule(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    this.privatePlayerMatricule.set(target?.value ?? '');
+  }
+
+  protected addPrivatePlayer(): void {
+    const detail = this.match();
+    const matricule = this.privatePlayerMatricule().trim();
+
+    if (!detail || !this.canShowPrivateAddForm() || this.isAddingPrivatePlayer()) {
+      return;
+    }
+
+    this.addPrivateSuccessMessage.set('');
+    this.addPrivateErrorMessage.set('');
+    this.addPrivateErrorDetails.set(null);
+
+    if (!matricule) {
+      this.addPrivateErrorMessage.set('Le matricule du joueur est obligatoire.');
+      return;
+    }
+
+    this.isAddingPrivatePlayer.set(true);
+
+    this.matchParticipationService
+      .ajouterJoueurPrive(detail.id, matricule)
+      .pipe(finalize(() => this.isAddingPrivatePlayer.set(false)))
+      .subscribe({
+        next: () => {
+          this.privatePlayerMatricule.set('');
+          this.addPrivateSuccessMessage.set('Le joueur a \u00e9t\u00e9 ajout\u00e9 avec succ\u00e8s.');
+          this.loadMatchDetail(detail.id);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.handleAddPrivatePlayerError(error);
         }
       });
   }
@@ -138,7 +183,7 @@ export class MatchDetailPageComponent implements OnInit {
     }
 
     if (error.status === 403) {
-      this.errorMessage.set(apiError.message ?? 'Accès refusé à ce match.');
+      this.errorMessage.set(apiError.message ?? 'Acc\u00e8s refus\u00e9 \u00e0 ce match.');
       return;
     }
 
@@ -147,7 +192,7 @@ export class MatchDetailPageComponent implements OnInit {
       return;
     }
 
-    this.errorMessage.set(apiError.message ?? 'Impossible de charger le détail du match.');
+    this.errorMessage.set(apiError.message ?? 'Impossible de charger le d\u00e9tail du match.');
   }
 
   private handleJoinError(error: HttpErrorResponse): void {
@@ -160,6 +205,18 @@ export class MatchDetailPageComponent implements OnInit {
 
     this.joinErrorMessage.set(apiError.message ?? 'Impossible de rejoindre le match.');
     this.joinErrorDetails.set(apiError.details ?? null);
+  }
+
+  private handleAddPrivatePlayerError(error: HttpErrorResponse): void {
+    const apiError = this.normalizeApiErrorBody(error.error);
+
+    if (error.status === 0) {
+      this.addPrivateErrorMessage.set('Backend inaccessible.');
+      return;
+    }
+
+    this.addPrivateErrorMessage.set(apiError.message ?? "Impossible d'ajouter le joueur.");
+    this.addPrivateErrorDetails.set(apiError.details ?? null);
   }
 
   private normalizeApiErrorBody(raw: unknown): ApiErrorBody {


### PR DESCRIPTION
- Ajout du champ `peutAjouterJoueurPrive` dans le détail match.
- Calcul backend de ce champ selon les règles d’autorisation.
- Affichage conditionnel du formulaire d’ajout côté frontend.
- Ajout d’un joueur à un match privé via l’endpoint existant :
  `POST /api/v1/matchs/{matchId}/participants/prive`
- Rechargement du détail du match après succès.
- Affichage d’un message de succès ou d’erreur.