### PR TITLE
feat(solde): compléter la traçabilité des mouvements métier

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AnnulationMatchService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AnnulationMatchService.java
@@ -5,6 +5,7 @@ import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
@@ -99,7 +100,16 @@ public class AnnulationMatchService {
         BigDecimal montantACrediter = detteAAnnuler.min(detteActuelle).setScale(2, RoundingMode.HALF_UP);
 
         if (montantACrediter.signum() > 0) {
-            soldeService.crediter(joueur.getMatricule(), montantACrediter);
+            soldeService.crediter(
+                    joueur.getMatricule(),
+                    montantACrediter,
+                    new SoldeOriginContext(
+                            OrigineMouvementSoldeType.ANNULATION_MATCH_NEUTRALISATION,
+                            participation.getId(),
+                            participation.getMatch() != null ? participation.getMatch().getId() : null,
+                            null
+                    )
+            );
         }
 
         if (montantRembourse.signum() > 0) {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/TraitementDebutMatchService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/TraitementDebutMatchService.java
@@ -4,6 +4,7 @@ import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
 import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
@@ -88,7 +89,16 @@ public class TraitementDebutMatchService {
 
         if (solde.signum() > 0) {
             String matOrga = match.getOrganisateur().getMatricule();
-            soldeService.debiter(matOrga, solde);
+            soldeService.debiter(
+                    matOrga,
+                    solde,
+                    new SoldeOriginContext(
+                            OrigineMouvementSoldeType.TRANSFERT_ORGANISATEUR_DEBUT_MATCH,
+                            null,
+                            match.getId(),
+                            null
+                    )
+            );
         }
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/TraitementJ1Service.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/TraitementJ1Service.java
@@ -6,6 +6,7 @@ import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
@@ -83,7 +84,16 @@ public class TraitementJ1Service {
                 // Annule la dette restante de CE match pour ce joueur (on avait débité 15 à l'inscription)
                 BigDecimal resteDu = PART_JOUEUR.subtract(paye).setScale(2, RoundingMode.HALF_UP);
                 if (resteDu.signum() > 0) {
-                    soldeService.crediter(part.getJoueur().getMatricule(), resteDu);
+                    soldeService.crediter(
+                            part.getJoueur().getMatricule(),
+                            resteDu,
+                            new SoldeOriginContext(
+                                    OrigineMouvementSoldeType.TRAITEMENT_J1_NEUTRALISATION,
+                                    part.getId(),
+                                    match.getId(),
+                                    null
+                            )
+                    );
                 }
 
                 // Supprime la participation (place redevient réservable)

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AnnulationMatchServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AnnulationMatchServiceTest.java
@@ -6,11 +6,13 @@ import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.entities.Site;
 import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.service.SoldeOriginContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -28,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -109,7 +112,15 @@ class AnnulationMatchServiceTest {
 
         assertTrue(result);
         assertTrue(match.getStatut() == MatchStatut.ANNULE);
-        verify(soldeService).crediter("J001", new BigDecimal("5.00"));
+        verify(soldeService).crediter(
+                org.mockito.ArgumentMatchers.eq("J001"),
+                org.mockito.ArgumentMatchers.eq(new BigDecimal("5.00")),
+                argThat((SoldeOriginContext context) ->
+                        context.getOrigineType() == OrigineMouvementSoldeType.ANNULATION_MATCH_NEUTRALISATION
+                                && Long.valueOf(11L).equals(context.getParticipationId())
+                                && Long.valueOf(1L).equals(context.getMatchId())
+                )
+        );
         verify(paiementService).enregistrerRemboursementAnnulation(participation, new BigDecimal("10.00"));
         verify(matchPadelRepository).save(match);
     }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/TraitementDebutMatchServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/TraitementDebutMatchServiceTest.java
@@ -5,10 +5,12 @@ import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
 import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
+import be.ephec.padel.backend.service.SoldeOriginContext;
 import be.ephec.padel.backend.service.SoldeService;
 import be.ephec.padel.backend.service.TraitementDebutMatchService;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +29,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -81,7 +84,15 @@ class TraitementDebutMatchServiceTest {
         int treated = service.traiterDebutMatchFenetreMinutes(5);
 
         assertThat(treated).isEqualTo(1);
-        verify(soldeService).debiter(eq("O1"), eq(new BigDecimal("30.00")));
+        verify(soldeService).debiter(
+                eq("O1"),
+                eq(new BigDecimal("30.00")),
+                argThat((SoldeOriginContext context) ->
+                        context.getOrigineType() == OrigineMouvementSoldeType.TRANSFERT_ORGANISATEUR_DEBUT_MATCH
+                                && context.getParticipationId() == null
+                                && Long.valueOf(55L).equals(context.getMatchId())
+                )
+        );
         assertThat(match.getSoldeTraiteLe()).isEqualTo(now);
     }
 
@@ -135,7 +146,15 @@ class TraitementDebutMatchServiceTest {
         int treated = service.traiterDebutMatchFenetreMinutes(5);
 
         assertThat(treated).isEqualTo(1);
-        verify(soldeService).debiter(eq("O1"), eq(new BigDecimal("35.00")));
+        verify(soldeService).debiter(
+                eq("O1"),
+                eq(new BigDecimal("35.00")),
+                argThat((SoldeOriginContext context) ->
+                        context.getOrigineType() == OrigineMouvementSoldeType.TRANSFERT_ORGANISATEUR_DEBUT_MATCH
+                                && context.getParticipationId() == null
+                                && Long.valueOf(57L).equals(context.getMatchId())
+                )
+        );
     }
 
     private static void setId(Object entity, Long id) {

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/TraitementJ1ServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/TraitementJ1ServiceTest.java
@@ -4,12 +4,14 @@ import be.ephec.padel.backend.common.Tarifs;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.service.SoldeOriginContext;
 import be.ephec.padel.backend.service.SoldeService;
 import be.ephec.padel.backend.service.TraitementJ1Service;
 import org.junit.jupiter.api.BeforeEach;
@@ -154,7 +156,15 @@ class TraitementJ1ServiceTest {
         assertThat(match.getParticipations().get(0).getJoueur().getMatricule()).isEqualTo("O1");
 
         // dette restante annulée = 15 - 0 = 15
-        verify(soldeService).crediter(eq("JX"), eq(new BigDecimal("15.00")));
+        verify(soldeService).crediter(
+                eq("JX"),
+                eq(new BigDecimal("15.00")),
+                argThat((SoldeOriginContext context) ->
+                        context.getOrigineType() == OrigineMouvementSoldeType.TRAITEMENT_J1_NEUTRALISATION
+                                && Long.valueOf(201L).equals(context.getParticipationId())
+                                && Long.valueOf(20L).equals(context.getMatchId())
+                )
+        );
 
         // pas de paiement solde orga à J-1 dans ce scénario non plus
         verify(soldeService, never()).debiter(eq("O1"), any());


### PR DESCRIPTION
- traçabilité du crédit de neutralisation J-1 avec TRAITEMENT_J1_NEUTRALISATION ;
- traçabilité du transfert du manque à l’organisateur au début du match avec  TRANSFERT_ORGANISATEUR_DEBUT_MATCH ;
- traçabilité de la neutralisation de dette lors d’une annulation avec ANNULATION_MATCH_NEUTRALISATION.

Fichiers principaux modifiés :
- TraitementJ1Service.java
- TraitementDebutMatchService.java
- AnnulationMatchService.java