### PR TITLE
feat(me): exposer les régularisations traçables

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/MeController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/MeController.java
@@ -5,9 +5,11 @@ import be.ephec.padel.backend.dto.response.JoueurDto;
 import be.ephec.padel.backend.dto.response.MeStatsDto;
 import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
 import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
+import be.ephec.padel.backend.dto.response.RegularisationsResponseDto;
 import be.ephec.padel.backend.mapper.JoueurMapper;
 import be.ephec.padel.backend.service.JoueurService;
 import be.ephec.padel.backend.service.MeStatsService;
+import be.ephec.padel.backend.service.RegularisationService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,10 +25,14 @@ public class MeController {
 
     private final JoueurService joueurService;
     private final MeStatsService meStatsService;
+    private final RegularisationService regularisationService;
 
-    public MeController(JoueurService joueurService, MeStatsService meStatsService) {
+    public MeController(JoueurService joueurService,
+                        MeStatsService meStatsService,
+                        RegularisationService regularisationService) {
         this.joueurService = joueurService;
         this.meStatsService = meStatsService;
+        this.regularisationService = regularisationService;
     }
 
     @GetMapping
@@ -47,6 +53,11 @@ public class MeController {
     @GetMapping("/dette")
     public ResponseEntity<DetteDto> getMyDette() {
         return ResponseEntity.ok(new DetteDto(joueurService.currentUserADette()));
+    }
+
+    @GetMapping("/regularisations")
+    public ResponseEntity<RegularisationsResponseDto> getMyRegularisations() {
+        return ResponseEntity.ok(regularisationService.getCurrentUserRegularisations());
     }
 
     @GetMapping("/stats")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/RegularisationDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/RegularisationDto.java
@@ -1,0 +1,25 @@
+package be.ephec.padel.backend.dto.response;
+
+import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record RegularisationDto(
+        Long participationId,
+        Long matchId,
+        LocalDateTime dateMatch,
+        String siteNom,
+        String terrainNom,
+        MatchVisibilite visibilite,
+        PlayerMatchRoleDto roleJoueur,
+        OrigineMouvementSoldeType origineType,
+        BigDecimal montantInitial,
+        BigDecimal montantDejaPaye,
+        BigDecimal montantRestant,
+        String description,
+        boolean payable
+) {
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/RegularisationsResponseDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/RegularisationsResponseDto.java
@@ -1,0 +1,10 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record RegularisationsResponseDto(
+        BigDecimal totalTracable,
+        List<RegularisationDto> items
+) {
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
@@ -3,6 +3,8 @@ import java.util.Optional;
 
 import be.ephec.padel.backend.model.entities.Participation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,6 +16,17 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     boolean existsByMatch_IdAndJoueur_Matricule(Long matchId, String joueurMatricule);
 
     Optional<Participation> findByMatch_IdAndJoueur_Matricule(Long matchId, String matricule);
+
+    @Query("""
+            select distinct p
+            from Participation p
+            join fetch p.joueur
+            join fetch p.match m
+            join fetch m.terrain t
+            join fetch t.site s
+            where p.id in :ids
+            """)
+    List<Participation> findByIdInWithDetails(@Param("ids") List<Long> ids);
 
     int countByMatch_Id(Long matchId);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/RegularisationService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/RegularisationService.java
@@ -1,0 +1,117 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+import be.ephec.padel.backend.dto.response.RegularisationDto;
+import be.ephec.padel.backend.dto.response.RegularisationsResponseDto;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
+import be.ephec.padel.backend.service.model.ImputationResult;
+import be.ephec.padel.backend.service.model.OpenDebtLine;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+public class RegularisationService {
+
+    private final CurrentUserFacade currentUserFacade;
+    private final SoldeImputationService soldeImputationService;
+    private final ParticipationRepository participationRepository;
+
+    public RegularisationService(CurrentUserFacade currentUserFacade,
+                                 SoldeImputationService soldeImputationService,
+                                 ParticipationRepository participationRepository) {
+        this.currentUserFacade = currentUserFacade;
+        this.soldeImputationService = soldeImputationService;
+        this.participationRepository = participationRepository;
+    }
+
+    public RegularisationsResponseDto getCurrentUserRegularisations() {
+        Joueur joueur = currentUserFacade.getCurrentJoueur();
+        ImputationResult imputationResult = soldeImputationService.reconstruirePourJoueur(joueur.getMatricule());
+
+        List<OpenDebtLine> openDebtLines = imputationResult.getOpenDebtLines();
+        if (openDebtLines.isEmpty()) {
+            return new RegularisationsResponseDto(
+                    BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+                    List.of()
+            );
+        }
+
+        List<Long> participationIds = openDebtLines.stream()
+                .map(OpenDebtLine::getParticipationId)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+
+        Map<Long, Participation> participationById = new LinkedHashMap<>();
+        participationRepository.findByIdInWithDetails(participationIds)
+                .forEach(participation -> participationById.put(participation.getId(), participation));
+
+        List<RegularisationDto> items = openDebtLines.stream()
+                .filter(line -> line.getMontantRestant().signum() > 0)
+                .map(line -> toRegularisationDto(line, participationById.get(line.getParticipationId()), joueur.getMatricule()))
+                .filter(java.util.Objects::nonNull)
+                .sorted(java.util.Comparator
+                        .comparing(RegularisationDto::dateMatch)
+                        .thenComparing(RegularisationDto::participationId))
+                .toList();
+
+        BigDecimal totalTracable = items.stream()
+                .map(RegularisationDto::montantRestant)
+                .reduce(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP), BigDecimal::add)
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return new RegularisationsResponseDto(totalTracable, items);
+    }
+
+    private RegularisationDto toRegularisationDto(OpenDebtLine line,
+                                                  Participation participation,
+                                                  String joueurCourantMatricule) {
+        if (line == null || participation == null || participation.getMatch() == null) {
+            return null;
+        }
+
+        MatchPadel match = participation.getMatch();
+        PlayerMatchRoleDto roleJoueur =
+                match.getOrganisateur() != null
+                        && match.getOrganisateur().getMatricule().equals(joueurCourantMatricule)
+                        ? PlayerMatchRoleDto.ORGANISATEUR
+                        : PlayerMatchRoleDto.PARTICIPANT;
+
+        BigDecimal montantInitial = scale(line.getMontantInitial());
+        BigDecimal montantRestant = scale(line.getMontantRestant());
+        BigDecimal montantDejaPaye = montantInitial.subtract(montantRestant).setScale(2, RoundingMode.HALF_UP);
+        boolean payable = match.getStatut() != MatchStatut.ANNULE && montantRestant.signum() > 0;
+
+        return new RegularisationDto(
+                participation.getId(),
+                match.getId(),
+                match.getDateDebut(),
+                match.getTerrain().getSite().getNom(),
+                match.getTerrain().getNom(),
+                match.getVisibilite(),
+                roleJoueur,
+                line.getOrigineType(),
+                montantInitial,
+                montantDejaPaye,
+                montantRestant,
+                line.getDescription(),
+                payable
+        );
+    }
+
+    private BigDecimal scale(BigDecimal montant) {
+        return (montant == null ? BigDecimal.ZERO : montant).setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/RegularisationServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/RegularisationServiceTest.java
@@ -1,0 +1,162 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+import be.ephec.padel.backend.dto.response.RegularisationsResponseDto;
+import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.repository.ParticipationRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
+import be.ephec.padel.backend.service.RegularisationService;
+import be.ephec.padel.backend.service.SoldeImputationService;
+import be.ephec.padel.backend.service.model.ImputationResult;
+import be.ephec.padel.backend.service.model.OpenDebtLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RegularisationServiceTest {
+
+    private CurrentUserFacade currentUserFacade;
+    private SoldeImputationService soldeImputationService;
+    private ParticipationRepository participationRepository;
+
+    private RegularisationService service;
+    private Joueur joueur;
+
+    @BeforeEach
+    void setUp() {
+        currentUserFacade = mock(CurrentUserFacade.class);
+        soldeImputationService = mock(SoldeImputationService.class);
+        participationRepository = mock(ParticipationRepository.class);
+        service = new RegularisationService(currentUserFacade, soldeImputationService, participationRepository);
+
+        joueur = new Joueur("G9001", "Joueur Global Demo", TypeJoueur.GLOBAL);
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
+    }
+
+    @Test
+    void aucuneDetteTracable_listeVide_totalZero() {
+        when(soldeImputationService.reconstruirePourJoueur("G9001"))
+                .thenReturn(new ImputationResult(List.of(), BigDecimal.ZERO));
+
+        RegularisationsResponseDto result = service.getCurrentUserRegularisations();
+
+        assertThat(result.totalTracable()).isEqualByComparingTo("0.00");
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    void uneDetteOuverteTracable_uneLigneCorrectementMappee() {
+        OpenDebtLine line = new OpenDebtLine(
+                1L,
+                10L,
+                100L,
+                OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE,
+                LocalDateTime.of(2030, 1, 1, 10, 0),
+                new BigDecimal("15.00"),
+                false,
+                null
+        );
+        line.imputer(new BigDecimal("5.00"));
+
+        when(soldeImputationService.reconstruirePourJoueur("G9001"))
+                .thenReturn(new ImputationResult(List.of(line), new BigDecimal("10.00")));
+
+        Participation participation = participation(10L, 100L, joueur, MatchVisibilite.PRIVE, MatchStatut.PLANIFIE);
+        when(participationRepository.findByIdInWithDetails(List.of(10L))).thenReturn(List.of(participation));
+
+        RegularisationsResponseDto result = service.getCurrentUserRegularisations();
+
+        assertThat(result.totalTracable()).isEqualByComparingTo("10.00");
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().getFirst().participationId()).isEqualTo(10L);
+        assertThat(result.items().getFirst().matchId()).isEqualTo(100L);
+        assertThat(result.items().getFirst().siteNom()).isEqualTo("Site Nord");
+        assertThat(result.items().getFirst().terrainNom()).isEqualTo("Terrain 1");
+        assertThat(result.items().getFirst().roleJoueur()).isEqualTo(PlayerMatchRoleDto.ORGANISATEUR);
+        assertThat(result.items().getFirst().montantInitial()).isEqualByComparingTo("15.00");
+        assertThat(result.items().getFirst().montantDejaPaye()).isEqualByComparingTo("5.00");
+        assertThat(result.items().getFirst().montantRestant()).isEqualByComparingTo("10.00");
+        assertThat(result.items().getFirst().payable()).isTrue();
+    }
+
+    @Test
+    void deuxDettesOuvertes_totalCorrect() {
+        OpenDebtLine line1 = new OpenDebtLine(1L, 10L, 100L, OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE,
+                LocalDateTime.of(2030, 1, 2, 10, 0), new BigDecimal("15.00"), false, null);
+        OpenDebtLine line2 = new OpenDebtLine(2L, 20L, 200L, OrigineMouvementSoldeType.CREATION_MATCH_ORGANISATEUR,
+                LocalDateTime.of(2030, 1, 3, 10, 0), new BigDecimal("15.00"), false, null);
+        line2.imputer(new BigDecimal("3.00"));
+
+        when(soldeImputationService.reconstruirePourJoueur("G9001"))
+                .thenReturn(new ImputationResult(List.of(line1, line2), new BigDecimal("27.00")));
+
+        Participation p1 = participation(10L, 100L, joueur, MatchVisibilite.PRIVE, MatchStatut.PLANIFIE);
+        Participation p2 = participation(20L, 200L, new Joueur("S9001", "Autre", TypeJoueur.SITE), MatchVisibilite.PUBLIC, MatchStatut.PLANIFIE);
+        when(participationRepository.findByIdInWithDetails(List.of(10L, 20L))).thenReturn(List.of(p1, p2));
+
+        RegularisationsResponseDto result = service.getCurrentUserRegularisations();
+
+        assertThat(result.items()).hasSize(2);
+        assertThat(result.totalTracable()).isEqualByComparingTo("27.00");
+    }
+
+    @Test
+    void participationTotalementSoldee_aucuneLigne() {
+        when(soldeImputationService.reconstruirePourJoueur("G9001"))
+                .thenReturn(new ImputationResult(List.of(), BigDecimal.ZERO));
+
+        RegularisationsResponseDto result = service.getCurrentUserRegularisations();
+
+        assertThat(result.items()).isEmpty();
+        assertThat(result.totalTracable()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    void detteGlobaleNonTracableEtDetteCiblee_seuleDetteCibleeRetournee() {
+        OpenDebtLine line = new OpenDebtLine(1L, 10L, 100L, OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE,
+                LocalDateTime.of(2030, 1, 2, 10, 0), new BigDecimal("15.00"), false, "Dette traçable");
+
+        when(soldeImputationService.reconstruirePourJoueur("G9001"))
+                .thenReturn(new ImputationResult(List.of(line), new BigDecimal("15.00")));
+
+        Participation p1 = participation(10L, 100L, joueur, MatchVisibilite.PRIVE, MatchStatut.PLANIFIE);
+        when(participationRepository.findByIdInWithDetails(List.of(10L))).thenReturn(List.of(p1));
+
+        RegularisationsResponseDto result = service.getCurrentUserRegularisations();
+
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.totalTracable()).isEqualByComparingTo("15.00");
+    }
+
+    private Participation participation(Long participationId,
+                                        Long matchId,
+                                        Joueur organisateur,
+                                        MatchVisibilite visibilite,
+                                        MatchStatut statut) {
+        Site site = new Site("Site Nord", "Bruxelles");
+        Terrain terrain = new Terrain("Terrain 1", site);
+        MatchPadel match = new MatchPadel(terrain, organisateur, LocalDateTime.of(2030, 1, 10, 18, 0), visibilite);
+        match.setStatut(statut);
+        ReflectionTestUtils.setField(match, "id", matchId);
+
+        Participation participation = new Participation(match, joueur);
+        ReflectionTestUtils.setField(participation, "id", participationId);
+        return participation;
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MeControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MeControllerTest.java
@@ -7,6 +7,8 @@ import be.ephec.padel.backend.dto.response.MeStatsDto;
 import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
 import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
 import be.ephec.padel.backend.dto.response.PlayerMatchSummaryDto;
+import be.ephec.padel.backend.dto.response.RegularisationDto;
+import be.ephec.padel.backend.dto.response.RegularisationsResponseDto;
 import be.ephec.padel.backend.error.ApiExceptionHandler;
 import be.ephec.padel.backend.exception.ForbiddenException;
 import be.ephec.padel.backend.model.entities.Joueur;
@@ -15,6 +17,7 @@ import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.service.JoueurService;
 import be.ephec.padel.backend.service.MeStatsService;
+import be.ephec.padel.backend.service.RegularisationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -48,6 +51,9 @@ class MeControllerTest {
 
     @MockitoBean
     MeStatsService meStatsService;
+
+    @MockitoBean
+    RegularisationService regularisationService;
 
     @Test
     @WithAnonymousUser
@@ -171,6 +177,43 @@ class MeControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.dette").value(true));
+    }
+
+    @Test
+    void getMyRegularisations_ok_200() throws Exception {
+        RegularisationDto item = new RegularisationDto(
+                77L,
+                1L,
+                LocalDateTime.of(2030, 1, 10, 10, 0),
+                "Site Delta",
+                "Terrain 1",
+                MatchVisibilite.PUBLIC,
+                PlayerMatchRoleDto.PARTICIPANT,
+                be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType.PAIEMENT_PARTICIPATION,
+                new BigDecimal("15.00"),
+                new BigDecimal("5.00"),
+                new BigDecimal("10.00"),
+                null,
+                true
+        );
+        when(regularisationService.getCurrentUserRegularisations())
+                .thenReturn(new RegularisationsResponseDto(new BigDecimal("10.00"), List.of(item)));
+
+        mvc.perform(get("/api/v1/me/regularisations"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.totalTracable").value(10.00))
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].participationId").value(77))
+                .andExpect(jsonPath("$.items[0].matchId").value(1))
+                .andExpect(jsonPath("$.items[0].siteNom").value("Site Delta"))
+                .andExpect(jsonPath("$.items[0].terrainNom").value("Terrain 1"))
+                .andExpect(jsonPath("$.items[0].roleJoueur").value("PARTICIPANT"))
+                .andExpect(jsonPath("$.items[0].montantInitial").value(15.00))
+                .andExpect(jsonPath("$.items[0].montantDejaPaye").value(5.00))
+                .andExpect(jsonPath("$.items[0].montantRestant").value(10.00))
+                .andExpect(jsonPath("$.items[0].payable").value(true));
     }
 
     @Test


### PR DESCRIPTION
- ajout de l’endpoint dans MeController ;
- création de RegularisationService ;
- réutilisation de SoldeImputationService ;
- ajout de RegularisationDto ;
- ajout de RegularisationsResponseDto ;
- ajout d’un chargement batch des participations avec match / terrain / site dans ParticipationRepository.

Règle conservée :
- /api/v1/me reste la source pour le solde global ;
- /api/v1/me/regularisations expose uniquement les dettes traçables par participation ;
- l’endpoint ne prétend pas expliquer toute la dette globale Joueur.solde.