### PR TITLE
feat(auth): ajouter la demande d'inscription joueur

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                     auth
                             .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                             .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").permitAll()
+                            .requestMatchers(HttpMethod.GET, "/api/v1/sites/**").permitAll()
                             .requestMatchers("/api/v1/admin/inscriptions/**").hasRole("ADMIN_GLOBAL")
                             .requestMatchers("/api/v1/admin/stats/**").hasRole("ADMIN_GLOBAL")
                             .requestMatchers("/api/v1/admin/sites/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/SiteControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/SiteControllerTest.java
@@ -39,6 +39,7 @@ class SiteControllerTest {
     SiteService siteService;
 
     @Test
+    @WithAnonymousUser
     void list_ok_200_jsonArray() throws Exception {
         Site s1 = org.mockito.Mockito.mock(Site.class);
         when(s1.getId()).thenReturn(1L);
@@ -64,6 +65,7 @@ class SiteControllerTest {
     }
 
     @Test
+    @WithAnonymousUser
     void getOne_ok_200_json() throws Exception {
         Site s = org.mockito.Mockito.mock(Site.class);
         when(s.getId()).thenReturn(10L);

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { authGuard } from './core/auth/auth.guard';
 import { LoginPageComponent } from './features/auth/login/login-page.component';
+import { RegisterPageComponent } from './features/auth/register/register-page.component';
 import { AdminPageComponent } from './features/admin/admin-page.component';
 import { HomePageComponent } from './features/home/home-page.component';
 import { CreateMatchPageComponent } from './features/matches/create-match/create-match-page.component';
@@ -18,6 +19,7 @@ export const routes: Routes = [
     children: [
       { path: '', component: HomePageComponent },
       { path: 'login', component: LoginPageComponent },
+      { path: 'inscription', component: RegisterPageComponent },
       { path: 'espace-prive', component: EspacePrivePageComponent, canActivate: [authGuard] },
       { path: 'matchs/creer', component: CreateMatchPageComponent, canActivate: [authGuard] },
       { path: 'matchs/:id', component: MatchDetailPageComponent, canActivate: [authGuard] },

--- a/frontend/src/app/core/auth/auth.models.ts
+++ b/frontend/src/app/core/auth/auth.models.ts
@@ -1,4 +1,5 @@
 export type AuthRole = 'ROLE_JOUEUR' | 'ROLE_ADMIN_SITE' | 'ROLE_ADMIN_GLOBAL';
+export type PlayerSubscriptionType = 'GLOBAL' | 'SITE' | 'LIBRE';
 
 export interface LoginRequest {
   username: string;
@@ -15,6 +16,21 @@ export interface LoginResponse {
 export interface StoredAuthContext {
   roles: AuthRole[];
   hasPlayerProfile: boolean;
+}
+
+export interface RegisterRequest {
+  username: string;
+  password: string;
+  nom: string;
+  typeAbonnementDemande: PlayerSubscriptionType;
+  siteIdDemande?: number;
+}
+
+export interface RegisterResponse {
+  userId: number;
+  username: string;
+  status: string;
+  message: string;
 }
 
 export interface ApiErrorResponse {

--- a/frontend/src/app/core/auth/auth.service.ts
+++ b/frontend/src/app/core/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { computed, inject, Injectable, signal } from '@angular/core';
 import { Observable, tap } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { AuthRole, LoginRequest, LoginResponse, StoredAuthContext } from './auth.models';
+import { AuthRole, LoginRequest, LoginResponse, RegisterRequest, RegisterResponse, StoredAuthContext } from './auth.models';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -18,6 +18,10 @@ export class AuthService {
     return this.http
       .post<LoginResponse>(`${environment.apiBaseUrl}/auth/login`, payload)
       .pipe(tap((response) => this.storeSession(response)));
+  }
+
+  register(payload: RegisterRequest): Observable<RegisterResponse> {
+    return this.http.post<RegisterResponse>(`${environment.apiBaseUrl}/auth/register`, payload);
   }
 
   getToken(): string | null {

--- a/frontend/src/app/features/auth/login/login-page.component.ts
+++ b/frontend/src/app/features/auth/login/login-page.component.ts
@@ -68,6 +68,13 @@ export class LoginPageComponent {
     }
 
     if (error.status === 403 && apiError?.message) {
+      if (
+        apiError.message.toLowerCase().includes('attente') &&
+        apiError.message.toLowerCase().includes('validation')
+      ) {
+        return 'Votre compte est en attente de validation par un administrateur.';
+      }
+
       return apiError.message;
     }
 

--- a/frontend/src/app/features/auth/register/register-page.component.css
+++ b/frontend/src/app/features/auth/register/register-page.component.css
@@ -1,0 +1,185 @@
+.register-page {
+  display: flex;
+  justify-content: center;
+  padding: 4rem 1.5rem;
+}
+
+.register-card {
+  width: min(100%, 36rem);
+  display: grid;
+  gap: 1.25rem;
+  padding: 2rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
+.eyebrow {
+  margin: 0;
+  color: #0f766e;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+h1 {
+  margin: 0;
+  color: #10233f;
+  font-size: 2rem;
+}
+
+.register-subtitle,
+.success-detail,
+.form-note {
+  margin: 0;
+  color: #526277;
+  line-height: 1.6;
+}
+
+.register-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.45rem;
+  color: #10233f;
+  font-weight: 600;
+}
+
+input,
+select {
+  width: 100%;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid #c3d0de;
+  border-radius: 0.75rem;
+  font: inherit;
+  background: #ffffff;
+}
+
+input:focus,
+select:focus {
+  outline: 2px solid #8fd3c1;
+  outline-offset: 2px;
+}
+
+select:disabled {
+  background: #f3f6fa;
+  color: #7a8899;
+}
+
+.password-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-field input {
+  padding-right: 3rem;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: #526277;
+  font: inherit;
+  cursor: pointer;
+}
+
+.password-toggle:hover {
+  background: rgba(15, 118, 110, 0.08);
+  color: #10233f;
+}
+
+.password-toggle:focus-visible {
+  outline: 2px solid #8fd3c1;
+  outline-offset: 2px;
+}
+
+.field-hint,
+.field-error {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.field-hint {
+  color: #526277;
+  font-weight: 400;
+}
+
+.field-error,
+.error-message {
+  color: #b91c1c;
+}
+
+.error-message {
+  margin: 0;
+  padding: 0.8rem 0.9rem;
+  border-radius: 0.75rem;
+  background: #fef2f2;
+}
+
+.form-actions,
+.success-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.primary-action,
+.secondary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.8rem 1rem;
+  border-radius: 0.5rem;
+  border: 0;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.primary-action {
+  background: #10233f;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.primary-action:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.secondary-action {
+  border: 1px solid #c7d3e0;
+  background: #f8fbff;
+  color: #10233f;
+}
+
+@media (max-width: 640px) {
+  .register-page {
+    padding: 2rem 1rem;
+  }
+
+  .register-card {
+    padding: 1.5rem;
+  }
+
+  .form-actions,
+  .success-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/app/features/auth/register/register-page.component.html
+++ b/frontend/src/app/features/auth/register/register-page.component.html
@@ -1,0 +1,135 @@
+<section class="register-page">
+  <div class="register-card">
+    <p class="eyebrow">Padel Manager</p>
+
+    @if (successResponse()) {
+      <h1>Demande envoy&eacute;e</h1>
+      <p class="register-subtitle">
+        Votre compte est en attente de validation par un administrateur.
+      </p>
+      <p class="success-detail">
+        Vous pourrez vous connecter une fois votre inscription valid&eacute;e.
+      </p>
+
+      <div class="success-actions">
+        <a routerLink="/" class="secondary-action">Retour &agrave; l&rsquo;accueil</a>
+        <a routerLink="/login" class="primary-action">Aller &agrave; la connexion</a>
+      </div>
+    } @else {
+      <h1>Demande d&rsquo;inscription</h1>
+      <p class="register-subtitle">
+        Remplissez ce formulaire pour demander l&rsquo;acc&egrave;s &agrave; l&rsquo;espace joueur. Votre demande restera en attente de validation.
+      </p>
+
+      <form class="register-form" [formGroup]="form" (ngSubmit)="onSubmit()">
+        <label class="field">
+          <span>Nom</span>
+          <input type="text" formControlName="nom" autocomplete="name" />
+          @if (showFieldError('nom')) {
+            <small class="field-error">Le nom est obligatoire.</small>
+          }
+        </label>
+
+        <label class="field">
+          <span>Login</span>
+          <input type="text" formControlName="username" autocomplete="username" />
+          @if (showFieldError('username')) {
+            <small class="field-error">Le login est obligatoire.</small>
+          }
+        </label>
+
+        <label class="field">
+          <span>Mot de passe</span>
+          <div class="password-field">
+            <input
+              [type]="showPassword() ? 'text' : 'password'"
+              formControlName="password"
+              autocomplete="new-password"
+            />
+            <button
+              type="button"
+              class="password-toggle"
+              [attr.aria-label]="showPassword() ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+              (click)="togglePasswordVisibility()"
+            >
+              &#128065;
+            </button>
+          </div>
+          @if (showFieldError('password')) {
+            <small class="field-error">Le mot de passe est obligatoire.</small>
+          }
+        </label>
+
+        <label class="field">
+          <span>Confirmation du mot de passe</span>
+          <div class="password-field">
+            <input
+              [type]="showConfirmPassword() ? 'text' : 'password'"
+              formControlName="confirmPassword"
+              autocomplete="new-password"
+            />
+            <button
+              type="button"
+              class="password-toggle"
+              [attr.aria-label]="showConfirmPassword() ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+              (click)="toggleConfirmPasswordVisibility()"
+            >
+              &#128065;
+            </button>
+          </div>
+          @if (showFieldError('confirmPassword')) {
+            <small class="field-error">La confirmation du mot de passe est obligatoire.</small>
+          } @else if (showPasswordMismatchError()) {
+            <small class="field-error">Les mots de passe doivent &ecirc;tre identiques.</small>
+          }
+        </label>
+
+        <label class="field">
+          <span>Type de membre demand&eacute;</span>
+          <select formControlName="typeAbonnementDemande">
+            @for (playerType of playerTypes; track playerType.value) {
+              <option [value]="playerType.value">{{ playerType.label }}</option>
+            }
+          </select>
+        </label>
+
+        @if (isSiteTypeSelected()) {
+          <label class="field">
+            <span>Site demand&eacute;</span>
+            <select formControlName="siteIdDemande" [disabled]="isLoadingSites() || sites().length === 0">
+              <option [ngValue]="null">S&eacute;lectionnez un site</option>
+              @for (site of sites(); track site.id) {
+                <option [ngValue]="site.id">{{ site.nom }} - {{ site.ville }}</option>
+              }
+            </select>
+
+            @if (isLoadingSites()) {
+              <small class="field-hint">Chargement des sites...</small>
+            } @else if (sitesErrorMessage()) {
+              <small class="field-error">{{ sitesErrorMessage() }}</small>
+            } @else if (showFieldError('siteIdDemande')) {
+              <small class="field-error">
+                Veuillez s&eacute;lectionner un site pour une demande de type membre d&rsquo;un site.
+              </small>
+            }
+          </label>
+        }
+
+        @if (errorMessage()) {
+          <p class="error-message">{{ errorMessage() }}</p>
+        }
+
+        <p class="form-note">
+          Votre compte ne sera pas actif imm&eacute;diatement. Un administrateur devra valider votre demande avant toute connexion.
+        </p>
+
+        <div class="form-actions">
+          <a routerLink="/" class="secondary-action">Retour &agrave; l&rsquo;accueil</a>
+          <button type="submit" class="primary-action" [disabled]="isSubmitting()">
+            {{ isSubmitting() ? 'Envoi en cours...' : 'Envoyer ma demande' }}
+          </button>
+        </div>
+      </form>
+    }
+  </div>
+</section>

--- a/frontend/src/app/features/auth/register/register-page.component.ts
+++ b/frontend/src/app/features/auth/register/register-page.component.ts
@@ -1,0 +1,253 @@
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { finalize } from 'rxjs';
+import {
+  ApiErrorResponse,
+  PlayerSubscriptionType,
+  RegisterRequest,
+  RegisterResponse
+} from '../../../core/auth/auth.models';
+import { AuthService } from '../../../core/auth/auth.service';
+import { SiteOption } from '../../../core/sites/site.models';
+import { SitesService } from '../../../core/sites/sites.service';
+
+@Component({
+  selector: 'app-register-page',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './register-page.component.html',
+  styleUrl: './register-page.component.css'
+})
+export class RegisterPageComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+  private readonly sitesService = inject(SitesService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly isSubmitting = signal(false);
+  protected readonly isLoadingSites = signal(true);
+  protected readonly sites = signal<SiteOption[]>([]);
+  protected readonly errorMessage = signal('');
+  protected readonly sitesErrorMessage = signal('');
+  protected readonly successResponse = signal<RegisterResponse | null>(null);
+  protected readonly showPassword = signal(false);
+  protected readonly showConfirmPassword = signal(false);
+
+  protected readonly playerTypes: Array<{ value: PlayerSubscriptionType; label: string }> = [
+    { value: 'GLOBAL', label: 'Membre global - accès à tous les sites' },
+    { value: 'SITE', label: 'Membre d’un site - rattachement à un site spécifique' },
+    { value: 'LIBRE', label: 'Membre libre - accès selon les délais de réservation' }
+  ];
+
+  protected readonly form = this.fb.group(
+    {
+      nom: this.fb.nonNullable.control('', [Validators.required, Validators.maxLength(255)]),
+      username: this.fb.nonNullable.control('', [Validators.required, Validators.maxLength(100)]),
+      password: this.fb.nonNullable.control('', [Validators.required, Validators.maxLength(255)]),
+      confirmPassword: this.fb.nonNullable.control('', [Validators.required]),
+      typeAbonnementDemande: this.fb.nonNullable.control<PlayerSubscriptionType>('GLOBAL', [Validators.required]),
+      siteIdDemande: this.fb.control<number | null>(null)
+    },
+    { validators: passwordMatchValidator() }
+  );
+
+  ngOnInit(): void {
+    this.loadSites();
+    this.watchTypeChanges();
+  }
+
+  protected onSubmit(): void {
+    this.applySiteValidator();
+
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isSubmitting.set(true);
+    this.errorMessage.set('');
+
+    this.authService
+      .register(this.buildPayload())
+      .pipe(finalize(() => this.isSubmitting.set(false)))
+      .subscribe({
+        next: (response) => {
+          this.successResponse.set(response);
+          this.form.reset({
+            nom: '',
+            username: '',
+            password: '',
+            confirmPassword: '',
+            typeAbonnementDemande: 'GLOBAL',
+            siteIdDemande: null
+          });
+          this.form.markAsPristine();
+          this.form.markAsUntouched();
+        },
+        error: (error: HttpErrorResponse) => {
+          this.errorMessage.set(this.buildErrorMessage(error));
+        }
+      });
+  }
+
+  protected togglePasswordVisibility(): void {
+    this.showPassword.update((value) => !value);
+  }
+
+  protected toggleConfirmPasswordVisibility(): void {
+    this.showConfirmPassword.update((value) => !value);
+  }
+
+  protected isSiteTypeSelected(): boolean {
+    return this.form.controls.typeAbonnementDemande.value === 'SITE';
+  }
+
+  protected showFieldError(fieldName: 'nom' | 'username' | 'password' | 'confirmPassword' | 'siteIdDemande'): boolean {
+    const control = this.form.controls[fieldName];
+    return control.invalid && (control.touched || control.dirty);
+  }
+
+  protected showPasswordMismatchError(): boolean {
+    return this.form.hasError('passwordMismatch') && this.form.controls.confirmPassword.touched;
+  }
+
+  private loadSites(): void {
+    this.isLoadingSites.set(true);
+    this.sitesErrorMessage.set('');
+
+    this.sitesService
+      .getSites()
+      .pipe(finalize(() => this.isLoadingSites.set(false)))
+      .subscribe({
+        next: (sites) => {
+          this.sites.set(sites);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.sites.set([]);
+          this.sitesErrorMessage.set(this.buildSitesErrorMessage(error));
+        }
+      });
+  }
+
+  private watchTypeChanges(): void {
+    this.form.controls.typeAbonnementDemande.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.errorMessage.set('');
+        this.applySiteValidator();
+      });
+  }
+
+  private applySiteValidator(): void {
+    const siteControl = this.form.controls.siteIdDemande;
+
+    if (this.isSiteTypeSelected()) {
+      siteControl.setValidators([Validators.required]);
+    } else {
+      siteControl.clearValidators();
+      siteControl.setValue(null);
+    }
+
+    siteControl.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private buildPayload(): RegisterRequest {
+    const rawValue = this.form.getRawValue();
+    const payload: RegisterRequest = {
+      nom: rawValue.nom.trim(),
+      username: rawValue.username.trim(),
+      password: rawValue.password,
+      typeAbonnementDemande: rawValue.typeAbonnementDemande
+    };
+
+    if (rawValue.typeAbonnementDemande === 'SITE' && rawValue.siteIdDemande != null) {
+      payload.siteIdDemande = rawValue.siteIdDemande;
+    }
+
+    return payload;
+  }
+
+  private buildErrorMessage(error: HttpErrorResponse): string {
+    const apiError = error.error as ApiErrorResponse | null;
+    const backendMessage = apiError?.message ?? '';
+
+    if (error.status === 0) {
+      return 'Backend inaccessible.';
+    }
+
+    if (error.status === 404) {
+      return 'Le site sélectionné est introuvable.';
+    }
+
+    if (error.status === 400) {
+      if (apiError?.details) {
+        return this.buildValidationDetailsMessage(apiError.details);
+      }
+
+      if (backendMessage.includes('Username') && backendMessage.includes('utilise')) {
+        return 'Ce login est déjà utilisé.';
+      }
+
+      if (backendMessage.includes("siteIdDemande") && backendMessage.includes('obligatoire')) {
+        return 'Veuillez sélectionner un site pour une demande de type membre d’un site.';
+      }
+
+      if (backendMessage.includes("siteIdDemande") && backendMessage.includes('interdit')) {
+        return 'Le site demandé ne correspond pas au type de profil sélectionné.';
+      }
+
+      return backendMessage || 'Demande invalide.';
+    }
+
+    return 'Impossible d’envoyer votre demande pour le moment.';
+  }
+
+  private buildValidationDetailsMessage(details: Record<string, string>): string {
+    if (details['nom']) {
+      return 'Le nom est obligatoire.';
+    }
+
+    if (details['username']) {
+      return 'Le login est obligatoire.';
+    }
+
+    if (details['password']) {
+      return 'Le mot de passe est obligatoire.';
+    }
+
+    if (details['typeAbonnementDemande']) {
+      return 'Le type de profil demandé est obligatoire.';
+    }
+
+    if (details['siteIdDemande']) {
+      return 'Veuillez sélectionner un site.';
+    }
+
+    return 'Certains champs du formulaire sont invalides.';
+  }
+
+  private buildSitesErrorMessage(error: HttpErrorResponse): string {
+    if (error.status === 0) {
+      return 'La liste des sites est momentanément indisponible.';
+    }
+
+    return 'Impossible de charger les sites pour le moment.';
+  }
+}
+
+function passwordMatchValidator(): ValidatorFn {
+  return (control): ValidationErrors | null => {
+    const password = control.get('password')?.value;
+    const confirmPassword = control.get('confirmPassword')?.value;
+
+    if (password === confirmPassword) {
+      return null;
+    }
+
+    return { passwordMismatch: true };
+  };
+}

--- a/frontend/src/app/features/home/home-page.component.html
+++ b/frontend/src/app/features/home/home-page.component.html
@@ -32,7 +32,7 @@
 
       <div class="action-group">
         <a routerLink="/login" class="primary-action">Se connecter</a>
-        <button type="button" class="disabled-action" disabled>Demander une inscription</button>
+        <a routerLink="/inscription" class="secondary-action">Demander une inscription</a>
       </div>
 
       <p class="availability-note">


### PR DESCRIPTION
- ajout de la route /inscription ;
- activation du bouton “Demander une inscription” depuis la page d’accueil ;
- création du formulaire public d’inscription ;
- choix du type de membre demandé :
  - Membre global ;
  - Membre d’un site ;
  - Membre libre ;
- affichage du champ “Site demandé” uniquement pour le type “Membre d’un site” ;
- chargement public de la liste des sites via GET /api/v1/sites ;
- appel à POST /api/v1/auth/register ;
- affichage d’un message de succès indiquant que la demande doit être validée par un administrateur ;
- pas de connexion automatique après inscription ;

Ajustement backend :
- ouverture en lecture de GET /api/v1/sites/**`pour permettre le choix du site dans le formulaire public ;
- les écritures sur les sites restent protégées.