### PR TITLE
feat(solde): imputer les dettes par participation

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MouvementSoldeRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MouvementSoldeRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 
 public interface MouvementSoldeRepository extends JpaRepository<MouvementSolde, Long> {
     List<MouvementSolde> findByJoueur_MatriculeOrderByDateMouvementDesc(String matricule);
+    List<MouvementSolde> findByJoueur_MatriculeOrderByDateMouvementAscIdAsc(String matricule);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeeder.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeeder.java
@@ -48,6 +48,7 @@ public class DevDataSeeder {
     private static final String EXPECTED_ADMIN_SITE_LOGIN = "admin.site.nord.dev";
     private static final String PLAYER_PASSWORD = "joueur123";
     private static final BigDecimal PART = Tarifs.PART_PAR_JOUEUR;
+    private static final BigDecimal ZERO = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
 
     private final SiteRepository siteRepository;
     private final TerrainRepository terrainRepository;
@@ -123,10 +124,10 @@ public class DevDataSeeder {
         Terrain sudT1 = ensureTerrain(siteSud, "Sud T1");
         Terrain sudT2 = ensureTerrain(siteSud, "Sud T2");
 
-        Joueur joueurGlobal = ensureJoueur("G9001", "Joueur Global Demo", TypeJoueur.GLOBAL, null, "0.00");
-        Joueur joueurSiteNord = ensureJoueur("S9001", "Joueur Site Nord Demo", TypeJoueur.SITE, siteNord, "0.00");
-        Joueur joueurLibre = ensureJoueur("L9001", "Joueur Libre Demo", TypeJoueur.LIBRE, null, "15.00");
-        Joueur joueurSiteSud = ensureJoueur("S9002", "Joueur Site Sud Demo", TypeJoueur.SITE, siteSud, "0.00");
+        Joueur joueurGlobal = ensureJoueur("G9001", "Joueur Global Demo", TypeJoueur.GLOBAL, null, ZERO);
+        Joueur joueurSiteNord = ensureJoueur("S9001", "Joueur Site Nord Demo", TypeJoueur.SITE, siteNord, ZERO);
+        Joueur joueurLibre = ensureJoueur("L9001", "Joueur Libre Demo", TypeJoueur.LIBRE, null, PART.multiply(BigDecimal.valueOf(2)).setScale(2, RoundingMode.HALF_UP));
+        Joueur joueurSiteSud = ensureJoueur("S9002", "Joueur Site Sud Demo", TypeJoueur.SITE, siteSud, ZERO);
 
         ensurePlayerUser("joueur.global.dev", joueurGlobal);
         ensurePlayerUser("joueur.site.dev", joueurSiteNord);
@@ -292,7 +293,7 @@ public class DevDataSeeder {
                                 String nom,
                                 TypeJoueur type,
                                 Site site,
-                                String solde) {
+                                BigDecimal solde) {
         Joueur joueur = joueurRepository.findById(matricule)
                 .orElseGet(() -> site == null
                         ? new Joueur(matricule, nom, type)
@@ -301,7 +302,7 @@ public class DevDataSeeder {
         joueur.setNom(nom);
         joueur.setType(type);
         joueur.setSite(site);
-        joueur.setSolde(amount(solde));
+        joueur.setSolde(solde == null ? ZERO : solde.setScale(2, RoundingMode.HALF_UP));
 
         return joueurRepository.save(joueur);
     }
@@ -365,9 +366,5 @@ public class DevDataSeeder {
                 TypePaiement.REMBOURSEMENT,
                 match.getDateDebut().minusDays(1)
         ));
-    }
-
-    private BigDecimal amount(String value) {
-        return new BigDecimal(value).setScale(2, RoundingMode.HALF_UP);
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/SoldeImputationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/SoldeImputationService.java
@@ -1,0 +1,145 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.model.entities.MouvementSolde;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
+import be.ephec.padel.backend.model.enums.TypeMouvement;
+import be.ephec.padel.backend.repository.MouvementSoldeRepository;
+import be.ephec.padel.backend.service.model.ImputationResult;
+import be.ephec.padel.backend.service.model.OpenDebtLine;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+public class SoldeImputationService {
+
+    private static final EnumSet<OrigineMouvementSoldeType> TRACKED_DEBIT_ORIGINS = EnumSet.of(
+            OrigineMouvementSoldeType.CREATION_MATCH_ORGANISATEUR,
+            OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE,
+            OrigineMouvementSoldeType.REJOINDRE_MATCH_PUBLIC_PART
+    );
+
+    private static final EnumSet<OrigineMouvementSoldeType> TRACKED_CREDIT_ORIGINS = EnumSet.of(
+            OrigineMouvementSoldeType.PAIEMENT_PARTICIPATION,
+            OrigineMouvementSoldeType.TRAITEMENT_J1_NEUTRALISATION,
+            OrigineMouvementSoldeType.ANNULATION_MATCH_NEUTRALISATION
+    );
+
+    private final MouvementSoldeRepository mouvementSoldeRepository;
+
+    public SoldeImputationService(MouvementSoldeRepository mouvementSoldeRepository) {
+        this.mouvementSoldeRepository = mouvementSoldeRepository;
+    }
+
+    public ImputationResult reconstruirePourJoueur(String matricule) {
+        List<MouvementSolde> mouvements =
+                mouvementSoldeRepository.findByJoueur_MatriculeOrderByDateMouvementAscIdAsc(matricule);
+        return reconstruirePourMouvements(mouvements);
+    }
+
+    ImputationResult reconstruirePourMouvements(List<MouvementSolde> mouvements) {
+        Map<Long, List<OpenDebtLine>> dettesParParticipation = construireDettesParParticipation(mouvements);
+        List<OpenDebtLine> openDebtLines = new ArrayList<>();
+
+        for (List<OpenDebtLine> lines : dettesParParticipation.values()) {
+            for (OpenDebtLine line : lines) {
+                if (line.isOpen()) {
+                    openDebtLines.add(line);
+                }
+            }
+        }
+
+        return new ImputationResult(openDebtLines, calculerTotalOuvert(dettesParParticipation.values()));
+    }
+
+    private Map<Long, List<OpenDebtLine>> construireDettesParParticipation(List<MouvementSolde> mouvements) {
+        Map<Long, List<OpenDebtLine>> dettesParParticipation = new LinkedHashMap<>();
+
+        for (MouvementSolde mouvement : mouvements) {
+            if (estDebitCibleParticipation(mouvement)) {
+                dettesParParticipation
+                        .computeIfAbsent(mouvement.getParticipationId(), ignored -> new ArrayList<>())
+                        .add(toOpenDebtLine(mouvement));
+                continue;
+            }
+
+            if (estCreditCibleParticipation(mouvement)) {
+                appliquerCreditCible(mouvement, dettesParParticipation);
+            }
+        }
+
+        return dettesParParticipation;
+    }
+
+    private void appliquerCreditCible(MouvementSolde credit, Map<Long, List<OpenDebtLine>> dettesParParticipation) {
+        List<OpenDebtLine> lines = dettesParParticipation.get(credit.getParticipationId());
+        if (lines == null || lines.isEmpty()) {
+            return;
+        }
+
+        BigDecimal restant = scale(credit.getMontant());
+        for (OpenDebtLine line : lines) {
+            if (!line.isOpen() || restant.signum() <= 0) {
+                continue;
+            }
+
+            BigDecimal imputation = restant.min(line.getMontantRestant());
+            line.imputer(imputation);
+            restant = restant.subtract(imputation).setScale(2, RoundingMode.HALF_UP);
+        }
+    }
+
+    private boolean estDebitCibleParticipation(MouvementSolde mouvement) {
+        return mouvement != null
+                && mouvement.getType() == TypeMouvement.DEBIT
+                && mouvement.getParticipationId() != null
+                && mouvement.getOrigineType() != null
+                && mouvement.getOrigineType() != OrigineMouvementSoldeType.LEGACY
+                && TRACKED_DEBIT_ORIGINS.contains(mouvement.getOrigineType());
+    }
+
+    private boolean estCreditCibleParticipation(MouvementSolde mouvement) {
+        return mouvement != null
+                && mouvement.getType() == TypeMouvement.CREDIT
+                && mouvement.getParticipationId() != null
+                && mouvement.getOrigineType() != null
+                && mouvement.getOrigineType() != OrigineMouvementSoldeType.LEGACY
+                && TRACKED_CREDIT_ORIGINS.contains(mouvement.getOrigineType());
+    }
+
+    private OpenDebtLine toOpenDebtLine(MouvementSolde mouvement) {
+        return new OpenDebtLine(
+                mouvement.getId(),
+                mouvement.getParticipationId(),
+                mouvement.getMatchId(),
+                mouvement.getOrigineType(),
+                mouvement.getDateMouvement(),
+                mouvement.getMontant(),
+                false,
+                mouvement.getDescription()
+        );
+    }
+
+    private BigDecimal calculerTotalOuvert(Collection<List<OpenDebtLine>> dettesParParticipation) {
+        BigDecimal total = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        for (List<OpenDebtLine> lines : dettesParParticipation) {
+            for (OpenDebtLine line : lines) {
+                total = total.add(line.getMontantRestant()).setScale(2, RoundingMode.HALF_UP);
+            }
+        }
+        return total;
+    }
+
+    private BigDecimal scale(BigDecimal montant) {
+        return (montant == null ? BigDecimal.ZERO : montant).setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/model/ImputationResult.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/model/ImputationResult.java
@@ -1,0 +1,26 @@
+package be.ephec.padel.backend.service.model;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Collections;
+import java.util.List;
+
+public class ImputationResult {
+
+    private final List<OpenDebtLine> openDebtLines;
+    private final BigDecimal totalTrackedOpenAmount;
+
+    public ImputationResult(List<OpenDebtLine> openDebtLines, BigDecimal totalTrackedOpenAmount) {
+        this.openDebtLines = List.copyOf(openDebtLines);
+        this.totalTrackedOpenAmount = (totalTrackedOpenAmount == null ? BigDecimal.ZERO : totalTrackedOpenAmount)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    public List<OpenDebtLine> getOpenDebtLines() {
+        return Collections.unmodifiableList(openDebtLines);
+    }
+
+    public BigDecimal getTotalTrackedOpenAmount() {
+        return totalTrackedOpenAmount;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/model/OpenDebtLine.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/model/OpenDebtLine.java
@@ -1,0 +1,104 @@
+package be.ephec.padel.backend.service.model;
+
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+
+public class OpenDebtLine {
+
+    private final Long sourceMouvementId;
+    private final Long participationId;
+    private final Long matchId;
+    private final OrigineMouvementSoldeType origineType;
+    private final LocalDateTime dateMouvement;
+    private final BigDecimal montantInitial;
+    private BigDecimal montantImpute;
+    private BigDecimal montantRestant;
+    private final boolean legacy;
+    private final String description;
+
+    public OpenDebtLine(Long sourceMouvementId,
+                        Long participationId,
+                        Long matchId,
+                        OrigineMouvementSoldeType origineType,
+                        LocalDateTime dateMouvement,
+                        BigDecimal montantInitial,
+                        boolean legacy,
+                        String description) {
+        this.sourceMouvementId = sourceMouvementId;
+        this.participationId = participationId;
+        this.matchId = matchId;
+        this.origineType = origineType;
+        this.dateMouvement = dateMouvement;
+        this.montantInitial = scale(montantInitial);
+        this.montantImpute = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        this.montantRestant = scale(montantInitial);
+        this.legacy = legacy;
+        this.description = description;
+    }
+
+    public Long getSourceMouvementId() {
+        return sourceMouvementId;
+    }
+
+    public Long getParticipationId() {
+        return participationId;
+    }
+
+    public Long getMatchId() {
+        return matchId;
+    }
+
+    public OrigineMouvementSoldeType getOrigineType() {
+        return origineType;
+    }
+
+    public LocalDateTime getDateMouvement() {
+        return dateMouvement;
+    }
+
+    public BigDecimal getMontantInitial() {
+        return montantInitial;
+    }
+
+    public BigDecimal getMontantImpute() {
+        return montantImpute;
+    }
+
+    public BigDecimal getMontantRestant() {
+        return montantRestant;
+    }
+
+    public boolean isLegacy() {
+        return legacy;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isOpen() {
+        return montantRestant.signum() > 0;
+    }
+
+    public boolean cibleParticipation(Long targetParticipationId) {
+        return participationId != null && participationId.equals(targetParticipationId);
+    }
+
+    public void imputer(BigDecimal montant) {
+        BigDecimal montantScale = scale(montant);
+        if (montantScale.signum() <= 0) {
+            return;
+        }
+
+        BigDecimal imputation = montantScale.min(montantRestant);
+        this.montantImpute = this.montantImpute.add(imputation).setScale(2, RoundingMode.HALF_UP);
+        this.montantRestant = this.montantRestant.subtract(imputation).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal scale(BigDecimal montant) {
+        return (montant == null ? BigDecimal.ZERO : montant).setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/PaiementServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/PaiementServiceTest.java
@@ -246,6 +246,30 @@ class PaiementServiceTest {
     }
 
     @Test
+    void payerParticipationAvecRattrapageDette_reste_flux_special_hors_moteur_cible() {
+        Participation participation = mock(Participation.class);
+        Joueur joueur = mock(Joueur.class);
+        MatchPadel match = mock(MatchPadel.class);
+        when(joueur.getMatricule()).thenReturn("G1");
+        when(joueur.getSolde()).thenReturn(new BigDecimal("5.00"));
+        when(match.getStatut()).thenReturn(MatchStatut.PLANIFIE);
+        when(participation.getId()).thenReturn(1L);
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(participation.getMatch()).thenReturn(match);
+        when(participationRepo.findById(1L)).thenReturn(Optional.of(participation));
+        when(paiementRepo.sumMontantByParticipationId(1L)).thenReturn(BigDecimal.ZERO);
+
+        Paiement saved = mock(Paiement.class);
+        when(paiementRepo.save(any(Paiement.class))).thenReturn(saved);
+
+        Paiement result = service.payerParticipationAvecRattrapageDette(1L, new BigDecimal("20.00"));
+
+        assertSame(saved, result);
+        verify(soldeService).crediter("G1", new BigDecimal("20.00"));
+        verify(soldeService, org.mockito.Mockito.never()).crediter(eq("G1"), eq(new BigDecimal("20.00")), any(SoldeOriginContext.class));
+    }
+
+    @Test
     void validerMontant_remboursementPositifOuZero_refuse() {
         assertThrows(BusinessException.class, () ->
                 ReflectionTestUtils.invokeMethod(

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/SoldeImputationServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/SoldeImputationServiceTest.java
@@ -1,0 +1,192 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MouvementSolde;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.enums.TypeMouvement;
+import be.ephec.padel.backend.repository.MouvementSoldeRepository;
+import be.ephec.padel.backend.service.SoldeImputationService;
+import be.ephec.padel.backend.service.model.ImputationResult;
+import be.ephec.padel.backend.service.model.OpenDebtLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SoldeImputationServiceTest {
+
+    private MouvementSoldeRepository mouvementSoldeRepository;
+    private SoldeImputationService service;
+    private Joueur joueur;
+
+    @BeforeEach
+    void setUp() {
+        mouvementSoldeRepository = mock(MouvementSoldeRepository.class);
+        service = new SoldeImputationService(mouvementSoldeRepository);
+        joueur = new Joueur("J1", "Joueur 1", TypeJoueur.GLOBAL);
+    }
+
+    @Test
+    void debitParticipationA15_aucunCredit_reste15() {
+        when(mouvementSoldeRepository.findByJoueur_MatriculeOrderByDateMouvementAscIdAsc("J1"))
+                .thenReturn(List.of(debit(1L, 100L, 10L, "15.00", OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE, 1)));
+
+        ImputationResult result = service.reconstruirePourJoueur("J1");
+
+        assertThat(result.getTotalTrackedOpenAmount()).isEqualByComparingTo("15.00");
+        assertThat(result.getOpenDebtLines()).hasSize(1);
+        assertThat(result.getOpenDebtLines().getFirst().getMontantRestant()).isEqualByComparingTo("15.00");
+    }
+
+    @Test
+    void debitParticipationA15_creditA10_reste5() {
+        when(mouvementSoldeRepository.findByJoueur_MatriculeOrderByDateMouvementAscIdAsc("J1"))
+                .thenReturn(List.of(
+                        debit(1L, 100L, 10L, "15.00", OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE, 1),
+                        credit(2L, 100L, 10L, "10.00", OrigineMouvementSoldeType.PAIEMENT_PARTICIPATION, 2)
+                ));
+
+        ImputationResult result = service.reconstruirePourJoueur("J1");
+
+        assertThat(result.getTotalTrackedOpenAmount()).isEqualByComparingTo("5.00");
+        assertThat(result.getOpenDebtLines()).hasSize(1);
+        OpenDebtLine line = result.getOpenDebtLines().getFirst();
+        assertThat(line.getMontantImpute()).isEqualByComparingTo("10.00");
+        assertThat(line.getMontantRestant()).isEqualByComparingTo("5.00");
+    }
+
+    @Test
+    void debitParticipationA15_creditA15_reste0() {
+        when(mouvementSoldeRepository.findByJoueur_MatriculeOrderByDateMouvementAscIdAsc("J1"))
+                .thenReturn(List.of(
+                        debit(1L, 100L, 10L, "15.00", OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE, 1),
+                        credit(2L, 100L, 10L, "15.00", OrigineMouvementSoldeType.PAIEMENT_PARTICIPATION, 2)
+                ));
+
+        ImputationResult result = service.reconstruirePourJoueur("J1");
+
+        assertThat(result.getTotalTrackedOpenAmount()).isEqualByComparingTo("0.00");
+        assertThat(result.getOpenDebtLines()).isEmpty();
+    }
+
+    @Test
+    void debitA15_debitB15_creditA15_A_soldee_B_reste15() {
+        when(mouvementSoldeRepository.findByJoueur_MatriculeOrderByDateMouvementAscIdAsc("J1"))
+                .thenReturn(List.of(
+                        debit(1L, 100L, 10L, "15.00", OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE, 1),
+                        debit(2L, 200L, 20L, "15.00", OrigineMouvementSoldeType.CREATION_MATCH_ORGANISATEUR, 2),
+                        credit(3L, 100L, 10L, "15.00", OrigineMouvementSoldeType.PAIEMENT_PARTICIPATION, 3)
+                ));
+
+        ImputationResult result = service.reconstruirePourJoueur("J1");
+
+        assertThat(result.getTotalTrackedOpenAmount()).isEqualByComparingTo("15.00");
+        assertThat(result.getOpenDebtLines()).hasSize(1);
+        assertThat(result.getOpenDebtLines().getFirst().getParticipationId()).isEqualTo(200L);
+        assertThat(result.getOpenDebtLines().getFirst().getMontantRestant()).isEqualByComparingTo("15.00");
+    }
+
+    @Test
+    void neutralisationJ1_surA_A_soldee() {
+        when(mouvementSoldeRepository.findByJoueur_MatriculeOrderByDateMouvementAscIdAsc("J1"))
+                .thenReturn(List.of(
+                        debit(1L, 100L, 10L, "15.00", OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE, 1),
+                        credit(2L, 100L, 10L, "15.00", OrigineMouvementSoldeType.TRAITEMENT_J1_NEUTRALISATION, 2)
+                ));
+
+        ImputationResult result = service.reconstruirePourJoueur("J1");
+
+        assertThat(result.getOpenDebtLines()).isEmpty();
+        assertThat(result.getTotalTrackedOpenAmount()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    void neutralisationAnnulation_surA_A_soldee() {
+        when(mouvementSoldeRepository.findByJoueur_MatriculeOrderByDateMouvementAscIdAsc("J1"))
+                .thenReturn(List.of(
+                        debit(1L, 100L, 10L, "15.00", OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE, 1),
+                        credit(2L, 100L, 10L, "15.00", OrigineMouvementSoldeType.ANNULATION_MATCH_NEUTRALISATION, 2)
+                ));
+
+        ImputationResult result = service.reconstruirePourJoueur("J1");
+
+        assertThat(result.getOpenDebtLines()).isEmpty();
+        assertThat(result.getTotalTrackedOpenAmount()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    void creditLegacy_ne_solde_pas_dette_ciblee() {
+        when(mouvementSoldeRepository.findByJoueur_MatriculeOrderByDateMouvementAscIdAsc("J1"))
+                .thenReturn(List.of(
+                        debit(1L, 100L, 10L, "15.00", OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE, 1),
+                        credit(2L, 100L, 10L, "15.00", OrigineMouvementSoldeType.LEGACY, 2)
+                ));
+
+        ImputationResult result = service.reconstruirePourJoueur("J1");
+
+        assertThat(result.getOpenDebtLines()).hasSize(1);
+        assertThat(result.getTotalTrackedOpenAmount()).isEqualByComparingTo("15.00");
+    }
+
+    @Test
+    void creditParticipationDifferente_ne_solde_pas_autre_participation() {
+        when(mouvementSoldeRepository.findByJoueur_MatriculeOrderByDateMouvementAscIdAsc("J1"))
+                .thenReturn(List.of(
+                        debit(1L, 100L, 10L, "15.00", OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE, 1),
+                        credit(2L, 200L, 20L, "15.00", OrigineMouvementSoldeType.PAIEMENT_PARTICIPATION, 2)
+                ));
+
+        ImputationResult result = service.reconstruirePourJoueur("J1");
+
+        assertThat(result.getOpenDebtLines()).hasSize(1);
+        assertThat(result.getOpenDebtLines().getFirst().getParticipationId()).isEqualTo(100L);
+        assertThat(result.getOpenDebtLines().getFirst().getMontantRestant()).isEqualByComparingTo("15.00");
+    }
+
+    private MouvementSolde debit(Long id,
+                                 Long participationId,
+                                 Long matchId,
+                                 String montant,
+                                 OrigineMouvementSoldeType origine,
+                                 int dayOffset) {
+        return mouvement(id, participationId, matchId, montant, TypeMouvement.DEBIT, origine, dayOffset);
+    }
+
+    private MouvementSolde credit(Long id,
+                                  Long participationId,
+                                  Long matchId,
+                                  String montant,
+                                  OrigineMouvementSoldeType origine,
+                                  int dayOffset) {
+        return mouvement(id, participationId, matchId, montant, TypeMouvement.CREDIT, origine, dayOffset);
+    }
+
+    private MouvementSolde mouvement(Long id,
+                                     Long participationId,
+                                     Long matchId,
+                                     String montant,
+                                     TypeMouvement type,
+                                     OrigineMouvementSoldeType origine,
+                                     int dayOffset) {
+        MouvementSolde mouvement = new MouvementSolde(
+                LocalDateTime.of(2030, 1, 1, 10, 0).plusDays(dayOffset),
+                new BigDecimal(montant),
+                type,
+                joueur,
+                participationId,
+                matchId,
+                origine,
+                null
+        );
+        ReflectionTestUtils.setField(mouvement, "id", id);
+        return mouvement;
+    }
+}


### PR DESCRIPTION
- création de SoldeImputationService ;
- création de OpenDebtLine ;
- création de ImputationResult ;
- ajout d’une lecture chronologique stable des mouvements de solde dans MouvementSoldeRepository ;
- reconstruction des dettes ouvertes uniquement à partir des mouvements traçables avec participationId.

Cas couverts :
- débit de participation sans crédit ;
- paiement partiel ;
- paiement complet ;
- plusieurs participations séparées ;
- neutralisation J-1 ;
- neutralisation lors d’une annulation ;
- exclusion des mouvements LEGACY ;
- exclusion des crédits liés à une autre participation.