### PR TITLE
feat(admin): valider ou refuser les inscriptions

### DIFF
--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -2,12 +2,30 @@ export interface AdminInfoResponse {
   status: string;
 }
 
+export type RegistrationSubscriptionType = 'GLOBAL' | 'SITE' | 'LIBRE';
+
 export interface PendingRegistrationItem {
   userId: number;
   username: string;
   nomDemande: string;
-  typeAbonnementDemande: 'GLOBAL' | 'SITE' | 'LIBRE';
+  typeAbonnementDemande: RegistrationSubscriptionType;
   siteIdDemande: number | null;
   siteNomDemande: string | null;
   status: string;
+}
+
+export interface ValidateRegistrationRequest {
+  typeAbonnementFinal: RegistrationSubscriptionType;
+  siteIdFinal?: number;
+}
+
+export interface RegistrationDecisionResponse {
+  userId: number;
+  username: string;
+  status: string;
+  message: string;
+  joueurMatricule: string | null;
+  joueurNom: string | null;
+  joueurType: RegistrationSubscriptionType | null;
+  joueurSiteId: number | null;
 }

--- a/frontend/src/app/core/admin/admin.service.ts
+++ b/frontend/src/app/core/admin/admin.service.ts
@@ -2,7 +2,12 @@ import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { AdminInfoResponse, PendingRegistrationItem } from './admin.models';
+import {
+  AdminInfoResponse,
+  PendingRegistrationItem,
+  RegistrationDecisionResponse,
+  ValidateRegistrationRequest
+} from './admin.models';
 
 @Injectable({ providedIn: 'root' })
 export class AdminService {
@@ -14,5 +19,22 @@ export class AdminService {
 
   getPendingRegistrations(): Observable<PendingRegistrationItem[]> {
     return this.http.get<PendingRegistrationItem[]>(`${environment.apiBaseUrl}/admin/inscriptions`);
+  }
+
+  validateRegistration(
+    userId: number,
+    payload: ValidateRegistrationRequest
+  ): Observable<RegistrationDecisionResponse> {
+    return this.http.post<RegistrationDecisionResponse>(
+      `${environment.apiBaseUrl}/admin/inscriptions/${userId}/validate`,
+      payload
+    );
+  }
+
+  rejectRegistration(userId: number): Observable<RegistrationDecisionResponse> {
+    return this.http.post<RegistrationDecisionResponse>(
+      `${environment.apiBaseUrl}/admin/inscriptions/${userId}/reject`,
+      null
+    );
   }
 }

--- a/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.css
+++ b/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.css
@@ -61,6 +61,12 @@
   color: #b91c1c;
 }
 
+.page-state.is-success {
+  border-color: #86efac;
+  background: #f0fdf4;
+  color: #166534;
+}
+
 .registrations-list {
   display: grid;
   gap: 1rem;
@@ -135,6 +141,127 @@
   font-weight: 700;
 }
 
+.registration-actions,
+.validation-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.primary-action,
+.secondary-action,
+.danger-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.8rem 1rem;
+  border-radius: 0.5rem;
+  border: 0;
+  font: inherit;
+  font-weight: 700;
+}
+
+.primary-action {
+  background: #166534;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.secondary-action {
+  border: 1px solid #c7d3e0;
+  background: #f8fbff;
+  color: #10233f;
+  cursor: pointer;
+}
+
+.danger-action {
+  background: #fef2f2;
+  color: #b91c1c;
+  cursor: pointer;
+}
+
+.primary-action:disabled,
+.secondary-action:disabled,
+.danger-action:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.validation-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #f8fbff;
+}
+
+.confirm-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid #bbf7d0;
+  border-radius: 0.5rem;
+  background: #f0fdf4;
+}
+
+.confirm-panel-danger {
+  border: 1px solid #fecaca;
+  background: #fff7f7;
+}
+
+.confirm-message {
+  margin: 0;
+  color: #166534;
+  font-weight: 600;
+}
+
+.confirm-message-danger {
+  color: #7f1d1d;
+}
+
+.field {
+  display: grid;
+  gap: 0.45rem;
+  color: #10233f;
+  font-weight: 600;
+}
+
+.field select {
+  width: 100%;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid #c3d0de;
+  border-radius: 0.75rem;
+  font: inherit;
+  background: #ffffff;
+}
+
+.field select:focus {
+  outline: 2px solid #8fd3c1;
+  outline-offset: 2px;
+}
+
+.field select:disabled {
+  background: #f3f6fa;
+  color: #7a8899;
+}
+
+.field-hint,
+.field-error {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.field-hint {
+  color: #526277;
+  font-weight: 400;
+}
+
+.field-error {
+  color: #b91c1c;
+}
+
 @media (max-width: 760px) {
   .admin-registrations-page {
     gap: 1rem;
@@ -146,6 +273,12 @@
   }
 
   .registration-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .registration-actions,
+  .validation-actions {
+    display: grid;
     grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.html
+++ b/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.html
@@ -6,6 +6,12 @@
     <p class="page-intro">Consultez les comptes en attente de validation.</p>
   </header>
 
+  @if (feedbackMessage()) {
+    <p class="page-state" [class.is-success]="feedbackTone() === 'success'" [class.is-error]="feedbackTone() === 'error'">
+      {{ feedbackMessage() }}
+    </p>
+  }
+
   @if (isLoading()) {
     <p class="page-state">Chargement en cours...</p>
   } @else if (errorMessage()) {
@@ -34,6 +40,135 @@
                 <strong><span class="status-badge">{{ getStatusLabel(registration.status) }}</span></strong>
               </p>
             </div>
+
+            <div class="registration-actions">
+              <button
+                type="button"
+                class="primary-action"
+                (click)="openDirectValidationConfirmation(registration)"
+                [disabled]="isProcessing(registration.userId)"
+              >
+                Valider la demande
+              </button>
+
+              <button
+                type="button"
+                class="secondary-action"
+                (click)="openValidationForm(registration)"
+                [disabled]="isProcessing(registration.userId)"
+              >
+                Corriger avant validation
+              </button>
+
+              <button
+                type="button"
+                class="danger-action"
+                (click)="openRejectConfirmation(registration)"
+                [disabled]="isProcessing(registration.userId)"
+              >
+                Refuser
+              </button>
+            </div>
+
+            @if (isValidationOpen(registration.userId)) {
+              <form class="validation-panel" [formGroup]="validationForm" (ngSubmit)="submitValidation(registration)">
+                <label class="field">
+                  <span>Type final</span>
+                  <select formControlName="typeAbonnementFinal" [disabled]="isProcessing(registration.userId)">
+                    @for (subscriptionType of subscriptionTypes; track subscriptionType.value) {
+                      <option [value]="subscriptionType.value">{{ subscriptionType.label }}</option>
+                    }
+                  </select>
+                </label>
+
+                @if (isSiteTypeSelected()) {
+                  <label class="field">
+                    <span>Site final</span>
+                    <select
+                      formControlName="siteIdFinal"
+                      [disabled]="isLoadingSites() || sites().length === 0 || isProcessing(registration.userId)"
+                    >
+                      <option [ngValue]="null">Selectionnez un site</option>
+                      @for (site of sites(); track site.id) {
+                        <option [ngValue]="site.id">{{ site.nom }} - {{ site.ville }}</option>
+                      }
+                    </select>
+
+                    @if (isLoadingSites()) {
+                      <small class="field-hint">Chargement des sites...</small>
+                    } @else if (sitesErrorMessage()) {
+                      <small class="field-error">{{ sitesErrorMessage() }}</small>
+                    } @else if (sites().length === 0) {
+                      <small class="field-error">Aucun site disponible.</small>
+                    } @else if (hasSiteFieldError()) {
+                      <small class="field-error">Veuillez selectionner un site.</small>
+                    }
+                  </label>
+                }
+
+                <div class="validation-actions">
+                  <button type="submit" class="primary-action" [disabled]="isProcessing(registration.userId)">
+                    {{ isProcessing(registration.userId) ? 'Validation...' : 'Confirmer la validation' }}
+                  </button>
+                  <button
+                    type="button"
+                    class="secondary-action"
+                    (click)="cancelValidationForm()"
+                    [disabled]="isProcessing(registration.userId)"
+                  >
+                    Annuler
+                  </button>
+                </div>
+              </form>
+            }
+
+            @if (isDirectValidationConfirmationOpen(registration.userId)) {
+              <div class="confirm-panel">
+                <p class="confirm-message">Confirmer la validation de cette demande ?</p>
+                <div class="validation-actions">
+                  <button
+                    type="button"
+                    class="primary-action"
+                    (click)="validateRequestedRegistration(registration)"
+                    [disabled]="isProcessing(registration.userId)"
+                  >
+                    {{ isProcessing(registration.userId) ? 'Validation...' : 'Confirmer la validation' }}
+                  </button>
+                  <button
+                    type="button"
+                    class="secondary-action"
+                    (click)="cancelDirectValidationConfirmation()"
+                    [disabled]="isProcessing(registration.userId)"
+                  >
+                    Annuler
+                  </button>
+                </div>
+              </div>
+            }
+
+            @if (isRejectConfirmationOpen(registration.userId)) {
+              <div class="confirm-panel confirm-panel-danger">
+                <p class="confirm-message confirm-message-danger">Confirmer le refus de cette demande ?</p>
+                <div class="validation-actions">
+                  <button
+                    type="button"
+                    class="danger-action"
+                    (click)="confirmRejectRegistration(registration)"
+                    [disabled]="isProcessing(registration.userId)"
+                  >
+                    {{ isProcessing(registration.userId) ? 'Refus...' : 'Confirmer le refus' }}
+                  </button>
+                  <button
+                    type="button"
+                    class="secondary-action"
+                    (click)="cancelRejectConfirmation()"
+                    [disabled]="isProcessing(registration.userId)"
+                  >
+                    Annuler
+                  </button>
+                </div>
+              </div>
+            }
           </div>
         </article>
       }

--- a/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.ts
+++ b/frontend/src/app/features/admin/inscriptions/admin-registrations-page.component.ts
@@ -1,30 +1,64 @@
 import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { finalize } from 'rxjs';
-import { PendingRegistrationItem } from '../../../core/admin/admin.models';
+import {
+  PendingRegistrationItem,
+  RegistrationDecisionResponse,
+  RegistrationSubscriptionType,
+  ValidateRegistrationRequest
+} from '../../../core/admin/admin.models';
 import { AdminService } from '../../../core/admin/admin.service';
+import { ApiErrorResponse } from '../../../core/auth/auth.models';
+import { SiteOption } from '../../../core/sites/site.models';
+import { SitesService } from '../../../core/sites/sites.service';
 
 @Component({
   selector: 'app-admin-registrations-page',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
   templateUrl: './admin-registrations-page.component.html',
   styleUrl: './admin-registrations-page.component.css'
 })
 export class AdminRegistrationsPageComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
   private readonly adminService = inject(AdminService);
+  private readonly sitesService = inject(SitesService);
+  private readonly destroyRef = inject(DestroyRef);
 
   protected readonly registrations = signal<PendingRegistrationItem[]>([]);
   protected readonly isLoading = signal(true);
   protected readonly errorMessage = signal('');
+  protected readonly feedbackMessage = signal('');
+  protected readonly feedbackTone = signal<'success' | 'error' | null>(null);
+  protected readonly activeValidationUserId = signal<number | null>(null);
+  protected readonly activeDirectValidationUserId = signal<number | null>(null);
+  protected readonly activeRejectUserId = signal<number | null>(null);
+  protected readonly processingUserId = signal<number | null>(null);
+  protected readonly isLoadingSites = signal(true);
+  protected readonly sites = signal<SiteOption[]>([]);
+  protected readonly sitesErrorMessage = signal('');
+  protected readonly subscriptionTypes: Array<{ value: RegistrationSubscriptionType; label: string }> = [
+    { value: 'GLOBAL', label: 'Membre global' },
+    { value: 'SITE', label: "Membre d'un site" },
+    { value: 'LIBRE', label: 'Membre libre' }
+  ];
 
   protected readonly isEmpty = computed(
     () => !this.isLoading() && !this.errorMessage() && this.registrations().length === 0
   );
 
+  protected readonly validationForm = this.fb.group({
+    typeAbonnementFinal: this.fb.nonNullable.control<RegistrationSubscriptionType>('GLOBAL', [Validators.required]),
+    siteIdFinal: this.fb.control<number | null>(null)
+  });
+
   ngOnInit(): void {
+    this.loadSites();
+    this.watchValidationTypeChanges();
     this.loadPendingRegistrations();
   }
 
@@ -48,6 +82,145 @@ export class AdminRegistrationsPageComponent implements OnInit {
     return status;
   }
 
+  protected openValidationForm(registration: PendingRegistrationItem): void {
+    this.feedbackMessage.set('');
+    this.feedbackTone.set(null);
+    this.activeDirectValidationUserId.set(null);
+    this.activeRejectUserId.set(null);
+    this.activeValidationUserId.set(registration.userId);
+    this.validationForm.reset({
+      typeAbonnementFinal: registration.typeAbonnementDemande,
+      siteIdFinal: registration.siteIdDemande
+    });
+    this.applySiteValidator();
+    this.validationForm.markAsPristine();
+    this.validationForm.markAsUntouched();
+  }
+
+  protected cancelValidationForm(): void {
+    this.activeValidationUserId.set(null);
+    this.validationForm.reset({
+      typeAbonnementFinal: 'GLOBAL',
+      siteIdFinal: null
+    });
+  }
+
+  protected isValidationOpen(userId: number): boolean {
+    return this.activeValidationUserId() === userId;
+  }
+
+  protected isProcessing(userId: number): boolean {
+    return this.processingUserId() === userId;
+  }
+
+  protected isDirectValidationConfirmationOpen(userId: number): boolean {
+    return this.activeDirectValidationUserId() === userId;
+  }
+
+  protected isRejectConfirmationOpen(userId: number): boolean {
+    return this.activeRejectUserId() === userId;
+  }
+
+  protected isSiteTypeSelected(): boolean {
+    return this.validationForm.controls.typeAbonnementFinal.value === 'SITE';
+  }
+
+  protected hasSiteFieldError(): boolean {
+    const control = this.validationForm.controls.siteIdFinal;
+    return control.invalid && (control.touched || control.dirty);
+  }
+
+  protected submitValidation(registration: PendingRegistrationItem): void {
+    this.feedbackMessage.set('');
+    this.feedbackTone.set(null);
+    this.applySiteValidator();
+
+    if (this.validationForm.invalid) {
+      this.validationForm.markAllAsTouched();
+      return;
+    }
+
+    this.processingUserId.set(registration.userId);
+
+    this.adminService
+      .validateRegistration(registration.userId, this.buildValidationPayload())
+      .pipe(finalize(() => this.processingUserId.set(null)))
+      .subscribe({
+        next: (response) => {
+          this.handleActionSuccess(response, 'Demande validee.');
+        },
+        error: (error: HttpErrorResponse) => {
+          this.feedbackTone.set('error');
+          this.feedbackMessage.set(this.getActionErrorMessage(error));
+        }
+      });
+  }
+
+  protected openDirectValidationConfirmation(registration: PendingRegistrationItem): void {
+    this.feedbackMessage.set('');
+    this.feedbackTone.set(null);
+    this.activeValidationUserId.set(null);
+    this.activeRejectUserId.set(null);
+    this.activeDirectValidationUserId.set(registration.userId);
+  }
+
+  protected cancelDirectValidationConfirmation(): void {
+    this.activeDirectValidationUserId.set(null);
+  }
+
+  protected validateRequestedRegistration(registration: PendingRegistrationItem): void {
+    this.feedbackMessage.set('');
+    this.feedbackTone.set(null);
+    this.activeDirectValidationUserId.set(null);
+    this.activeRejectUserId.set(null);
+    this.activeValidationUserId.set(null);
+    this.processingUserId.set(registration.userId);
+
+    this.adminService
+      .validateRegistration(registration.userId, this.buildRequestedValidationPayload(registration))
+      .pipe(finalize(() => this.processingUserId.set(null)))
+      .subscribe({
+        next: (response) => {
+          this.handleActionSuccess(response, 'Demande validee.');
+        },
+        error: (error: HttpErrorResponse) => {
+          this.feedbackTone.set('error');
+          this.feedbackMessage.set(this.getActionErrorMessage(error));
+        }
+      });
+  }
+
+  protected openRejectConfirmation(registration: PendingRegistrationItem): void {
+    this.feedbackMessage.set('');
+    this.feedbackTone.set(null);
+    this.activeValidationUserId.set(null);
+    this.activeDirectValidationUserId.set(null);
+    this.activeRejectUserId.set(registration.userId);
+  }
+
+  protected cancelRejectConfirmation(): void {
+    this.activeRejectUserId.set(null);
+  }
+
+  protected confirmRejectRegistration(registration: PendingRegistrationItem): void {
+    this.feedbackMessage.set('');
+    this.feedbackTone.set(null);
+    this.processingUserId.set(registration.userId);
+
+    this.adminService
+      .rejectRegistration(registration.userId)
+      .pipe(finalize(() => this.processingUserId.set(null)))
+      .subscribe({
+        next: (response) => {
+          this.handleActionSuccess(response, 'Demande refusee.');
+        },
+        error: (error: HttpErrorResponse) => {
+          this.feedbackTone.set('error');
+          this.feedbackMessage.set(this.getActionErrorMessage(error));
+        }
+      });
+  }
+
   private loadPendingRegistrations(): void {
     this.isLoading.set(true);
     this.errorMessage.set('');
@@ -65,6 +238,79 @@ export class AdminRegistrationsPageComponent implements OnInit {
       });
   }
 
+  private loadSites(): void {
+    this.isLoadingSites.set(true);
+    this.sitesErrorMessage.set('');
+
+    this.sitesService
+      .getSites()
+      .pipe(finalize(() => this.isLoadingSites.set(false)))
+      .subscribe({
+        next: (sites) => {
+          this.sites.set(sites);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.sites.set([]);
+          this.sitesErrorMessage.set(this.getSitesErrorMessage(error));
+        }
+      });
+  }
+
+  private watchValidationTypeChanges(): void {
+    this.validationForm.controls.typeAbonnementFinal.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.applySiteValidator();
+      });
+  }
+
+  private applySiteValidator(): void {
+    const siteControl = this.validationForm.controls.siteIdFinal;
+
+    if (this.isSiteTypeSelected()) {
+      siteControl.setValidators([Validators.required]);
+    } else {
+      siteControl.clearValidators();
+      siteControl.setValue(null);
+    }
+
+    siteControl.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private buildValidationPayload(): ValidateRegistrationRequest {
+    const rawValue = this.validationForm.getRawValue();
+    const payload: ValidateRegistrationRequest = {
+      typeAbonnementFinal: rawValue.typeAbonnementFinal
+    };
+
+    if (rawValue.typeAbonnementFinal === 'SITE' && rawValue.siteIdFinal != null) {
+      payload.siteIdFinal = rawValue.siteIdFinal;
+    }
+
+    return payload;
+  }
+
+  private buildRequestedValidationPayload(registration: PendingRegistrationItem): ValidateRegistrationRequest {
+    const payload: ValidateRegistrationRequest = {
+      typeAbonnementFinal: registration.typeAbonnementDemande
+    };
+
+    if (registration.typeAbonnementDemande === 'SITE' && registration.siteIdDemande != null) {
+      payload.siteIdFinal = registration.siteIdDemande;
+    }
+
+    return payload;
+  }
+
+  private handleActionSuccess(response: RegistrationDecisionResponse, fallbackMessage: string): void {
+    this.feedbackTone.set('success');
+    this.feedbackMessage.set(response.message || fallbackMessage);
+    this.activeDirectValidationUserId.set(null);
+    this.activeRejectUserId.set(null);
+    this.cancelValidationForm();
+    this.loadPendingRegistrations();
+  }
+
   private getErrorMessage(error: HttpErrorResponse): string {
     if (error.status === 0) {
       return 'Backend inaccessible.';
@@ -79,5 +325,64 @@ export class AdminRegistrationsPageComponent implements OnInit {
     }
 
     return "Impossible de charger les demandes d'inscription.";
+  }
+
+  private getActionErrorMessage(error: HttpErrorResponse): string {
+    const apiError = error.error as ApiErrorResponse | null;
+    const backendMessage = apiError?.message ?? '';
+
+    if (error.status === 0) {
+      return 'Backend inaccessible.';
+    }
+
+    if (error.status === 404) {
+      if (backendMessage.includes("Demande d'inscription introuvable")) {
+        return 'Demande introuvable.';
+      }
+
+      if (backendMessage.includes('Site introuvable')) {
+        return 'Site introuvable.';
+      }
+
+      return backendMessage || 'Ressource introuvable.';
+    }
+
+    if (error.status === 400) {
+      if (apiError?.details?.['typeAbonnementFinal']) {
+        return 'Le type final est obligatoire.';
+      }
+
+      if (backendMessage.includes("n'est plus en attente")) {
+        return 'Demande deja traitee.';
+      }
+
+      if (backendMessage.includes('siteIdFinal') && backendMessage.includes('obligatoire')) {
+        return 'Le site est obligatoire pour un membre de site.';
+      }
+
+      if (backendMessage.includes('siteIdFinal') && backendMessage.includes('interdit')) {
+        return 'Aucun site ne doit etre envoye pour ce type.';
+      }
+
+      return backendMessage || 'Demande invalide.';
+    }
+
+    if (error.status === 401) {
+      return 'Authentification requise.';
+    }
+
+    if (error.status === 403) {
+      return 'Acces administrateur refuse.';
+    }
+
+    return "Impossible de traiter cette demande pour le moment.";
+  }
+
+  private getSitesErrorMessage(error: HttpErrorResponse): string {
+    if (error.status === 0) {
+      return 'La liste des sites est momentanement indisponible.';
+    }
+
+    return 'Impossible de charger les sites pour le moment.';
   }
 }


### PR DESCRIPTION
- ajout du bouton Valider la demande ;
- ajout d’une confirmation inline avant validation directe ;
- ajout du bouton Corriger avant validation ;
- formulaire inline pour ajuster le type final et le site final si nécessaire ;
- ajout du bouton Refuser ;
- confirmation inline avant refus ;
- appels aux endpoints existants :
  - POST /api/v1/admin/inscriptions/{userId}/validate
  - POST /api/v1/admin/inscriptions/{userId}/reject
- réutilisation de SitesService pour le choix du site final ;
- affichage des messages de succès / erreur ;
- rechargement de la liste après chaque action réussie.
