### PR TITLE
feat(me): afficher les dettes et participations non soldées

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PlayerMatchSummaryDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/PlayerMatchSummaryDto.java
@@ -5,6 +5,7 @@ import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public record PlayerMatchSummaryDto(
@@ -19,6 +20,10 @@ public record PlayerMatchSummaryDto(
         PlayerMatchRoleDto roleJoueur,
         MatchTemporalStatusDto statutTemporel,
         Integer joursAvantMatch,
-        boolean paiementJoueurEffectue
+        boolean paiementJoueurEffectue,
+        Long participationId,
+        BigDecimal montantPayeJoueur,
+        BigDecimal montantRestantJoueur,
+        boolean peutPayerParticipation
 ) {
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeeder.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeeder.java
@@ -1,5 +1,6 @@
 package be.ephec.padel.backend.seed;
 
+import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.model.entities.HoraireSite;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
@@ -46,7 +47,7 @@ public class DevDataSeeder {
     private static final String EXPECTED_ADMIN_SITE_MAPPING = "admin.site.nord.dev:1";
     private static final String EXPECTED_ADMIN_SITE_LOGIN = "admin.site.nord.dev";
     private static final String PLAYER_PASSWORD = "joueur123";
-    private static final BigDecimal PART = new BigDecimal("7.50");
+    private static final BigDecimal PART = Tarifs.PART_PAR_JOUEUR;
 
     private final SiteRepository siteRepository;
     private final TerrainRepository terrainRepository;

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/JoueurService.java
@@ -1,5 +1,6 @@
 package be.ephec.padel.backend.service;
 
+import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
 import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
 import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
@@ -8,6 +9,7 @@ import be.ephec.padel.backend.exception.BusinessException;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Paiement;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.entities.Site;
 import be.ephec.padel.backend.model.enums.MatchStatut;
@@ -23,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -32,6 +35,7 @@ import java.util.List;
 public class JoueurService {
 
     private static final int CAPACITE_MATCH = 4;
+    private static final BigDecimal PART_JOUEUR = Tarifs.PART_PAR_JOUEUR;
 
     private final JoueurRepository joueurRepository;
     private final SiteRepository siteRepository;
@@ -152,6 +156,11 @@ public class JoueurService {
         }
 
         boolean paiementJoueurEffectue = !participation.getPaiements().isEmpty();
+        BigDecimal montantPayeJoueur = getMontantPayeParticipation(participation);
+        BigDecimal montantRestantJoueur = getMontantRestantParticipation(montantPayeJoueur);
+        boolean peutPayerParticipation =
+                match.getStatut() != MatchStatut.ANNULE
+                        && montantRestantJoueur.signum() > 0;
 
         return new PlayerMatchSummaryDto(
                 match.getId(),
@@ -165,8 +174,33 @@ public class JoueurService {
                 roleJoueur,
                 statutTemporel,
                 joursAvantMatch,
-                paiementJoueurEffectue
+                paiementJoueurEffectue,
+                participation.getId(),
+                montantPayeJoueur,
+                montantRestantJoueur,
+                peutPayerParticipation
         );
+    }
+
+    private BigDecimal getMontantPayeParticipation(Participation participation) {
+        if (participation.getPaiements() == null || participation.getPaiements().isEmpty()) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        return participation.getPaiements().stream()
+                .map(Paiement::getMontant)
+                .filter(java.util.Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal getMontantRestantParticipation(BigDecimal montantPayeJoueur) {
+        BigDecimal montantPaye = montantPayeJoueur == null
+                ? BigDecimal.ZERO
+                : montantPayeJoueur.setScale(2, RoundingMode.HALF_UP);
+
+        BigDecimal restant = PART_JOUEUR.subtract(montantPaye).setScale(2, RoundingMode.HALF_UP);
+        return restant.signum() < 0 ? BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP) : restant;
     }
 
     public List<PlayerMatchSummaryDto> getPlayerMatches(String matricule) {

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/JoueurServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/JoueurServiceTest.java
@@ -67,6 +67,7 @@ class JoueurServiceTest {
 
         when(participation.getMatch()).thenReturn(match);
         when(participation.getJoueur()).thenReturn(joueur);
+        when(participation.getId()).thenReturn(terrainId + 1000L);
 
         when(match.getId()).thenReturn(999L);
         when(match.getDateDebut()).thenReturn(LocalDateTime.of(dateMatch, LocalTime.of(10, 0)));
@@ -86,10 +87,50 @@ class JoueurServiceTest {
         when(site.getNom()).thenReturn(siteNom);
 
         if (paiementEffectue) {
-            when(participation.getPaiements()).thenReturn(List.of(mock(Paiement.class)));
+            Paiement paiement = mock(Paiement.class);
+            when(paiement.getMontant()).thenReturn(new BigDecimal("7.50"));
+            when(participation.getPaiements()).thenReturn(List.of(paiement));
         } else {
             when(participation.getPaiements()).thenReturn(List.of());
         }
+
+        return participation;
+    }
+
+    private Participation mockParticipationAvecMontants(String organisateurMatricule,
+                                                        String joueurMatricule,
+                                                        LocalDate dateMatch,
+                                                        MatchVisibilite visibilite,
+                                                        MatchStatut statut,
+                                                        Long terrainId,
+                                                        String terrainNom,
+                                                        Long siteId,
+                                                        String siteNom,
+                                                        Long participationId,
+                                                        BigDecimal... montantsPaiements) {
+        Participation participation = mockParticipation(
+                organisateurMatricule,
+                joueurMatricule,
+                dateMatch,
+                visibilite,
+                false,
+                terrainId,
+                terrainNom,
+                siteId,
+                siteNom
+        );
+
+        when(participation.getId()).thenReturn(participationId);
+        when(participation.getMatch().getStatut()).thenReturn(statut);
+
+        List<Paiement> paiements = java.util.Arrays.stream(montantsPaiements)
+                .map(montant -> {
+                    Paiement paiement = mock(Paiement.class);
+                    when(paiement.getMontant()).thenReturn(montant);
+                    return paiement;
+                })
+                .toList();
+        when(participation.getPaiements()).thenReturn(paiements);
 
         return participation;
     }
@@ -397,6 +438,10 @@ class JoueurServiceTest {
         assertEquals("Terrain 1", dto.terrainNom());
         assertEquals(1L, dto.siteId());
         assertEquals("Site Delta", dto.siteNom());
+        assertEquals(1010L, dto.participationId());
+        assertEquals(new BigDecimal("0.00"), dto.montantPayeJoueur());
+        assertEquals(new BigDecimal("15.00"), dto.montantRestantJoueur());
+        assertTrue(dto.peutPayerParticipation());
     }
 
     @Test
@@ -569,6 +614,122 @@ class JoueurServiceTest {
         assertEquals("Terrain B", result.get(1).terrainNom());
         assertEquals(PlayerMatchRoleDto.ORGANISATEUR, result.get(1).roleJoueur());
         assertTrue(result.get(1).paiementJoueurEffectue());
+    }
+
+    @Test
+    void getPlayerMatches_participationImpayee_montantRestantComplet_et_peutPayerTrue() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        Participation participation = mockParticipationAvecMontants(
+                "G9999",
+                "G0001",
+                LocalDate.now().plusDays(2),
+                MatchVisibilite.PRIVE,
+                MatchStatut.PLANIFIE,
+                60L,
+                "Terrain Impaye",
+                600L,
+                "Site Impaye",
+                5001L
+        );
+
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of(participation));
+
+        PlayerMatchSummaryDto dto = service.getPlayerMatches("G0001").get(0);
+
+        assertEquals(5001L, dto.participationId());
+        assertEquals(new BigDecimal("0.00"), dto.montantPayeJoueur());
+        assertEquals(new BigDecimal("15.00"), dto.montantRestantJoueur());
+        assertTrue(dto.peutPayerParticipation());
+    }
+
+    @Test
+    void getPlayerMatches_participationPartiellementPayee_montantRestantPositif_et_peutPayerTrue() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        Participation participation = mockParticipationAvecMontants(
+                "G9999",
+                "G0001",
+                LocalDate.now().plusDays(2),
+                MatchVisibilite.PRIVE,
+                MatchStatut.PLANIFIE,
+                61L,
+                "Terrain Partiel",
+                610L,
+                "Site Partiel",
+                5002L,
+                new BigDecimal("2.50")
+        );
+
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of(participation));
+
+        PlayerMatchSummaryDto dto = service.getPlayerMatches("G0001").get(0);
+
+        assertEquals(new BigDecimal("2.50"), dto.montantPayeJoueur());
+        assertEquals(new BigDecimal("12.50"), dto.montantRestantJoueur());
+        assertTrue(dto.peutPayerParticipation());
+    }
+
+    @Test
+    void getPlayerMatches_participationTotalementPayee_montantRestantZero_et_peutPayerFalse() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        Participation participation = mockParticipationAvecMontants(
+                "G9999",
+                "G0001",
+                LocalDate.now().plusDays(2),
+                MatchVisibilite.PUBLIC,
+                MatchStatut.PLANIFIE,
+                62L,
+                "Terrain Paye",
+                620L,
+                "Site Paye",
+                5003L,
+                new BigDecimal("15.00")
+        );
+
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of(participation));
+
+        PlayerMatchSummaryDto dto = service.getPlayerMatches("G0001").get(0);
+
+        assertEquals(new BigDecimal("15.00"), dto.montantPayeJoueur());
+        assertEquals(new BigDecimal("0.00"), dto.montantRestantJoueur());
+        assertFalse(dto.peutPayerParticipation());
+    }
+
+    @Test
+    void getPlayerMatches_matchAnnule_peutPayerFalse() {
+        Joueur joueur = mock(Joueur.class);
+        when(joueurRepo.findById("G0001")).thenReturn(Optional.of(joueur));
+
+        Participation participation = mockParticipationAvecMontants(
+                "G9999",
+                "G0001",
+                LocalDate.now().plusDays(2),
+                MatchVisibilite.PUBLIC,
+                MatchStatut.ANNULE,
+                63L,
+                "Terrain Annule",
+                630L,
+                "Site Annule",
+                5004L,
+                new BigDecimal("1.50")
+        );
+
+        when(participationRepo.findByJoueur_MatriculeOrderByMatch_DateDebutAsc("G0001"))
+                .thenReturn(List.of(participation));
+
+        PlayerMatchSummaryDto dto = service.getPlayerMatches("G0001").get(0);
+
+        assertEquals(new BigDecimal("1.50"), dto.montantPayeJoueur());
+        assertEquals(new BigDecimal("13.50"), dto.montantRestantJoueur());
+        assertFalse(dto.peutPayerParticipation());
     }
     // ----------------
 // getOrganizedMatches

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MeControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MeControllerTest.java
@@ -25,8 +25,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDateTime;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -93,7 +93,11 @@ class MeControllerTest {
                 PlayerMatchRoleDto.PARTICIPANT,
                 MatchTemporalStatusDto.FUTUR,
                 5,
-                false
+                false,
+                77L,
+                new BigDecimal("0.00"),
+                new BigDecimal("7.50"),
+                true
         );
 
         when(joueurService.getCurrentPlayerMatches()).thenReturn(List.of(dto));
@@ -112,7 +116,11 @@ class MeControllerTest {
                 .andExpect(jsonPath("$[0].roleJoueur").value("PARTICIPANT"))
                 .andExpect(jsonPath("$[0].statutTemporel").value("FUTUR"))
                 .andExpect(jsonPath("$[0].joursAvantMatch").value(5))
-                .andExpect(jsonPath("$[0].paiementJoueurEffectue").value(false));
+                .andExpect(jsonPath("$[0].paiementJoueurEffectue").value(false))
+                .andExpect(jsonPath("$[0].participationId").value(77))
+                .andExpect(jsonPath("$[0].montantPayeJoueur").value(0.00))
+                .andExpect(jsonPath("$[0].montantRestantJoueur").value(7.50))
+                .andExpect(jsonPath("$[0].peutPayerParticipation").value(true));
     }
 
     @Test

--- a/frontend/src/app/core/matches/player-match-summary.models.ts
+++ b/frontend/src/app/core/matches/player-match-summary.models.ts
@@ -15,4 +15,8 @@ export interface PlayerMatchSummary {
   statutTemporel: MatchTemporalStatus;
   joursAvantMatch: number | null;
   paiementJoueurEffectue: boolean;
+  participationId: number;
+  montantPayeJoueur: number;
+  montantRestantJoueur: number;
+  peutPayerParticipation: boolean;
 }

--- a/frontend/src/app/core/payments/paiement.models.ts
+++ b/frontend/src/app/core/payments/paiement.models.ts
@@ -1,0 +1,10 @@
+export interface PayParticipationRequest {
+  montant: number;
+}
+
+export interface Paiement {
+  id: number;
+  participationId: number;
+  montant: number;
+  datePaiement: string;
+}

--- a/frontend/src/app/core/payments/paiement.service.ts
+++ b/frontend/src/app/core/payments/paiement.service.ts
@@ -1,0 +1,19 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { Paiement, PayParticipationRequest } from './paiement.models';
+
+@Injectable({ providedIn: 'root' })
+export class PaiementService {
+  private readonly http = inject(HttpClient);
+
+  payerParticipation(participationId: number, montant: number): Observable<Paiement> {
+    const body: PayParticipationRequest = { montant };
+
+    return this.http.post<Paiement>(
+      `${environment.apiBaseUrl}/participations/${participationId}/paiements`,
+      body
+    );
+  }
+}

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.css
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.css
@@ -109,6 +109,101 @@
   color: #92400e;
 }
 
+.section-note {
+  margin: 0 0 1rem;
+  color: #526277;
+}
+
+.empty-regularizations {
+  margin: 0;
+  color: #526277;
+}
+
+.regularization-list {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.regularization-card {
+  padding: 1rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.75rem;
+  background: #f8fbff;
+}
+
+.regularization-site {
+  margin: 0 0 0.25rem;
+  color: #0f766e;
+  font-weight: 700;
+}
+
+.regularization-summary {
+  min-width: 0;
+  margin-bottom: 0.85rem;
+}
+
+.regularization-summary h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #10233f;
+}
+
+.regularization-datetime {
+  margin: 0.35rem 0 0;
+  color: #526277;
+}
+
+.regularization-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.meta-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.meta-badge.is-secondary {
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.regularization-amounts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.75rem 1rem;
+}
+
+.amount-item {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0;
+  color: #526277;
+}
+
+.amount-item span {
+  font-size: 0.9rem;
+}
+
+.amount-item strong {
+  color: #10233f;
+  font-size: 1rem;
+}
+
+.amount-item.is-remaining strong {
+  color: #92400e;
+}
+
 .shortcuts {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.html
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.html
@@ -47,6 +47,48 @@
         </p>
       </section>
 
+      <section class="info-section">
+        <h2>Participations non totalement pay&eacute;es</h2>
+        <p class="section-note">
+          Ces montants indiquent les participations qui ne sont pas totalement pay&eacute;es. Ils ne constituent
+          pas forc&eacute;ment le d&eacute;tail exact du solde global.
+        </p>
+
+        @if (unpaidMatches().length === 0) {
+          <p class="empty-regularizations">Aucune participation non totalement pay&eacute;e.</p>
+        } @else {
+          <div class="regularization-list">
+            @for (match of unpaidMatches(); track match.participationId) {
+              <article class="regularization-card">
+                <div class="regularization-summary">
+                  <p class="regularization-site">{{ match.siteNom }}</p>
+                  <h3>{{ match.terrainNom }}</h3>
+                  <p class="regularization-datetime">
+                    {{ match.dateDebut | date:'dd/MM/yyyy' }} &agrave; {{ match.dateDebut | date:'HH:mm' }}
+                  </p>
+
+                  <div class="regularization-badges">
+                    <span class="meta-badge">{{ match.visibilite }}</span>
+                    <span class="meta-badge is-secondary">{{ match.roleJoueur }}</span>
+                  </div>
+                </div>
+
+                <div class="regularization-amounts">
+                  <p class="amount-item">
+                    <span>D&eacute;j&agrave; pay&eacute;</span>
+                    <strong>{{ formatAmount(match.montantPayeJoueur) }}</strong>
+                  </p>
+                  <p class="amount-item is-remaining">
+                    <span>Reste th&eacute;orique</span>
+                    <strong>{{ formatAmount(match.montantRestantJoueur) }}</strong>
+                  </p>
+                </div>
+              </article>
+            }
+          </div>
+        }
+      </section>
+
       <section class="info-section shortcuts-section">
         <h2>Acc&egrave;s rapides</h2>
 

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.ts
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.ts
@@ -2,7 +2,9 @@ import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { finalize } from 'rxjs';
+import { finalize, forkJoin } from 'rxjs';
+import { PlayerMatchSummary } from '../../../core/matches/player-match-summary.models';
+import { PlayerMatchesService } from '../../../core/matches/player-matches.service';
 import { MeProfile } from '../../../core/me/me.models';
 import { MeService } from '../../../core/me/me.service';
 
@@ -15,8 +17,10 @@ import { MeService } from '../../../core/me/me.service';
 })
 export class EspacePrivePageComponent implements OnInit {
   private readonly meService = inject(MeService);
+  private readonly playerMatchesService = inject(PlayerMatchesService);
 
   protected readonly profile = signal<MeProfile | null>(null);
+  protected readonly matches = signal<PlayerMatchSummary[]>([]);
   protected readonly isLoading = signal(true);
   protected readonly errorMessage = signal('');
 
@@ -24,6 +28,9 @@ export class EspacePrivePageComponent implements OnInit {
     const profile = this.profile();
     return profile != null && profile.solde > 0;
   });
+  protected readonly unpaidMatches = computed(() =>
+    this.matches().filter((match) => match.montantRestantJoueur > 0)
+  );
 
   protected readonly debtMessage = computed(() => {
     const profile = this.profile();
@@ -39,7 +46,7 @@ export class EspacePrivePageComponent implements OnInit {
   });
 
   ngOnInit(): void {
-    this.loadProfile();
+    this.loadPageData();
   }
 
   protected getTypeLabel(type: MeProfile['type']): string {
@@ -61,16 +68,19 @@ export class EspacePrivePageComponent implements OnInit {
     }).format(amount) + ' \u20ac';
   }
 
-  private loadProfile(): void {
+  private loadPageData(): void {
     this.isLoading.set(true);
     this.errorMessage.set('');
 
-    this.meService
-      .getMe()
+    forkJoin({
+      profile: this.meService.getMe(),
+      matches: this.playerMatchesService.getMyMatches()
+    })
       .pipe(finalize(() => this.isLoading.set(false)))
       .subscribe({
-        next: (profile) => {
+        next: ({ profile, matches }) => {
           this.profile.set(profile);
+          this.matches.set(matches);
         },
         error: (error: HttpErrorResponse) => {
           if (error.status === 0) {


### PR DESCRIPTION
Issue 14 clôturée avec recadrage.

L’objectif initial était de permettre une régularisation depuis `/espace-prive`. Pendant les tests, j'ai identifié une limite métier importante du modèle actuel :

- `Joueur.solde` représente une dette globale ;
- les restes par participation sont calculés séparément à partir des paiements liés à chaque participation ;
- ces deux notions peuvent diverger, car les mouvements de solde ne sont pas encore reliés à une origine métier précise.

Conséquence observée :
la page pouvait afficher un solde global différent de la somme des restes par participation. Le backend pouvait donc refuser un paiement proposé par l’interface.

Décision retenue :
- conserver l’affichage du profil, du solde global et du message de dette ;
- afficher les participations non totalement payées à titre informatif ;
- retirer le bouton `Payer` depuis `/espace-prive` ;
- ne pas proposer une régularisation qui n’est pas encore garantie par le modèle backend.

État final :
- `/espace-prive` affiche le profil joueur ;
- le solde global est affiché ;
- les participations non totalement payées sont affichées comme information ;
- aucun paiement n’est déclenché depuis cette page ;
- `npm run build` OK.

Suite prévue :
ouvrir une future issue backend dédiée à la traçabilité des dettes et régularisations, afin de relier les mouvements de solde à une origine métier et de permettre plus tard un paiement fiable depuis l’espace joueur.