### PR TITLE
feat(admin): lister les demandes d'inscription

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { authGuard } from './core/auth/auth.guard';
 import { LoginPageComponent } from './features/auth/login/login-page.component';
 import { RegisterPageComponent } from './features/auth/register/register-page.component';
+import { AdminRegistrationsPageComponent } from './features/admin/inscriptions/admin-registrations-page.component';
 import { AdminPageComponent } from './features/admin/admin-page.component';
 import { HomePageComponent } from './features/home/home-page.component';
 import { CreateMatchPageComponent } from './features/matches/create-match/create-match-page.component';
@@ -26,7 +27,8 @@ export const routes: Routes = [
       { path: 'me/matchs', component: MyMatchesPageComponent, canActivate: [authGuard] },
       { path: 'me/matchs/organises', component: OrganizedMatchesPageComponent, canActivate: [authGuard] },
       { path: 'matchs', component: PublicMatchesPageComponent, canActivate: [authGuard] },
-      { path: 'admin', component: AdminPageComponent, canActivate: [authGuard] }
+      { path: 'admin', component: AdminPageComponent, canActivate: [authGuard] },
+      { path: 'admin/inscriptions', component: AdminRegistrationsPageComponent, canActivate: [authGuard] }
     ]
   },
   { path: '**', redirectTo: '' }

--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -1,3 +1,13 @@
 export interface AdminInfoResponse {
   status: string;
 }
+
+export interface PendingRegistrationItem {
+  userId: number;
+  username: string;
+  nomDemande: string;
+  typeAbonnementDemande: 'GLOBAL' | 'SITE' | 'LIBRE';
+  siteIdDemande: number | null;
+  siteNomDemande: string | null;
+  status: string;
+}

--- a/frontend/src/app/core/admin/admin.service.ts
+++ b/frontend/src/app/core/admin/admin.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { AdminInfoResponse } from './admin.models';
+import { AdminInfoResponse, PendingRegistrationItem } from './admin.models';
 
 @Injectable({ providedIn: 'root' })
 export class AdminService {
@@ -10,5 +10,9 @@ export class AdminService {
 
   getInfo(): Observable<AdminInfoResponse> {
     return this.http.get<AdminInfoResponse>(`${environment.apiBaseUrl}/admin/info`);
+  }
+
+  getPendingRegistrations(): Observable<PendingRegistrationItem[]> {
+    return this.http.get<PendingRegistrationItem[]>(`${environment.apiBaseUrl}/admin/inscriptions`);
   }
 }

--- a/frontend/src/app/features/admin/admin-page.component.css
+++ b/frontend/src/app/features/admin/admin-page.component.css
@@ -131,9 +131,28 @@
   background: #f8fbff;
 }
 
+.future-card-link {
+  text-decoration: none;
+}
+
+.future-card-link:hover {
+  border-color: #8fd3c1;
+  background: #f0fdf4;
+}
+
+.future-card-link:focus-visible {
+  outline: 2px solid #8fd3c1;
+  outline-offset: 2px;
+}
+
 .future-card-content {
   display: grid;
   gap: 0.5rem;
+}
+
+.future-summary {
+  font-weight: 700;
+  color: #10233f;
 }
 
 .future-badge {
@@ -148,6 +167,11 @@
   color: #374151;
   font-size: 0.82rem;
   font-weight: 700;
+}
+
+.future-badge.is-active {
+  background: #dcfce7;
+  color: #166534;
 }
 
 code {

--- a/frontend/src/app/features/admin/admin-page.component.html
+++ b/frontend/src/app/features/admin/admin-page.component.html
@@ -35,14 +35,27 @@
         </div>
 
         <div class="future-grid">
-          @for (card of shortcutCards; track card.title) {
-            <article class="future-card">
-              <div class="future-card-content">
-                <h3>{{ card.title }}</h3>
-                <p>{{ card.description }}</p>
-              </div>
-              <span class="future-badge">À venir</span>
-            </article>
+          @for (card of shortcutCards(); track card.title) {
+            @if (card.route) {
+              <a [routerLink]="card.route" class="future-card future-card-link">
+                <div class="future-card-content">
+                  <h3>{{ card.title }}</h3>
+                  <p>{{ card.description }}</p>
+                  @if (card.route === '/admin/inscriptions') {
+                    <p class="future-summary">{{ registrationSummary() }}</p>
+                  }
+                </div>
+                <span class="future-badge is-active">Ouvrir</span>
+              </a>
+            } @else {
+              <article class="future-card">
+                <div class="future-card-content">
+                  <h3>{{ card.title }}</h3>
+                  <p>{{ card.description }}</p>
+                </div>
+                <span class="future-badge">&Agrave; venir</span>
+              </article>
+            }
           }
         </div>
       </section>

--- a/frontend/src/app/features/admin/admin-page.component.ts
+++ b/frontend/src/app/features/admin/admin-page.component.ts
@@ -1,20 +1,22 @@
 import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { finalize } from 'rxjs';
 import { AuthService } from '../../core/auth/auth.service';
-import { AdminInfoResponse } from '../../core/admin/admin.models';
+import { AdminInfoResponse, PendingRegistrationItem } from '../../core/admin/admin.models';
 import { AdminService } from '../../core/admin/admin.service';
 
 interface AdminShortcutCard {
   title: string;
   description: string;
+  route?: string;
 }
 
 @Component({
   selector: 'app-admin-page',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterLink],
   templateUrl: './admin-page.component.html',
   styleUrl: './admin-page.component.css'
 })
@@ -23,8 +25,12 @@ export class AdminPageComponent implements OnInit {
   private readonly adminService = inject(AdminService);
 
   protected readonly adminInfo = signal<AdminInfoResponse | null>(null);
+  protected readonly pendingRegistrations = signal<PendingRegistrationItem[]>([]);
   protected readonly isLoading = signal(true);
   protected readonly errorMessage = signal('');
+  protected readonly isLoadingRegistrations = signal(false);
+  protected readonly registrationsError = signal(false);
+  protected readonly canViewRegistrationRequests = computed(() => this.authService.hasRole('ROLE_ADMIN_GLOBAL'));
 
   protected readonly apiStatusMessage = computed(() => {
     const status = this.adminInfo()?.status;
@@ -48,16 +54,59 @@ export class AdminPageComponent implements OnInit {
     return 'P\u00e9rim\u00e8tre : acc\u00e8s administrateur';
   });
 
-  protected readonly shortcutCards: AdminShortcutCard[] = [
-    { title: "Demandes d'inscription", description: 'Module à venir.' },
-    { title: 'Joueurs', description: 'Module à venir.' },
-    { title: 'Fermetures', description: 'Module à venir.' },
-    { title: 'Statistiques', description: 'Module à venir.' },
-    { title: 'Horaires', description: 'Module à venir.' }
-  ];
+  protected readonly registrationSummary = computed(() => {
+    if (!this.canViewRegistrationRequests()) {
+      return '';
+    }
+
+    if (this.isLoadingRegistrations()) {
+      return 'Chargement des demandes...';
+    }
+
+    if (this.registrationsError()) {
+      return 'Demandes non charg\u00e9es';
+    }
+
+    const count = this.pendingRegistrations().length;
+
+    if (count === 0) {
+      return 'Aucune demande en attente de validation';
+    }
+
+    if (count === 1) {
+      return '1 demande en attente de validation';
+    }
+
+    return `${count} demandes en attente de validation`;
+  });
+
+  protected readonly shortcutCards = computed<AdminShortcutCard[]>(() => {
+    const cards: AdminShortcutCard[] = [];
+
+    if (this.canViewRegistrationRequests()) {
+      cards.push({
+        title: "Demandes d'inscription",
+        description: 'Consultez les comptes en attente de validation.',
+        route: '/admin/inscriptions'
+      });
+    }
+
+    cards.push(
+      { title: 'Joueurs', description: 'Module \u00e0 venir.' },
+      { title: 'Fermetures', description: 'Module \u00e0 venir.' },
+      { title: 'Statistiques', description: 'Module \u00e0 venir.' },
+      { title: 'Horaires', description: 'Module \u00e0 venir.' }
+    );
+
+    return cards;
+  });
 
   ngOnInit(): void {
     this.loadAdminInfo();
+
+    if (this.canViewRegistrationRequests()) {
+      this.loadPendingRegistrations();
+    }
   }
 
   protected isApiOperational(): boolean {
@@ -77,6 +126,24 @@ export class AdminPageComponent implements OnInit {
         },
         error: (error: HttpErrorResponse) => {
           this.errorMessage.set(this.getErrorMessage(error));
+        }
+      });
+  }
+
+  private loadPendingRegistrations(): void {
+    this.isLoadingRegistrations.set(true);
+    this.registrationsError.set(false);
+
+    this.adminService
+      .getPendingRegistrations()
+      .pipe(finalize(() => this.isLoadingRegistrations.set(false)))
+      .subscribe({
+        next: (registrations) => {
+          this.pendingRegistrations.set(registrations);
+        },
+        error: () => {
+          this.pendingRegistrations.set([]);
+          this.registrationsError.set(true);
         }
       });
   }

--- a/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.css
+++ b/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.css
@@ -1,0 +1,151 @@
+.admin-registrations-page {
+  width: min(100%, 64rem);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  padding: 3rem 0;
+}
+
+.page-header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.back-link {
+  width: fit-content;
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.back-link:focus-visible {
+  outline: 2px solid #8fd3c1;
+  outline-offset: 2px;
+}
+
+.page-eyebrow {
+  margin: 0;
+  color: #0f766e;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  color: #10233f;
+}
+
+.page-intro {
+  margin: 0;
+  color: #526277;
+}
+
+.page-state {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #2c3a4b;
+}
+
+.page-state.is-error {
+  border-color: #ef4444;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.registrations-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.registration-card {
+  padding: 1.5rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.06);
+}
+
+.registration-main {
+  display: grid;
+  gap: 1rem;
+}
+
+.registration-heading {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.registration-heading h2 {
+  margin: 0;
+  color: #10233f;
+  font-size: 1.25rem;
+}
+
+.registration-login {
+  margin: 0;
+  color: #526277;
+  font-weight: 600;
+}
+
+.registration-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.9rem;
+}
+
+.registration-meta p {
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #f8fbff;
+}
+
+.registration-meta span {
+  color: #526277;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.registration-meta strong {
+  color: #10233f;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+@media (max-width: 760px) {
+  .admin-registrations-page {
+    gap: 1rem;
+    padding: 2rem 0;
+  }
+
+  .registration-card {
+    padding: 1.25rem;
+  }
+
+  .registration-meta {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.html
+++ b/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.html
@@ -1,0 +1,42 @@
+<section class="admin-registrations-page">
+  <header class="page-header">
+    <p class="page-eyebrow">Administration</p>
+    <a routerLink="/admin" class="back-link">&larr; Retour &agrave; l&rsquo;administration</a>
+    <h1>Demandes d&rsquo;inscription</h1>
+    <p class="page-intro">Consultez les comptes en attente de validation.</p>
+  </header>
+
+  @if (isLoading()) {
+    <p class="page-state">Chargement en cours...</p>
+  } @else if (errorMessage()) {
+    <p class="page-state is-error">{{ errorMessage() }}</p>
+  } @else if (isEmpty()) {
+    <p class="page-state">Aucune demande d&rsquo;inscription en attente.</p>
+  } @else {
+    <div class="registrations-list">
+      @for (registration of registrations(); track registration.userId) {
+        <article class="registration-card">
+          <div class="registration-main">
+            <div class="registration-heading">
+              <h2>{{ registration.nomDemande }}</h2>
+              <p class="registration-login">{{ registration.username }}</p>
+            </div>
+
+            <div class="registration-meta">
+              <p><span>Type</span><strong>{{ getTypeLabel(registration.typeAbonnementDemande) }}</strong></p>
+
+              @if (registration.siteNomDemande) {
+                <p><span>Site demand&eacute;</span><strong>{{ registration.siteNomDemande }}</strong></p>
+              }
+
+              <p>
+                <span>Statut</span>
+                <strong><span class="status-badge">{{ getStatusLabel(registration.status) }}</span></strong>
+              </p>
+            </div>
+          </div>
+        </article>
+      }
+    </div>
+  }
+</section>

--- a/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.ts
+++ b/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.ts
@@ -1,0 +1,83 @@
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { finalize } from 'rxjs';
+import { PendingRegistrationItem } from '../../../core/admin/admin.models';
+import { AdminService } from '../../../core/admin/admin.service';
+
+@Component({
+  selector: 'app-admin-registrations-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './admin-registrations-page.component.html',
+  styleUrl: './admin-registrations-page.component.css'
+})
+export class AdminRegistrationsPageComponent implements OnInit {
+  private readonly adminService = inject(AdminService);
+
+  protected readonly registrations = signal<PendingRegistrationItem[]>([]);
+  protected readonly isLoading = signal(true);
+  protected readonly errorMessage = signal('');
+
+  protected readonly isEmpty = computed(
+    () => !this.isLoading() && !this.errorMessage() && this.registrations().length === 0
+  );
+
+  ngOnInit(): void {
+    this.loadPendingRegistrations();
+  }
+
+  protected getTypeLabel(type: PendingRegistrationItem['typeAbonnementDemande']): string {
+    switch (type) {
+      case 'GLOBAL':
+        return 'Membre global';
+      case 'SITE':
+        return 'Membre d’un site';
+      case 'LIBRE':
+      default:
+        return 'Membre libre';
+    }
+  }
+
+  protected getStatusLabel(status: PendingRegistrationItem['status']): string {
+    if (status === 'PENDING') {
+      return 'En attente';
+    }
+
+    return status;
+  }
+
+  private loadPendingRegistrations(): void {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+
+    this.adminService
+      .getPendingRegistrations()
+      .pipe(finalize(() => this.isLoading.set(false)))
+      .subscribe({
+        next: (items) => {
+          this.registrations.set(items);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.errorMessage.set(this.getErrorMessage(error));
+        }
+      });
+  }
+
+  private getErrorMessage(error: HttpErrorResponse): string {
+    if (error.status === 0) {
+      return 'Backend inaccessible.';
+    }
+
+    if (error.status === 401) {
+      return 'Authentification requise.';
+    }
+
+    if (error.status === 403) {
+      return 'Acc\u00e8s administrateur refus\u00e9.';
+    }
+
+    return "Impossible de charger les demandes d'inscription.";
+  }
+}


### PR DESCRIPTION
- ajout de la route /admin/inscriptions ;
- création d’une page admin dédiée ;
- consommation de GET /api/v1/admin/inscriptions ;
- affichage des demandes en attente avec :
  - nom ;
  - login ;
  - type de membre demandé ;
  - site demandé ;
  - statut ;
- affichage d’un état vide si aucune demande n’est en attente ;
- gestion des erreurs 401 / 403 / backend inaccessible ;
- ajout d’un retour vers /admin ;
- carte “Demandes d’inscription” visible et cliquable uniquement pour ROLE_ADMIN_GLOBAL ;
- affichage du nombre de demandes en attente directement sur la zone admin.