### PR TITLE
feat(admin): afficher la liste des joueurs

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminGlobalController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminGlobalController.java
@@ -1,15 +1,16 @@
 package be.ephec.padel.backend.controller;
 
+import be.ephec.padel.backend.dto.response.AdminInfoDto;
 import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
 import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
 import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
+import be.ephec.padel.backend.service.AdminInfoService;
 import be.ephec.padel.backend.service.AdminStatsService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.util.Map;
 
 @SecurityRequirement(name = "bearerAuth")
 @RestController
@@ -17,15 +18,18 @@ import java.util.Map;
 public class AdminGlobalController {
 
     private final AdminStatsService adminStatsService;
+    private final AdminInfoService adminInfoService;
 
-    public AdminGlobalController(AdminStatsService adminStatsService) {
+    public AdminGlobalController(AdminStatsService adminStatsService,
+                                 AdminInfoService adminInfoService) {
         this.adminStatsService = adminStatsService;
+        this.adminInfoService = adminInfoService;
     }
 
     // ex AdminController
     @GetMapping("/info")
-    public Map<String, Object> adminInfo() {
-        return Map.of("status", "ok");
+    public AdminInfoDto adminInfo() {
+        return adminInfoService.getAdminInfo();
     }
 
     // ex AdminStatsController (on garde les routes pour éviter de casser)

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminInfoDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminInfoDto.java
@@ -1,0 +1,32 @@
+package be.ephec.padel.backend.dto.response;
+
+public class AdminInfoDto {
+
+    private final String status;
+    private final String adminType;
+    private final Long siteId;
+    private final String siteNom;
+
+    public AdminInfoDto(String status, String adminType, Long siteId, String siteNom) {
+        this.status = status;
+        this.adminType = adminType;
+        this.siteId = siteId;
+        this.siteNom = siteNom;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getAdminType() {
+        return adminType;
+    }
+
+    public Long getSiteId() {
+        return siteId;
+    }
+
+    public String getSiteNom() {
+        return siteNom;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/security/ServiceAutorisationAdmin.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/security/ServiceAutorisationAdmin.java
@@ -62,6 +62,25 @@ public class ServiceAutorisationAdmin {
         return false;
     }
 
+    public Long getSiteAdministreId() {
+        if (currentUserFacade.hasRole(SecurityRole.ROLE_ADMIN_GLOBAL)) {
+            return null;
+        }
+
+        if (currentUserFacade.hasRole(SecurityRole.ROLE_ADMIN_SITE)) {
+            String login = currentUserFacade.getCurrentUser().getLogin();
+            Long siteAutoriseId = perimetreAdminsSiteParLogin.get(login);
+
+            if (siteAutoriseId == null) {
+                throw new AccessDeniedException("ADMIN_SITE sans site associe");
+            }
+
+            return siteAutoriseId;
+        }
+
+        throw new AccessDeniedException("Acces refuse");
+    }
+
     private Map<String, Long> parserAdminsSite(String adminsSite) {
         Map<String, Long> map = new HashMap<>();
         if (adminsSite == null || adminsSite.isBlank()) {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminInfoService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminInfoService.java
@@ -1,0 +1,40 @@
+package be.ephec.padel.backend.service;
+
+import be.ephec.padel.backend.dto.response.AdminInfoDto;
+import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
+import be.ephec.padel.backend.security.ServiceAutorisationAdmin;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AdminInfoService {
+
+    private final CurrentUserFacade currentUserFacade;
+    private final ServiceAutorisationAdmin serviceAutorisationAdmin;
+    private final SiteRepository siteRepository;
+
+    public AdminInfoService(CurrentUserFacade currentUserFacade,
+                            ServiceAutorisationAdmin serviceAutorisationAdmin,
+                            SiteRepository siteRepository) {
+        this.currentUserFacade = currentUserFacade;
+        this.serviceAutorisationAdmin = serviceAutorisationAdmin;
+        this.siteRepository = siteRepository;
+    }
+
+    public AdminInfoDto getAdminInfo() {
+        if (currentUserFacade.hasRole(SecurityRole.ROLE_ADMIN_GLOBAL)) {
+            return new AdminInfoDto("ok", "GLOBAL", null, null);
+        }
+
+        Long siteId = serviceAutorisationAdmin.getSiteAdministreId();
+        Site site = siteRepository.findById(siteId)
+                .orElseThrow(() -> new NotFoundException("Site admin introuvable: " + siteId));
+
+        return new AdminInfoDto("ok", "SITE", site.getId(), site.getNom());
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminInfoServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminInfoServiceTest.java
@@ -1,0 +1,72 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.dto.response.AdminInfoDto;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.enums.SecurityRole;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.security.CurrentUserFacade;
+import be.ephec.padel.backend.security.ServiceAutorisationAdmin;
+import be.ephec.padel.backend.service.AdminInfoService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminInfoServiceTest {
+
+    @Mock
+    CurrentUserFacade currentUserFacade;
+
+    @Mock
+    ServiceAutorisationAdmin serviceAutorisationAdmin;
+
+    @Mock
+    SiteRepository siteRepository;
+
+    @InjectMocks
+    AdminInfoService adminInfoService;
+
+    @Test
+    void getAdminInfo_retourne_le_contexte_global() {
+        when(currentUserFacade.hasRole(SecurityRole.ROLE_ADMIN_GLOBAL)).thenReturn(true);
+
+        AdminInfoDto result = adminInfoService.getAdminInfo();
+
+        assertThat(result.getStatus()).isEqualTo("ok");
+        assertThat(result.getAdminType()).isEqualTo("GLOBAL");
+        assertThat(result.getSiteId()).isNull();
+        assertThat(result.getSiteNom()).isNull();
+    }
+
+    @Test
+    void getAdminInfo_retourne_le_contexte_site() throws Exception {
+        Site site = site(7L, "Site Nord");
+
+        when(currentUserFacade.hasRole(SecurityRole.ROLE_ADMIN_GLOBAL)).thenReturn(false);
+        when(serviceAutorisationAdmin.getSiteAdministreId()).thenReturn(7L);
+        when(siteRepository.findById(7L)).thenReturn(Optional.of(site));
+
+        AdminInfoDto result = adminInfoService.getAdminInfo();
+
+        assertThat(result.getStatus()).isEqualTo("ok");
+        assertThat(result.getAdminType()).isEqualTo("SITE");
+        assertThat(result.getSiteId()).isEqualTo(7L);
+        assertThat(result.getSiteNom()).isEqualTo("Site Nord");
+    }
+
+    private Site site(Long id, String nom) throws Exception {
+        Site site = new Site(nom, "Bruxelles");
+        Field field = Site.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(site, id);
+        return site;
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AdminGlobalControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/AdminGlobalControllerTest.java
@@ -4,8 +4,10 @@ import be.ephec.padel.backend.config.SecurityConfig;
 import be.ephec.padel.backend.controller.AdminGlobalController;
 import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
 import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
+import be.ephec.padel.backend.dto.response.AdminInfoDto;
 import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
 import be.ephec.padel.backend.exception.BusinessException;
+import be.ephec.padel.backend.service.AdminInfoService;
 import be.ephec.padel.backend.service.AdminStatsService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -33,6 +36,9 @@ class AdminGlobalControllerTest {
     @MockitoBean
     private AdminStatsService adminStatsService;
 
+    @MockitoBean
+    private AdminInfoService adminInfoService;
+
     // -----------------------------
     // /api/v1/admin/info
     // -----------------------------
@@ -46,18 +52,30 @@ class AdminGlobalControllerTest {
     @Test
     @WithMockUser(username = "adminSite1", roles = {"ADMIN_SITE"})
     void adminInfo_adminSite_200() throws Exception {
+        when(adminInfoService.getAdminInfo())
+                .thenReturn(new AdminInfoDto("ok", "SITE", 1L, "Site Nord"));
+
         mvc.perform(get("/api/v1/admin/info"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.status").value("ok"));
+                .andExpect(jsonPath("$.status").value("ok"))
+                .andExpect(jsonPath("$.adminType").value("SITE"))
+                .andExpect(jsonPath("$.siteId").value(1))
+                .andExpect(jsonPath("$.siteNom").value("Site Nord"));
     }
 
     @Test
     @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
     void adminInfo_adminGlobal_200() throws Exception {
+        when(adminInfoService.getAdminInfo())
+                .thenReturn(new AdminInfoDto("ok", "GLOBAL", null, null));
+
         mvc.perform(get("/api/v1/admin/info"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("ok"));
+                .andExpect(jsonPath("$.status").value("ok"))
+                .andExpect(jsonPath("$.adminType").value("GLOBAL"))
+                .andExpect(jsonPath("$.siteId").value(nullValue()))
+                .andExpect(jsonPath("$.siteNom").value(nullValue()));
     }
 
     // -----------------------------

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { authGuard } from './core/auth/auth.guard';
 import { LoginPageComponent } from './features/auth/login/login-page.component';
 import { RegisterPageComponent } from './features/auth/register/register-page.component';
+import { AdminPlayersPageComponent } from './features/admin/joueurs/admin-players-page.component';
 import { AdminRegistrationsPageComponent } from './features/admin/inscriptions/admin-registrations-page.component';
 import { AdminPageComponent } from './features/admin/admin-page.component';
 import { HomePageComponent } from './features/home/home-page.component';
@@ -28,6 +29,7 @@ export const routes: Routes = [
       { path: 'me/matchs/organises', component: OrganizedMatchesPageComponent, canActivate: [authGuard] },
       { path: 'matchs', component: PublicMatchesPageComponent, canActivate: [authGuard] },
       { path: 'admin', component: AdminPageComponent, canActivate: [authGuard] },
+      { path: 'admin/joueurs', component: AdminPlayersPageComponent, canActivate: [authGuard] },
       { path: 'admin/inscriptions', component: AdminRegistrationsPageComponent, canActivate: [authGuard] }
     ]
   },

--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -1,8 +1,35 @@
 export interface AdminInfoResponse {
   status: string;
+  adminType: 'GLOBAL' | 'SITE';
+  siteId: number | null;
+  siteNom: string | null;
 }
 
 export type RegistrationSubscriptionType = 'GLOBAL' | 'SITE' | 'LIBRE';
+
+export interface AdminPlayerResponse {
+  matricule: string;
+  nom: string;
+  type: RegistrationSubscriptionType;
+  siteId: number | null;
+  solde: number | null;
+}
+
+export interface AdminSitePlayerResponse {
+  matricule: string;
+  nom: string;
+  type: RegistrationSubscriptionType;
+  solde: number | null;
+}
+
+export interface AdminPlayerListItem {
+  matricule: string;
+  nom: string;
+  type: RegistrationSubscriptionType;
+  siteId: number | null;
+  siteNom: string | null;
+  solde: number | null;
+}
 
 export interface PendingRegistrationItem {
   userId: number;

--- a/frontend/src/app/core/admin/admin.service.ts
+++ b/frontend/src/app/core/admin/admin.service.ts
@@ -3,6 +3,8 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import {
+  AdminPlayerResponse,
+  AdminSitePlayerResponse,
   AdminInfoResponse,
   PendingRegistrationItem,
   RegistrationDecisionResponse,
@@ -19,6 +21,14 @@ export class AdminService {
 
   getPendingRegistrations(): Observable<PendingRegistrationItem[]> {
     return this.http.get<PendingRegistrationItem[]>(`${environment.apiBaseUrl}/admin/inscriptions`);
+  }
+
+  getPlayers(): Observable<AdminPlayerResponse[]> {
+    return this.http.get<AdminPlayerResponse[]>(`${environment.apiBaseUrl}/joueurs`);
+  }
+
+  getPlayersBySite(siteId: number): Observable<AdminSitePlayerResponse[]> {
+    return this.http.get<AdminSitePlayerResponse[]>(`${environment.apiBaseUrl}/admin/sites/${siteId}/joueurs`);
   }
 
   validateRegistration(

--- a/frontend/src/app/features/admin/admin-page.component.ts
+++ b/frontend/src/app/features/admin/admin-page.component.ts
@@ -43,8 +43,14 @@ export class AdminPageComponent implements OnInit {
   });
 
   protected readonly scopeLabel = computed(() => {
-    if (this.authService.hasRole('ROLE_ADMIN_GLOBAL')) {
+    const adminInfo = this.adminInfo();
+
+    if (adminInfo?.adminType === 'GLOBAL') {
       return 'P\u00e9rim\u00e8tre : tous les sites';
+    }
+
+    if (adminInfo?.adminType === 'SITE' && adminInfo.siteNom) {
+      return `P\u00e9rim\u00e8tre : ${adminInfo.siteNom}`;
     }
 
     if (this.authService.hasRole('ROLE_ADMIN_SITE')) {
@@ -92,7 +98,7 @@ export class AdminPageComponent implements OnInit {
     }
 
     cards.push(
-      { title: 'Joueurs', description: 'Module \u00e0 venir.' },
+      { title: 'Joueurs', description: 'Consultez les joueurs enregistr\u00e9s dans votre p\u00e9rim\u00e8tre.', route: '/admin/joueurs' },
       { title: 'Fermetures', description: 'Module \u00e0 venir.' },
       { title: 'Statistiques', description: 'Module \u00e0 venir.' },
       { title: 'Horaires', description: 'Module \u00e0 venir.' }

--- a/frontend/src/app/features/admin/joueurs/admin-players-page.component.css
+++ b/frontend/src/app/features/admin/joueurs/admin-players-page.component.css
@@ -1,0 +1,135 @@
+.admin-players-page {
+  width: min(100%, 64rem);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  padding: 3rem 0;
+}
+
+.page-header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.back-link {
+  width: fit-content;
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.back-link:focus-visible {
+  outline: 2px solid #8fd3c1;
+  outline-offset: 2px;
+}
+
+.page-eyebrow {
+  margin: 0;
+  color: #0f766e;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  color: #10233f;
+}
+
+.page-intro {
+  margin: 0;
+  color: #526277;
+}
+
+.page-state {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #2c3a4b;
+}
+
+.page-state.is-error {
+  border-color: #ef4444;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.players-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.player-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.06);
+}
+
+.player-heading {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.player-heading h2 {
+  margin: 0;
+  color: #10233f;
+  font-size: 1.25rem;
+}
+
+.player-id {
+  margin: 0;
+  color: #526277;
+  font-weight: 600;
+}
+
+.player-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.9rem;
+}
+
+.player-meta p {
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #f8fbff;
+}
+
+.player-meta span {
+  color: #526277;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.player-meta strong {
+  color: #10233f;
+}
+
+@media (max-width: 760px) {
+  .admin-players-page {
+    gap: 1rem;
+    padding: 2rem 0;
+  }
+
+  .player-card {
+    padding: 1.25rem;
+  }
+
+  .player-meta {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/app/features/admin/joueurs/admin-players-page.component.html
+++ b/frontend/src/app/features/admin/joueurs/admin-players-page.component.html
@@ -1,0 +1,50 @@
+<section class="admin-players-page">
+  <header class="page-header">
+    <p class="page-eyebrow">Administration</p>
+    <a routerLink="/admin" class="back-link">&larr; Retour &agrave; l&rsquo;administration</a>
+    <h1>Joueurs</h1>
+    <p class="page-intro">Consultez les joueurs que vous pouvez administrer.</p>
+  </header>
+
+  @if (isLoading()) {
+    <p class="page-state">Chargement en cours...</p>
+  } @else if (errorMessage()) {
+    <p class="page-state is-error">{{ errorMessage() }}</p>
+  } @else {
+    <p class="page-state">{{ playersCountMessage() }}</p>
+
+    @if (isEmpty()) {
+      <p class="page-state">Aucun joueur trouv&eacute; dans votre p&eacute;rim&egrave;tre.</p>
+    }
+
+    <div class="players-list">
+      @for (player of players(); track player.matricule) {
+        <article class="player-card">
+          <div class="player-heading">
+            <h2>{{ player.nom }}</h2>
+            <p class="player-id">{{ player.matricule }}</p>
+          </div>
+
+          <div class="player-meta">
+            <p>
+              <span>Type</span>
+              <strong>{{ getTypeLabel(player.type) }}</strong>
+            </p>
+
+            @if (hasSite(player)) {
+              <p>
+                <span>Site</span>
+                <strong>{{ player.siteNom }}</strong>
+              </p>
+            }
+
+            <p>
+              <span>{{ getBalanceLabel(player) }}</span>
+              <strong>{{ formatBalance(player.solde) }}</strong>
+            </p>
+          </div>
+        </article>
+      }
+    </div>
+  }
+</section>

--- a/frontend/src/app/features/admin/joueurs/admin-players-page.component.ts
+++ b/frontend/src/app/features/admin/joueurs/admin-players-page.component.ts
@@ -1,0 +1,170 @@
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { catchError, finalize, forkJoin, map, of, switchMap } from 'rxjs';
+import {
+  AdminInfoResponse,
+  AdminPlayerListItem,
+  AdminPlayerResponse,
+  AdminSitePlayerResponse,
+  RegistrationSubscriptionType
+} from '../../../core/admin/admin.models';
+import { AdminService } from '../../../core/admin/admin.service';
+import { SiteOption } from '../../../core/sites/site.models';
+import { SitesService } from '../../../core/sites/sites.service';
+
+@Component({
+  selector: 'app-admin-players-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './admin-players-page.component.html',
+  styleUrl: './admin-players-page.component.css'
+})
+export class AdminPlayersPageComponent implements OnInit {
+  private readonly adminService = inject(AdminService);
+  private readonly sitesService = inject(SitesService);
+  private readonly currencyFormatter = new Intl.NumberFormat('fr-BE', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+
+  protected readonly adminInfo = signal<AdminInfoResponse | null>(null);
+  protected readonly players = signal<AdminPlayerListItem[]>([]);
+  protected readonly isLoading = signal(true);
+  protected readonly errorMessage = signal('');
+
+  protected readonly isEmpty = computed(() => !this.isLoading() && !this.errorMessage() && this.players().length === 0);
+
+  protected readonly playersCountMessage = computed(() => {
+    const count = this.players().length;
+
+    if (count === 0) {
+      return 'Aucun joueur accessible';
+    }
+
+    if (count === 1) {
+      return '1 joueur accessible';
+    }
+
+    return `${count} joueurs accessibles`;
+  });
+
+  ngOnInit(): void {
+    this.loadPlayers();
+  }
+
+  protected getTypeLabel(type: RegistrationSubscriptionType): string {
+    switch (type) {
+      case 'GLOBAL':
+        return 'Membre global';
+      case 'SITE':
+        return "Membre d'un site";
+      case 'LIBRE':
+      default:
+        return 'Membre libre';
+    }
+  }
+
+  protected hasSite(player: AdminPlayerListItem): boolean {
+    return player.siteNom != null;
+  }
+
+  protected getBalanceLabel(player: AdminPlayerListItem): string {
+    return player.solde != null && player.solde > 0 ? 'Dette' : 'Solde';
+  }
+
+  protected formatBalance(solde: number | null): string {
+    if (solde == null) {
+      return 'Indisponible';
+    }
+
+    return `${this.currencyFormatter.format(solde)} \u20ac`;
+  }
+
+  private loadPlayers(): void {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+
+    this.adminService
+      .getInfo()
+      .pipe(
+        switchMap((adminInfo) => {
+          this.adminInfo.set(adminInfo);
+
+          if (adminInfo.adminType === 'GLOBAL') {
+            return forkJoin({
+              players: this.adminService.getPlayers(),
+              sites: this.sitesService.getSites().pipe(catchError(() => of([] as SiteOption[])))
+            }).pipe(map(({ players, sites }) => this.mapGlobalPlayers(players, sites)));
+          }
+
+          if (adminInfo.siteId == null) {
+            throw new Error("Perimetre administrateur introuvable.");
+          }
+
+          return this.adminService
+            .getPlayersBySite(adminInfo.siteId)
+            .pipe(map((players) => this.mapSitePlayers(players, adminInfo)));
+        }),
+        finalize(() => this.isLoading.set(false))
+      )
+      .subscribe({
+        next: (players) => {
+          this.players.set(players);
+        },
+        error: (error: HttpErrorResponse | Error) => {
+          this.players.set([]);
+          this.errorMessage.set(this.getErrorMessage(error));
+        }
+      });
+  }
+
+  private mapGlobalPlayers(players: AdminPlayerResponse[], sites: SiteOption[]): AdminPlayerListItem[] {
+    const siteNames = new Map(sites.map((site) => [site.id, site.nom]));
+
+    return players.map((player) => ({
+      matricule: player.matricule,
+      nom: player.nom,
+      type: player.type,
+      siteId: player.siteId,
+      siteNom: player.siteId == null ? null : siteNames.get(player.siteId) ?? null,
+      solde: player.solde
+    }));
+  }
+
+  private mapSitePlayers(players: AdminSitePlayerResponse[], adminInfo: AdminInfoResponse): AdminPlayerListItem[] {
+    return players.map((player) => ({
+      matricule: player.matricule,
+      nom: player.nom,
+      type: player.type,
+      siteId: adminInfo.siteId,
+      siteNom: adminInfo.siteNom,
+      solde: player.solde
+    }));
+  }
+
+  private getErrorMessage(error: HttpErrorResponse | Error): string {
+    if (error instanceof HttpErrorResponse) {
+      if (error.status === 0) {
+        return 'Backend inaccessible.';
+      }
+
+      if (error.status === 401) {
+        return 'Authentification requise.';
+      }
+
+      if (error.status === 403) {
+        return 'Acces administrateur refuse.';
+      }
+
+      if (error.status === 404) {
+        return 'Perimetre administrateur introuvable.';
+      }
+
+      return "Impossible de charger la liste des joueurs.";
+    }
+
+    return error.message || "Impossible de charger la liste des joueurs.";
+  }
+}


### PR DESCRIPTION
- ajout de la route /admin/joueurs ;
- création d’une page admin de consultation des joueurs ;
- carte Joueurs rendue cliquable depuis /admin ;
- enrichissement de /api/v1/admin/info pour exposer le contexte admin ;
- support ADMIN_GLOBAL : affichage de tous les joueurs ;
- support ADMIN_SITE : affichage uniquement des joueurs de son site ;
- affichage des informations joueur :
  - nom ;
  - matricule ;
  - type de membre ;
  - site si disponible ;
  - solde ;
- ajout d’un compteur de joueurs accessibles ;
- gestion des états loading / erreur / vide.