### PR TITLE
feat(espace-prive): ajouter les matchs à payer

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeeder.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeeder.java
@@ -11,6 +11,7 @@ import be.ephec.padel.backend.model.entities.Terrain;
 import be.ephec.padel.backend.model.entities.User;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
+import be.ephec.padel.backend.model.enums.OrigineMouvementSoldeType;
 import be.ephec.padel.backend.model.enums.SecurityRole;
 import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
@@ -23,6 +24,8 @@ import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.repository.SiteRepository;
 import be.ephec.padel.backend.repository.TerrainRepository;
 import be.ephec.padel.backend.repository.UserRepository;
+import be.ephec.padel.backend.service.SoldeOriginContext;
+import be.ephec.padel.backend.service.SoldeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -59,6 +62,7 @@ public class DevDataSeeder {
     private final ParticipationRepository participationRepository;
     private final PaiementRepository paiementRepository;
     private final PasswordEncoder passwordEncoder;
+    private final SoldeService soldeService;
     private final Clock clock;
     private final String adminGlobalUsername;
     private final String adminSiteUsers;
@@ -72,6 +76,7 @@ public class DevDataSeeder {
                          ParticipationRepository participationRepository,
                          PaiementRepository paiementRepository,
                          PasswordEncoder passwordEncoder,
+                         SoldeService soldeService,
                          Clock clock,
                          @Value("${app.security.admin.global.username:}") String adminGlobalUsername,
                          @Value("${app.security.admin.site.users:}") String adminSiteUsers) {
@@ -84,6 +89,7 @@ public class DevDataSeeder {
         this.participationRepository = participationRepository;
         this.paiementRepository = paiementRepository;
         this.passwordEncoder = passwordEncoder;
+        this.soldeService = soldeService;
         this.clock = clock;
         this.adminGlobalUsername = adminGlobalUsername;
         this.adminSiteUsers = adminSiteUsers;
@@ -126,7 +132,7 @@ public class DevDataSeeder {
 
         Joueur joueurGlobal = ensureJoueur("G9001", "Joueur Global Demo", TypeJoueur.GLOBAL, null, ZERO);
         Joueur joueurSiteNord = ensureJoueur("S9001", "Joueur Site Nord Demo", TypeJoueur.SITE, siteNord, ZERO);
-        Joueur joueurLibre = ensureJoueur("L9001", "Joueur Libre Demo", TypeJoueur.LIBRE, null, PART.multiply(BigDecimal.valueOf(2)).setScale(2, RoundingMode.HALF_UP));
+        Joueur joueurLibre = ensureJoueur("L9001", "Joueur Libre Demo", TypeJoueur.LIBRE, null, ZERO);
         Joueur joueurSiteSud = ensureJoueur("S9002", "Joueur Site Sud Demo", TypeJoueur.SITE, siteSud, ZERO);
 
         ensurePlayerUser("joueur.global.dev", joueurGlobal);
@@ -157,11 +163,12 @@ public class DevDataSeeder {
         );
         ensureParticipation(publicFuturComplet, joueurSiteNord);
         ensureParticipation(publicFuturComplet, joueurGlobal);
-        ensureParticipation(publicFuturComplet, joueurLibre);
+        Participation participationLibrePublic = ensureParticipation(publicFuturComplet, joueurLibre);
         ensureParticipation(publicFuturComplet, joueurSiteSud);
         ensureEncaissement(publicFuturComplet, joueurSiteNord, PART);
         ensureEncaissement(publicFuturComplet, joueurGlobal, PART);
         ensureEncaissement(publicFuturComplet, joueurSiteSud, PART);
+        ensureSeedDebt(participationLibrePublic, OrigineMouvementSoldeType.REJOINDRE_MATCH_PUBLIC_PART);
 
         MatchPadel priveFutur = ensureMatch(
                 sudT1,
@@ -171,8 +178,9 @@ public class DevDataSeeder {
                 MatchStatut.PLANIFIE
         );
         ensureParticipation(priveFutur, joueurSiteSud);
-        ensureParticipation(priveFutur, joueurLibre);
+        Participation participationLibrePrive = ensureParticipation(priveFutur, joueurLibre);
         ensureEncaissement(priveFutur, joueurSiteSud, PART);
+        ensureSeedDebt(participationLibrePrive, OrigineMouvementSoldeType.AJOUT_MATCH_PRIVE);
 
         MatchPadel publicPasse = ensureMatch(
                 nordT1,
@@ -366,5 +374,18 @@ public class DevDataSeeder {
                 TypePaiement.REMBOURSEMENT,
                 match.getDateDebut().minusDays(1)
         ));
+    }
+
+    private void ensureSeedDebt(Participation participation, OrigineMouvementSoldeType origineType) {
+        soldeService.debiter(
+                participation.getJoueur().getMatricule(),
+                PART,
+                new SoldeOriginContext(
+                        origineType,
+                        participation.getId(),
+                        participation.getMatch().getId(),
+                        null
+                )
+        );
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/PaiementService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/PaiementService.java
@@ -119,7 +119,7 @@ public class PaiementService {
 
         String matricule = participation.getJoueur().getMatricule();
         if (autoriserRattrapageDette) {
-            soldeService.crediter(matricule, m);
+            crediterParticipationEtRattrapage(participation, m, restePart);
         } else {
             Long matchId = participation.getMatch() != null ? participation.getMatch().getId() : null;
             soldeService.crediter(
@@ -135,6 +135,41 @@ public class PaiementService {
         }
 
         return saved;
+    }
+
+    private void crediterParticipationEtRattrapage(Participation participation,
+                                                   BigDecimal montantTotal,
+                                                   BigDecimal restePart) {
+        String matricule = participation.getJoueur().getMatricule();
+        Long matchId = participation.getMatch() != null ? participation.getMatch().getId() : null;
+
+        BigDecimal montantParticipation = montantTotal.min(restePart).setScale(2, RoundingMode.HALF_UP);
+        if (montantParticipation.signum() > 0) {
+            soldeService.crediter(
+                    matricule,
+                    montantParticipation,
+                    new SoldeOriginContext(
+                            OrigineMouvementSoldeType.PAIEMENT_PARTICIPATION,
+                            participation.getId(),
+                            matchId,
+                            null
+                    )
+            );
+        }
+
+        BigDecimal montantRattrapage = montantTotal.subtract(montantParticipation).setScale(2, RoundingMode.HALF_UP);
+        if (montantRattrapage.signum() > 0) {
+            soldeService.crediter(
+                    matricule,
+                    montantRattrapage,
+                    new SoldeOriginContext(
+                            OrigineMouvementSoldeType.RATTRAPAGE_DETTE,
+                            null,
+                            null,
+                            null
+                    )
+            );
+        }
     }
 
     private Participation getParticipationByIdOrThrow(Long participationId) {

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/seed/DevDataSeederTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/seed/DevDataSeederTest.java
@@ -9,6 +9,7 @@ import be.ephec.padel.backend.repository.SiteRepository;
 import be.ephec.padel.backend.repository.TerrainRepository;
 import be.ephec.padel.backend.repository.UserRepository;
 import be.ephec.padel.backend.seed.DevDataSeeder;
+import be.ephec.padel.backend.service.SoldeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +49,8 @@ class DevDataSeederTest {
     PaiementRepository paiementRepository;
     @Mock
     PasswordEncoder passwordEncoder;
+    @Mock
+    SoldeService soldeService;
 
     DevDataSeeder seeder;
 
@@ -64,6 +67,7 @@ class DevDataSeederTest {
                 participationRepository,
                 paiementRepository,
                 passwordEncoder,
+                soldeService,
                 clock,
                 "admin.global.dev",
                 "admin.site.nord.dev:1"
@@ -96,6 +100,7 @@ class DevDataSeederTest {
                 participationRepository,
                 paiementRepository,
                 passwordEncoder,
+                soldeService,
                 clock,
                 "admin.global.dev",
                 "admin.site.nord.dev:99"

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/PaiementServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/PaiementServiceTest.java
@@ -252,6 +252,7 @@ class PaiementServiceTest {
         MatchPadel match = mock(MatchPadel.class);
         when(joueur.getMatricule()).thenReturn("G1");
         when(joueur.getSolde()).thenReturn(new BigDecimal("5.00"));
+        when(match.getId()).thenReturn(70L);
         when(match.getStatut()).thenReturn(MatchStatut.PLANIFIE);
         when(participation.getId()).thenReturn(1L);
         when(participation.getJoueur()).thenReturn(joueur);
@@ -265,8 +266,45 @@ class PaiementServiceTest {
         Paiement result = service.payerParticipationAvecRattrapageDette(1L, new BigDecimal("20.00"));
 
         assertSame(saved, result);
-        verify(soldeService).crediter("G1", new BigDecimal("20.00"));
-        verify(soldeService, org.mockito.Mockito.never()).crediter(eq("G1"), eq(new BigDecimal("20.00")), any(SoldeOriginContext.class));
+        verify(soldeService).crediter(eq("G1"), eq(new BigDecimal("15.00")), argThat((SoldeOriginContext context) ->
+                context.getOrigineType() == OrigineMouvementSoldeType.PAIEMENT_PARTICIPATION
+                        && Long.valueOf(1L).equals(context.getParticipationId())
+                        && Long.valueOf(70L).equals(context.getMatchId())
+        ));
+        verify(soldeService).crediter(eq("G1"), eq(new BigDecimal("5.00")), argThat((SoldeOriginContext context) ->
+                context.getOrigineType() == OrigineMouvementSoldeType.RATTRAPAGE_DETTE
+                        && context.getParticipationId() == null
+                        && context.getMatchId() == null
+        ));
+    }
+
+    @Test
+    void payerParticipationAvecRattrapageDette_sansDetteAnterieure_trace_un_credit_cible_sur_la_participation() {
+        Participation participation = mock(Participation.class);
+        Joueur joueur = mock(Joueur.class);
+        MatchPadel match = mock(MatchPadel.class);
+        when(joueur.getMatricule()).thenReturn("G1");
+        when(joueur.getSolde()).thenReturn(new BigDecimal("0.00"));
+        when(match.getId()).thenReturn(71L);
+        when(match.getStatut()).thenReturn(MatchStatut.PLANIFIE);
+        when(participation.getId()).thenReturn(2L);
+        when(participation.getJoueur()).thenReturn(joueur);
+        when(participation.getMatch()).thenReturn(match);
+        when(participationRepo.findById(2L)).thenReturn(Optional.of(participation));
+        when(paiementRepo.sumMontantByParticipationId(2L)).thenReturn(BigDecimal.ZERO);
+
+        Paiement saved = mock(Paiement.class);
+        when(paiementRepo.save(any(Paiement.class))).thenReturn(saved);
+
+        Paiement result = service.payerParticipationAvecRattrapageDette(2L, new BigDecimal("15.00"));
+
+        assertSame(saved, result);
+        verify(soldeService).crediter(eq("G1"), eq(new BigDecimal("15.00")), argThat((SoldeOriginContext context) ->
+                context.getOrigineType() == OrigineMouvementSoldeType.PAIEMENT_PARTICIPATION
+                        && Long.valueOf(2L).equals(context.getParticipationId())
+                        && Long.valueOf(71L).equals(context.getMatchId())
+        ));
+        verify(soldeService, org.mockito.Mockito.never()).crediter(eq("G1"), eq(new BigDecimal("15.00")));
     }
 
     @Test

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/SoldeImputationServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/SoldeImputationServiceTest.java
@@ -151,6 +151,20 @@ class SoldeImputationServiceTest {
         assertThat(result.getOpenDebtLines().getFirst().getMontantRestant()).isEqualByComparingTo("15.00");
     }
 
+    @Test
+    void rejoindrePublic_avecPaiementImmediat_ne_laisse_aucune_dette_tracable_sur_la_participation() {
+        when(mouvementSoldeRepository.findByJoueur_MatriculeOrderByDateMouvementAscIdAsc("J1"))
+                .thenReturn(List.of(
+                        debit(1L, 300L, 30L, "15.00", OrigineMouvementSoldeType.REJOINDRE_MATCH_PUBLIC_PART, 1),
+                        credit(2L, 300L, 30L, "15.00", OrigineMouvementSoldeType.PAIEMENT_PARTICIPATION, 2)
+                ));
+
+        ImputationResult result = service.reconstruirePourJoueur("J1");
+
+        assertThat(result.getOpenDebtLines()).isEmpty();
+        assertThat(result.getTotalTrackedOpenAmount()).isEqualByComparingTo("0.00");
+    }
+
     private MouvementSolde debit(Long id,
                                  Long participationId,
                                  Long matchId,

--- a/frontend/src/app/core/regularisations/regularisation.models.ts
+++ b/frontend/src/app/core/regularisations/regularisation.models.ts
@@ -1,0 +1,22 @@
+export type RegularisationRole = 'ORGANISATEUR' | 'PARTICIPANT';
+
+export interface Regularisation {
+  participationId: number;
+  matchId: number;
+  dateMatch: string;
+  siteNom: string;
+  terrainNom: string;
+  visibilite: string;
+  roleJoueur: RegularisationRole;
+  origineType: string;
+  montantInitial: number;
+  montantDejaPaye: number;
+  montantRestant: number;
+  description: string | null;
+  payable: boolean;
+}
+
+export interface RegularisationsResponse {
+  totalTracable: number;
+  items: Regularisation[];
+}

--- a/frontend/src/app/core/regularisations/regularisation.service.ts
+++ b/frontend/src/app/core/regularisations/regularisation.service.ts
@@ -1,0 +1,14 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { RegularisationsResponse } from './regularisation.models';
+
+@Injectable({ providedIn: 'root' })
+export class RegularisationService {
+  private readonly http = inject(HttpClient);
+
+  getMyRegularisations(): Observable<RegularisationsResponse> {
+    return this.http.get<RegularisationsResponse>(`${environment.apiBaseUrl}/me/regularisations`);
+  }
+}

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.html
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.html
@@ -14,10 +14,10 @@
           <p class="feedback-title is-error">Création impossible</p>
           <p class="feedback-message is-error">{{ globalErrorMessage() }}</p>
 
-          @if (backendErrorDetails().length > 0) {
+          @if (friendlyErrorDetails().length > 0) {
             <ul class="feedback-details">
-              @for (detail of backendErrorDetails(); track detail[0]) {
-                <li><strong>{{ detail[0] }}</strong> : {{ detail[1] }}</li>
+              @for (detail of friendlyErrorDetails(); track detail.key) {
+                <li>{{ detail.message }}</li>
               }
             </ul>
           }

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.ts
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.ts
@@ -17,6 +17,11 @@ interface ApiErrorBody {
   details?: Record<string, string>;
 }
 
+interface FriendlyErrorDetail {
+  key: string;
+  message: string;
+}
+
 @Component({
   selector: 'app-create-match-page',
   standalone: true,
@@ -40,6 +45,7 @@ export class CreateMatchPageComponent implements OnInit {
   protected readonly successMessage = signal('');
   protected readonly createdMatch = signal<CreatedMatch | null>(null);
   protected readonly backendFieldErrors = signal<Record<string, string>>({});
+  protected readonly friendlyErrorDetails = signal<FriendlyErrorDetail[]>([]);
   protected readonly timeSlots = this.buildTimeSlots();
 
   protected readonly form = this.fb.nonNullable.group({
@@ -58,6 +64,7 @@ export class CreateMatchPageComponent implements OnInit {
       .subscribe((siteId) => {
         this.form.controls.terrainId.reset(null);
         this.backendFieldErrors.set({});
+        this.friendlyErrorDetails.set([]);
 
         if (siteId == null) {
           this.form.controls.terrainId.disable();
@@ -85,6 +92,7 @@ export class CreateMatchPageComponent implements OnInit {
     this.successMessage.set('');
     this.createdMatch.set(null);
     this.backendFieldErrors.set({});
+    this.friendlyErrorDetails.set([]);
 
     if (this.isLoadingSites() || this.isLoadingTerrains() || this.isSubmitting()) {
       return;
@@ -193,10 +201,6 @@ export class CreateMatchPageComponent implements OnInit {
     return this.backendFieldErrors()['dateDebut'] ?? '';
   }
 
-  protected backendErrorDetails(): Array<[string, string]> {
-    return Object.entries(this.backendFieldErrors());
-  }
-
   private loadSites(): void {
     this.isLoadingSites.set(true);
     this.globalErrorMessage.set('');
@@ -267,6 +271,12 @@ export class CreateMatchPageComponent implements OnInit {
 
     if (apiError.details) {
       this.backendFieldErrors.set(apiError.details);
+      this.friendlyErrorDetails.set(this.mapFriendlyErrorDetails(apiError.details));
+
+      if (apiError.details['dateDebut']) {
+        this.globalErrorMessage.set('Impossible de créer ce match.');
+        return;
+      }
     }
 
     if (apiError.message) {
@@ -296,6 +306,19 @@ export class CreateMatchPageComponent implements OnInit {
     }
 
     return {};
+  }
+
+  private mapFriendlyErrorDetails(details: Record<string, string>): FriendlyErrorDetail[] {
+    const friendlyDetails: FriendlyErrorDetail[] = [];
+
+    if (details['dateDebut']) {
+      friendlyDetails.push({
+        key: 'dateDebut',
+        message: 'La date et l’heure du match doivent être dans le futur.'
+      });
+    }
+
+    return friendlyDetails;
   }
 
   private buildTimeSlots(): string[] {

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.css
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.css
@@ -231,6 +231,16 @@ dd {
   cursor: wait;
 }
 
+.already-joined-message {
+  display: inline-flex;
+  margin: 1rem 0 0;
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  background: #dcfce7;
+  color: #166534;
+  font-weight: 700;
+}
+
 .private-add-section {
   margin-bottom: 1rem;
 }

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.html
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.html
@@ -112,8 +112,10 @@
             [disabled]="isJoining()"
             (click)="joinPublicMatch()"
           >
-            {{ isJoining() ? 'Inscription en cours...' : 'Rejoindre le match' }}
+            {{ isJoining() ? 'Inscription en cours...' : 'Rejoindre et payer' }}
           </button>
+        } @else if (isAlreadyParticipant()) {
+          <p class="already-joined-message">Déjà inscrit</p>
         }
       </article>
 

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.ts
@@ -2,10 +2,12 @@ import { CommonModule, CurrencyPipe, DatePipe, Location } from '@angular/common'
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { finalize } from 'rxjs';
+import { finalize, forkJoin } from 'rxjs';
 import { MatchParticipationService } from '../../../core/matches/match-participation.service';
 import { MatchDetail } from '../../../core/matches/match-detail.models';
 import { MatchDetailService } from '../../../core/matches/match-detail.service';
+import { MeProfile } from '../../../core/me/me.models';
+import { MeService } from '../../../core/me/me.service';
 
 interface ApiErrorBody {
   message?: string;
@@ -25,8 +27,10 @@ export class MatchDetailPageComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly matchDetailService = inject(MatchDetailService);
   private readonly matchParticipationService = inject(MatchParticipationService);
+  private readonly meService = inject(MeService);
 
   protected readonly match = signal<MatchDetail | null>(null);
+  protected readonly currentProfile = signal<MeProfile | null>(null);
   protected readonly isLoading = signal(true);
   protected readonly errorMessage = signal('');
   protected readonly isJoining = signal(false);
@@ -40,11 +44,22 @@ export class MatchDetailPageComponent implements OnInit {
   protected readonly addPrivateErrorDetails = signal<Record<string, string> | null>(null);
   protected readonly canShowJoinButton = computed(() => {
     const detail = this.match();
+    const currentProfile = this.currentProfile();
 
     return !!detail
+      && !!currentProfile
       && detail.visibilite === 'PUBLIC'
       && detail.statut === 'PLANIFIE'
-      && detail.complet === false;
+      && detail.complet === false
+      && !detail.participants.some((participant) => participant.matricule === currentProfile.matricule);
+  });
+  protected readonly isAlreadyParticipant = computed(() => {
+    const detail = this.match();
+    const currentProfile = this.currentProfile();
+
+    return !!detail
+      && !!currentProfile
+      && detail.participants.some((participant) => participant.matricule === currentProfile.matricule);
   });
   protected readonly canShowPrivateAddForm = computed(() => this.match()?.peutAjouterJoueurPrive === true);
 
@@ -86,7 +101,7 @@ export class MatchDetailPageComponent implements OnInit {
       .pipe(finalize(() => this.isJoining.set(false)))
       .subscribe({
         next: () => {
-          this.joinSuccessMessage.set('Vous avez rejoint le match avec succ\u00e8s.');
+          this.joinSuccessMessage.set('Vous avez rejoint le match et pay\u00e9 votre participation avec succ\u00e8s.');
           this.loadMatchDetail(detail.id);
         },
         error: (error: HttpErrorResponse) => {
@@ -161,12 +176,15 @@ export class MatchDetailPageComponent implements OnInit {
     this.isLoading.set(true);
     this.errorMessage.set('');
 
-    this.matchDetailService
-      .getMatchDetail(id)
+    forkJoin({
+      match: this.matchDetailService.getMatchDetail(id),
+      profile: this.meService.getMe()
+    })
       .pipe(finalize(() => this.isLoading.set(false)))
       .subscribe({
-        next: (match) => {
+        next: ({ match, profile }) => {
           this.match.set(match);
+          this.currentProfile.set(profile);
         },
         error: (error: HttpErrorResponse) => {
           this.handleLoadError(error);

--- a/frontend/src/app/features/matches/public-matches/public-matches-page.component.ts
+++ b/frontend/src/app/features/matches/public-matches/public-matches-page.component.ts
@@ -100,7 +100,16 @@ export class PublicMatchesPageComponent implements OnInit {
   }
 
   protected getDetailLinkLabel(match: PublicMatch): string {
-    return this.isMatchJoinable(match) ? 'Voir le d\u00e9tail / rejoindre' : 'Voir le d\u00e9tail';
+    if (!this.isMatchJoinable(match)) {
+      return 'Voir le d\u00e9tail';
+    }
+
+    const montant = new Intl.NumberFormat('fr-BE', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    }).format(match.montantParJoueur);
+
+    return `Voir le d\u00e9tail / rejoindre et payer ${montant} \u20ac`;
   }
 
   protected getMatchBadgeLabel(match: PublicMatch): string {

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.css
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.css
@@ -48,6 +48,12 @@
   background: #fef2f2;
 }
 
+.page-state.is-success {
+  border-color: #86efac;
+  color: #166534;
+  background: #f0fdf4;
+}
+
 .page-grid {
   display: grid;
   gap: 1rem;
@@ -114,6 +120,29 @@
   color: #526277;
 }
 
+.traceable-total {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0 0 0.75rem;
+  color: #526277;
+}
+
+.traceable-total strong {
+  color: #10233f;
+  font-size: 1.1rem;
+}
+
+.traceable-warning {
+  margin: 0 0 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid #fcd34d;
+  border-radius: 0.5rem;
+  background: #fffbeb;
+  color: #92400e;
+}
+
 .empty-regularizations {
   margin: 0;
   color: #526277;
@@ -129,6 +158,13 @@
   border: 1px solid #d7e0eb;
   border-radius: 0.75rem;
   background: #f8fbff;
+}
+
+.regularization-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem 1.25rem;
+  align-items: end;
 }
 
 .regularization-site {
@@ -176,32 +212,58 @@
   color: #374151;
 }
 
-.regularization-amounts {
+.regularization-payment {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
-  gap: 0.75rem 1rem;
+  gap: 0.85rem;
+  min-width: 14rem;
 }
 
-.amount-item {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.75rem;
+.payment-amount {
   margin: 0;
+  display: grid;
+  gap: 0.25rem;
+  text-align: right;
   color: #526277;
 }
 
-.amount-item span {
+.payment-amount span {
   font-size: 0.9rem;
 }
 
-.amount-item strong {
-  color: #10233f;
-  font-size: 1rem;
+.payment-amount strong {
+  color: #92400e;
+  font-size: 1.15rem;
 }
 
-.amount-item.is-remaining strong {
-  color: #92400e;
+.pay-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 8rem;
+  min-height: 2.75rem;
+  padding: 0.8rem 1rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.pay-button:hover:not(:disabled) {
+  filter: brightness(0.96);
+}
+
+.pay-button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.payment-unavailable {
+  margin: 0;
+  color: #526277;
+  font-size: 0.92rem;
+  text-align: right;
 }
 
 .shortcuts {
@@ -236,6 +298,20 @@
 
   .info-section {
     padding: 1.25rem;
+  }
+
+  .regularization-main {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .payment-amount,
+  .payment-unavailable {
+    text-align: left;
+  }
+
+  .pay-button {
+    width: 100%;
   }
 
   .shortcut-link {

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.html
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.html
@@ -48,40 +48,73 @@
       </section>
 
       <section class="info-section">
-        <h2>Participations non totalement pay&eacute;es</h2>
-        <p class="section-note">
-          Ces montants indiquent les participations qui ne sont pas totalement pay&eacute;es. Ils ne constituent
-          pas forc&eacute;ment le d&eacute;tail exact du solde global.
-        </p>
+        <h2>Matchs &agrave; payer</h2>
 
-        @if (unpaidMatches().length === 0) {
-          <p class="empty-regularizations">Aucune participation non totalement pay&eacute;e.</p>
+        @if (hasRegularisations()) {
+          <p class="section-note">Voici les matchs pour lesquels un paiement est encore attendu.</p>
+        }
+
+        @if (hasRegularisations()) {
+          <p class="traceable-total">
+            <span>Total &agrave; payer identifi&eacute;</span>
+            <strong>{{ formatAmount(totalTracable()) }}</strong>
+          </p>
+        }
+
+        @if (hasTraceableGap()) {
+          <p class="traceable-warning">
+            Une partie de votre solde peut concerner d&rsquo;anciens mouvements non d&eacute;taill&eacute;s ici.
+          </p>
+        }
+
+        @if (paymentSuccessMessage()) {
+          <p class="page-state is-success">{{ paymentSuccessMessage() }}</p>
+        }
+
+        @if (paymentErrorMessage()) {
+          <p class="page-state is-error">{{ paymentErrorMessage() }}</p>
+        }
+
+        @if (!hasRegularisations()) {
+          <p class="empty-regularizations">Tous vos paiements sont &agrave; jour.</p>
+          <p class="empty-regularizations">Aucun match ne n&eacute;cessite de paiement pour le moment.</p>
         } @else {
           <div class="regularization-list">
-            @for (match of unpaidMatches(); track match.participationId) {
+            @for (regularisation of regularisationItems(); track regularisation.participationId) {
               <article class="regularization-card">
-                <div class="regularization-summary">
-                  <p class="regularization-site">{{ match.siteNom }}</p>
-                  <h3>{{ match.terrainNom }}</h3>
-                  <p class="regularization-datetime">
-                    {{ match.dateDebut | date:'dd/MM/yyyy' }} &agrave; {{ match.dateDebut | date:'HH:mm' }}
-                  </p>
+                <div class="regularization-main">
+                  <div class="regularization-summary">
+                    <p class="regularization-site">{{ regularisation.siteNom }}</p>
+                    <h3>{{ regularisation.terrainNom }}</h3>
+                    <p class="regularization-datetime">
+                      {{ regularisation.dateMatch | date:'dd/MM/yyyy' }} &agrave;
+                      {{ regularisation.dateMatch | date:'HH:mm' }}
+                    </p>
 
-                  <div class="regularization-badges">
-                    <span class="meta-badge">{{ match.visibilite }}</span>
-                    <span class="meta-badge is-secondary">{{ match.roleJoueur }}</span>
+                    <div class="regularization-badges">
+                      <span class="meta-badge">{{ regularisation.visibilite }}</span>
+                      <span class="meta-badge is-secondary">{{ getRoleLabel(regularisation.roleJoueur) }}</span>
+                    </div>
                   </div>
-                </div>
 
-                <div class="regularization-amounts">
-                  <p class="amount-item">
-                    <span>D&eacute;j&agrave; pay&eacute;</span>
-                    <strong>{{ formatAmount(match.montantPayeJoueur) }}</strong>
-                  </p>
-                  <p class="amount-item is-remaining">
-                    <span>Reste th&eacute;orique</span>
-                    <strong>{{ formatAmount(match.montantRestantJoueur) }}</strong>
-                  </p>
+                  <div class="regularization-payment">
+                    <p class="payment-amount">
+                      <span>Montant &agrave; payer</span>
+                      <strong>{{ formatAmount(regularisation.montantRestant) }}</strong>
+                    </p>
+
+                    @if (regularisation.payable) {
+                      <button
+                        type="button"
+                        class="pay-button"
+                        [disabled]="isPaying(regularisation.participationId)"
+                        (click)="payerRegularisation(regularisation)">
+                        {{ isPaying(regularisation.participationId) ? 'Paiement en cours...' : 'Payer' }}
+                      </button>
+                    } @else {
+                      <p class="payment-unavailable">Paiement indisponible</p>
+                    }
+                  </div>
                 </div>
               </article>
             }

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.ts
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.ts
@@ -3,10 +3,12 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { finalize, forkJoin } from 'rxjs';
-import { PlayerMatchSummary } from '../../../core/matches/player-match-summary.models';
-import { PlayerMatchesService } from '../../../core/matches/player-matches.service';
 import { MeProfile } from '../../../core/me/me.models';
 import { MeService } from '../../../core/me/me.service';
+import { PaiementService } from '../../../core/payments/paiement.service';
+import { Regularisation } from '../../../core/regularisations/regularisation.models';
+import { RegularisationsResponse } from '../../../core/regularisations/regularisation.models';
+import { RegularisationService } from '../../../core/regularisations/regularisation.service';
 
 @Component({
   selector: 'app-espace-prive-page',
@@ -17,20 +19,31 @@ import { MeService } from '../../../core/me/me.service';
 })
 export class EspacePrivePageComponent implements OnInit {
   private readonly meService = inject(MeService);
-  private readonly playerMatchesService = inject(PlayerMatchesService);
+  private readonly regularisationService = inject(RegularisationService);
+  private readonly paiementService = inject(PaiementService);
 
   protected readonly profile = signal<MeProfile | null>(null);
-  protected readonly matches = signal<PlayerMatchSummary[]>([]);
+  protected readonly regularisations = signal<RegularisationsResponse>({
+    totalTracable: 0,
+    items: []
+  });
   protected readonly isLoading = signal(true);
   protected readonly errorMessage = signal('');
+  protected readonly paymentSuccessMessage = signal('');
+  protected readonly paymentErrorMessage = signal('');
+  protected readonly payingParticipationId = signal<number | null>(null);
 
   protected readonly hasDebt = computed(() => {
     const profile = this.profile();
     return profile != null && profile.solde > 0;
   });
-  protected readonly unpaidMatches = computed(() =>
-    this.matches().filter((match) => match.montantRestantJoueur > 0)
-  );
+  protected readonly regularisationItems = computed(() => this.regularisations().items);
+  protected readonly totalTracable = computed(() => this.regularisations().totalTracable);
+  protected readonly hasTraceableGap = computed(() => {
+    const profile = this.profile();
+    return profile != null && this.totalTracable() < profile.solde;
+  });
+  protected readonly hasRegularisations = computed(() => this.regularisationItems().length > 0);
 
   protected readonly debtMessage = computed(() => {
     const profile = this.profile();
@@ -61,6 +74,10 @@ export class EspacePrivePageComponent implements OnInit {
     }
   }
 
+  protected getRoleLabel(role: 'ORGANISATEUR' | 'PARTICIPANT'): string {
+    return role === 'ORGANISATEUR' ? 'Organisateur' : 'Participant';
+  }
+
   protected formatAmount(amount: number): string {
     return new Intl.NumberFormat('fr-BE', {
       minimumFractionDigits: 2,
@@ -68,19 +85,48 @@ export class EspacePrivePageComponent implements OnInit {
     }).format(amount) + ' \u20ac';
   }
 
+  protected isPaying(participationId: number): boolean {
+    return this.payingParticipationId() === participationId;
+  }
+
+  protected payerRegularisation(regularisation: Regularisation): void {
+    if (!regularisation.payable || this.isPaying(regularisation.participationId)) {
+      return;
+    }
+
+    this.paymentSuccessMessage.set('');
+    this.paymentErrorMessage.set('');
+    this.payingParticipationId.set(regularisation.participationId);
+
+    this.paiementService
+      .payerParticipation(regularisation.participationId, regularisation.montantRestant)
+      .pipe(finalize(() => this.payingParticipationId.set(null)))
+      .subscribe({
+        next: () => {
+          this.paymentSuccessMessage.set('Paiement enregistré avec succès.');
+          this.reloadFinancialData();
+        },
+        error: (error: HttpErrorResponse) => {
+          this.paymentErrorMessage.set(this.getPaymentErrorMessage(error));
+        }
+      });
+  }
+
   private loadPageData(): void {
     this.isLoading.set(true);
     this.errorMessage.set('');
+    this.paymentSuccessMessage.set('');
+    this.paymentErrorMessage.set('');
 
     forkJoin({
       profile: this.meService.getMe(),
-      matches: this.playerMatchesService.getMyMatches()
+      regularisations: this.regularisationService.getMyRegularisations()
     })
       .pipe(finalize(() => this.isLoading.set(false)))
       .subscribe({
-        next: ({ profile, matches }) => {
+        next: ({ profile, regularisations }) => {
           this.profile.set(profile);
-          this.matches.set(matches);
+          this.regularisations.set(regularisations);
         },
         error: (error: HttpErrorResponse) => {
           if (error.status === 0) {
@@ -91,5 +137,35 @@ export class EspacePrivePageComponent implements OnInit {
           this.errorMessage.set('Impossible de charger votre espace.');
         }
       });
+  }
+
+  private reloadFinancialData(): void {
+    forkJoin({
+      profile: this.meService.getMe(),
+      regularisations: this.regularisationService.getMyRegularisations()
+    }).subscribe({
+      next: ({ profile, regularisations }) => {
+        this.profile.set(profile);
+        this.regularisations.set(regularisations);
+      },
+      error: () => {
+        this.paymentErrorMessage.set('Le paiement a été enregistré, mais la mise à jour de l’espace a échoué.');
+      }
+    });
+  }
+
+  private getPaymentErrorMessage(error: HttpErrorResponse): string {
+    if (error.status === 0) {
+      return 'Backend inaccessible.';
+    }
+
+    const backendMessage =
+      typeof error.error?.message === 'string'
+        ? error.error.message
+        : typeof error.error?.error === 'string'
+          ? error.error.error
+          : '';
+
+    return backendMessage || 'Impossible d’enregistrer le paiement.';
   }
 }


### PR DESCRIPTION
- ajout des modèles et du service frontend de régularisations ;
- remplacement de l’ancienne source /me/matchs par /me/regularisations ;
- affichage d’une section Matchs à payer orientée joueur ;
- affichage du montant à payer par match ;
- ajout du bouton Payer uniquement si la ligne est payable ;
- paiement via POST /api/v1/participations/{participationId}/paiements ;
- rechargement du solde et de la liste après paiement ;
- affichage d’un état vide clair quand tout est payé ;
- message de clarification si une partie du solde global n’est pas détaillée.