### PR TITLE
feat(admin): consulter les fermetures

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { authGuard } from './core/auth/auth.guard';
 import { LoginPageComponent } from './features/auth/login/login-page.component';
 import { RegisterPageComponent } from './features/auth/register/register-page.component';
+import { AdminClosuresPageComponent } from './features/admin/fermetures/admin-closures-page.component';
 import { AdminPlayersPageComponent } from './features/admin/joueurs/admin-players-page.component';
 import { AdminRegistrationsPageComponent } from './features/admin/inscriptions/admin-registrations-page.component';
 import { AdminPageComponent } from './features/admin/admin-page.component';
@@ -29,6 +30,7 @@ export const routes: Routes = [
       { path: 'me/matchs/organises', component: OrganizedMatchesPageComponent, canActivate: [authGuard] },
       { path: 'matchs', component: PublicMatchesPageComponent, canActivate: [authGuard] },
       { path: 'admin', component: AdminPageComponent, canActivate: [authGuard] },
+      { path: 'admin/fermetures', component: AdminClosuresPageComponent, canActivate: [authGuard] },
       { path: 'admin/joueurs', component: AdminPlayersPageComponent, canActivate: [authGuard] },
       { path: 'admin/inscriptions', component: AdminRegistrationsPageComponent, canActivate: [authGuard] }
     ]

--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -56,3 +56,18 @@ export interface RegistrationDecisionResponse {
   joueurType: RegistrationSubscriptionType | null;
   joueurSiteId: number | null;
 }
+
+export interface AdminGlobalClosureResponse {
+  id: number;
+  date: string;
+  motif: string | null;
+}
+
+export interface AdminSiteClosureResponse {
+  id: number;
+  siteId: number;
+  date: string | null;
+  dateDebut: string | null;
+  dateFin: string | null;
+  motif: string | null;
+}

--- a/frontend/src/app/core/admin/admin.service.ts
+++ b/frontend/src/app/core/admin/admin.service.ts
@@ -3,8 +3,10 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import {
+  AdminGlobalClosureResponse,
   AdminPlayerResponse,
   AdminSitePlayerResponse,
+  AdminSiteClosureResponse,
   AdminInfoResponse,
   PendingRegistrationItem,
   RegistrationDecisionResponse,
@@ -29,6 +31,16 @@ export class AdminService {
 
   getPlayersBySite(siteId: number): Observable<AdminSitePlayerResponse[]> {
     return this.http.get<AdminSitePlayerResponse[]>(`${environment.apiBaseUrl}/admin/sites/${siteId}/joueurs`);
+  }
+
+  getGlobalClosures(): Observable<AdminGlobalClosureResponse[]> {
+    return this.http.get<AdminGlobalClosureResponse[]>(`${environment.apiBaseUrl}/fermetures-globales`);
+  }
+
+  getSiteClosures(siteId: number): Observable<AdminSiteClosureResponse[]> {
+    return this.http.get<AdminSiteClosureResponse[]>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/fermetures`
+    );
   }
 
   validateRegistration(

--- a/frontend/src/app/features/admin/admin-page.component.html
+++ b/frontend/src/app/features/admin/admin-page.component.html
@@ -31,7 +31,7 @@
       <section class="future-section">
         <div class="section-heading">
           <h2>Acc&egrave;s rapides</h2>
-          <p>Modules pr&eacute;paratoires non fonctionnels dans cette issue.</p>
+          <p>Modules disponibles ou pr&eacute;paratoires.</p>
         </div>
 
         <div class="future-grid">

--- a/frontend/src/app/features/admin/admin-page.component.ts
+++ b/frontend/src/app/features/admin/admin-page.component.ts
@@ -99,7 +99,7 @@ export class AdminPageComponent implements OnInit {
 
     cards.push(
       { title: 'Joueurs', description: 'Consultez les joueurs enregistr\u00e9s dans votre p\u00e9rim\u00e8tre.', route: '/admin/joueurs' },
-      { title: 'Fermetures', description: 'Module \u00e0 venir.' },
+      { title: 'Fermetures', description: 'Consultez les fermetures globales et les fermetures de site.', route: '/admin/fermetures' },
       { title: 'Statistiques', description: 'Module \u00e0 venir.' },
       { title: 'Horaires', description: 'Module \u00e0 venir.' }
     );

--- a/frontend/src/app/features/admin/fermetures/admin-closures-page.component.css
+++ b/frontend/src/app/features/admin/fermetures/admin-closures-page.component.css
@@ -1,0 +1,170 @@
+.admin-closures-page {
+  width: min(100%, 64rem);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  padding: 3rem 0;
+}
+
+.page-header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.back-link {
+  width: fit-content;
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.back-link:focus-visible,
+.site-picker select:focus-visible {
+  outline: 2px solid #8fd3c1;
+  outline-offset: 2px;
+}
+
+.page-eyebrow {
+  margin: 0;
+  color: #0f766e;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  color: #10233f;
+}
+
+.page-intro,
+.site-scope {
+  margin: 0;
+  color: #526277;
+}
+
+.page-state {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #2c3a4b;
+}
+
+.page-state.is-error {
+  border-color: #ef4444;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.closures-layout,
+.closures-section,
+.closures-list,
+.section-heading {
+  display: grid;
+}
+
+.closures-layout {
+  gap: 2rem;
+}
+
+.closures-section {
+  gap: 1rem;
+}
+
+.section-heading {
+  gap: 0.75rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+  color: #10233f;
+  font-size: 1.45rem;
+}
+
+.site-picker {
+  width: min(100%, 22rem);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.site-picker span {
+  color: #526277;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.site-picker select {
+  min-height: 2.75rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid #bac7d6;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #10233f;
+  font: inherit;
+}
+
+.closures-list {
+  gap: 1rem;
+}
+
+.closure-card {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1.25rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.06);
+}
+
+.closure-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.closure-heading h3 {
+  margin: 0;
+  color: #10233f;
+  font-size: 1.15rem;
+}
+
+.closure-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #075985;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.closure-motif {
+  margin: 0;
+  color: #526277;
+}
+
+@media (max-width: 760px) {
+  .admin-closures-page {
+    gap: 1rem;
+    padding: 2rem 0;
+  }
+
+  .closures-layout {
+    gap: 1.5rem;
+  }
+
+  .closure-card {
+    padding: 1.1rem;
+  }
+}

--- a/frontend/src/app/features/admin/fermetures/admin-closures-page.component.html
+++ b/frontend/src/app/features/admin/fermetures/admin-closures-page.component.html
@@ -1,0 +1,83 @@
+<section class="admin-closures-page">
+  <header class="page-header">
+    <p class="page-eyebrow">Administration</p>
+    <a routerLink="/admin" class="back-link">&larr; Retour &agrave; l&rsquo;administration</a>
+    <h1>Fermetures</h1>
+    <p class="page-intro">Consultez les fermetures globales et les fermetures de site.</p>
+  </header>
+
+  @if (isLoading()) {
+    <p class="page-state">Chargement en cours...</p>
+  } @else if (errorMessage()) {
+    <p class="page-state is-error">{{ errorMessage() }}</p>
+  } @else {
+    <div class="closures-layout">
+      <section class="closures-section">
+        <div class="section-heading">
+          <h2>Fermetures globales</h2>
+        </div>
+
+        @if (globalClosuresError()) {
+          <p class="page-state is-error">{{ globalClosuresError() }}</p>
+        } @else if (hasNoGlobalClosures()) {
+          <p class="page-state">Aucune fermeture globale enregistr&eacute;e.</p>
+        } @else {
+          <div class="closures-list">
+            @for (closure of globalClosures(); track getGlobalClosureTrack(closure)) {
+              <article class="closure-card">
+                <div class="closure-heading">
+                  <span class="closure-badge">Date unique</span>
+                  <h3>{{ formatDate(closure.date) }}</h3>
+                </div>
+                <p class="closure-motif">{{ getMotifLabel(closure.motif) }}</p>
+              </article>
+            }
+          </div>
+        }
+      </section>
+
+      <section class="closures-section">
+        <div class="section-heading">
+          <h2>Fermetures du site</h2>
+
+          @if (isAdminGlobal()) {
+            @if (sites().length > 0) {
+              <label class="site-picker">
+                <span>Site</span>
+                <select [value]="selectedSiteId() ?? ''" (change)="onSiteChange($any($event.target).value)">
+                  @for (site of sites(); track site.id) {
+                    <option [value]="site.id">{{ site.nom }}</option>
+                  }
+                </select>
+              </label>
+            }
+          } @else {
+            <p class="site-scope">{{ siteScopeLabel() }}</p>
+          }
+        </div>
+
+        @if (isAdminGlobal() && sites().length === 0) {
+          <p class="page-state">Aucun site disponible.</p>
+        } @else if (isLoadingSiteClosures()) {
+          <p class="page-state">Chargement des fermetures du site...</p>
+        } @else if (siteClosuresError()) {
+          <p class="page-state is-error">{{ siteClosuresError() }}</p>
+        } @else if (hasNoSiteClosures()) {
+          <p class="page-state">Aucune fermeture enregistr&eacute;e pour ce site.</p>
+        } @else {
+          <div class="closures-list">
+            @for (closure of siteClosures(); track getSiteClosureTrack(closure)) {
+              <article class="closure-card">
+                <div class="closure-heading">
+                  <span class="closure-badge">{{ getSiteClosureTypeLabel(closure) }}</span>
+                  <h3>{{ getSiteClosureDateLabel(closure) }}</h3>
+                </div>
+                <p class="closure-motif">{{ getMotifLabel(closure.motif) }}</p>
+              </article>
+            }
+          </div>
+        }
+      </section>
+    </div>
+  }
+</section>

--- a/frontend/src/app/features/admin/fermetures/admin-closures-page.component.ts
+++ b/frontend/src/app/features/admin/fermetures/admin-closures-page.component.ts
@@ -1,0 +1,243 @@
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { finalize, forkJoin, of, switchMap } from 'rxjs';
+import {
+  AdminGlobalClosureResponse,
+  AdminInfoResponse,
+  AdminSiteClosureResponse
+} from '../../../core/admin/admin.models';
+import { AdminService } from '../../../core/admin/admin.service';
+import { SiteOption } from '../../../core/sites/site.models';
+import { SitesService } from '../../../core/sites/sites.service';
+
+@Component({
+  selector: 'app-admin-closures-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './admin-closures-page.component.html',
+  styleUrl: './admin-closures-page.component.css'
+})
+export class AdminClosuresPageComponent implements OnInit {
+  private readonly adminService = inject(AdminService);
+  private readonly sitesService = inject(SitesService);
+
+  protected readonly adminInfo = signal<AdminInfoResponse | null>(null);
+  protected readonly globalClosures = signal<AdminGlobalClosureResponse[]>([]);
+  protected readonly siteClosures = signal<AdminSiteClosureResponse[]>([]);
+  protected readonly sites = signal<SiteOption[]>([]);
+  protected readonly selectedSiteId = signal<number | null>(null);
+
+  protected readonly isLoading = signal(true);
+  protected readonly isLoadingSiteClosures = signal(false);
+  protected readonly errorMessage = signal('');
+  protected readonly globalClosuresError = signal('');
+  protected readonly siteClosuresError = signal('');
+
+  protected readonly isAdminGlobal = computed(() => this.adminInfo()?.adminType === 'GLOBAL');
+  protected readonly hasNoGlobalClosures = computed(() => !this.globalClosuresError() && this.globalClosures().length === 0);
+  protected readonly hasNoSiteClosures = computed(
+    () => !this.siteClosuresError() && !this.isLoadingSiteClosures() && this.siteClosures().length === 0
+  );
+
+  protected readonly selectedSiteName = computed(() => {
+    const selectedSiteId = this.selectedSiteId();
+
+    if (selectedSiteId == null) {
+      return '';
+    }
+
+    return this.sites().find((site) => site.id === selectedSiteId)?.nom ?? `Site ${selectedSiteId}`;
+  });
+
+  protected readonly siteScopeLabel = computed(() => {
+    const adminInfo = this.adminInfo();
+
+    if (adminInfo?.adminType === 'SITE') {
+      return adminInfo.siteNom ?? 'Site administré';
+    }
+
+    return this.selectedSiteName();
+  });
+
+  ngOnInit(): void {
+    this.loadClosures();
+  }
+
+  protected onSiteChange(value: string): void {
+    const siteId = Number(value);
+
+    if (Number.isNaN(siteId)) {
+      this.selectedSiteId.set(null);
+      this.siteClosures.set([]);
+      return;
+    }
+
+    this.selectedSiteId.set(siteId);
+    this.loadSiteClosures(siteId);
+  }
+
+  protected getGlobalClosureTrack(closure: AdminGlobalClosureResponse): number {
+    return closure.id;
+  }
+
+  protected getSiteClosureTrack(closure: AdminSiteClosureResponse): number {
+    return closure.id;
+  }
+
+  protected getMotifLabel(motif: string | null): string {
+    const trimmedMotif = motif?.trim();
+    return trimmedMotif ? trimmedMotif : 'Aucun motif renseigné';
+  }
+
+  protected getSiteClosureTypeLabel(closure: AdminSiteClosureResponse): string {
+    return closure.date ? 'Date unique' : 'Période';
+  }
+
+  protected getSiteClosureDateLabel(closure: AdminSiteClosureResponse): string {
+    if (closure.date) {
+      return this.formatDate(closure.date);
+    }
+
+    if (closure.dateDebut && closure.dateFin) {
+      return `${this.formatDate(closure.dateDebut)} au ${this.formatDate(closure.dateFin)}`;
+    }
+
+    return 'Dates indisponibles';
+  }
+
+  protected formatDate(value: string): string {
+    const date = new Date(`${value}T00:00:00`);
+
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+
+    return new Intl.DateTimeFormat('fr-BE', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    }).format(date);
+  }
+
+  private loadClosures(): void {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+    this.globalClosuresError.set('');
+    this.siteClosuresError.set('');
+
+    this.adminService
+      .getInfo()
+      .pipe(
+        switchMap((adminInfo) => {
+          this.adminInfo.set(adminInfo);
+
+          if (adminInfo.adminType === 'GLOBAL') {
+            return forkJoin({
+              globalClosures: this.adminService.getGlobalClosures(),
+              sites: this.sitesService.getSites()
+            });
+          }
+
+          return forkJoin({
+            globalClosures: this.adminService.getGlobalClosures(),
+            sites: of([] as SiteOption[])
+          });
+        }),
+        finalize(() => this.isLoading.set(false))
+      )
+      .subscribe({
+        next: ({ globalClosures, sites }) => {
+          this.globalClosures.set(globalClosures);
+          this.sites.set(sites);
+          this.loadInitialSiteClosures();
+        },
+        error: (error: HttpErrorResponse) => {
+          this.globalClosures.set([]);
+          this.siteClosures.set([]);
+          this.errorMessage.set(this.getPageErrorMessage(error));
+        }
+      });
+  }
+
+  private loadInitialSiteClosures(): void {
+    const adminInfo = this.adminInfo();
+
+    if (adminInfo?.adminType === 'GLOBAL') {
+      const firstSite = this.sites()[0];
+
+      if (!firstSite) {
+        this.selectedSiteId.set(null);
+        this.siteClosures.set([]);
+        return;
+      }
+
+      this.selectedSiteId.set(firstSite.id);
+      this.loadSiteClosures(firstSite.id);
+      return;
+    }
+
+    if (adminInfo?.adminType === 'SITE' && adminInfo.siteId != null) {
+      this.selectedSiteId.set(adminInfo.siteId);
+      this.loadSiteClosures(adminInfo.siteId);
+      return;
+    }
+
+    this.siteClosuresError.set('Périmètre administrateur introuvable.');
+  }
+
+  private loadSiteClosures(siteId: number): void {
+    this.isLoadingSiteClosures.set(true);
+    this.siteClosuresError.set('');
+
+    this.adminService
+      .getSiteClosures(siteId)
+      .pipe(finalize(() => this.isLoadingSiteClosures.set(false)))
+      .subscribe({
+        next: (closures) => {
+          this.siteClosures.set(closures);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.siteClosures.set([]);
+          this.siteClosuresError.set(this.getSiteClosuresErrorMessage(error));
+        }
+      });
+  }
+
+  private getPageErrorMessage(error: HttpErrorResponse): string {
+    if (error.status === 0) {
+      return 'Backend inaccessible.';
+    }
+
+    if (error.status === 401) {
+      return 'Authentification requise.';
+    }
+
+    if (error.status === 403) {
+      return 'Accès administrateur refusé.';
+    }
+
+    return 'Impossible de charger les fermetures.';
+  }
+
+  private getSiteClosuresErrorMessage(error: HttpErrorResponse): string {
+    if (error.status === 0) {
+      return 'Backend inaccessible.';
+    }
+
+    if (error.status === 401) {
+      return 'Authentification requise.';
+    }
+
+    if (error.status === 403) {
+      return 'Accès refusé pour ce site.';
+    }
+
+    if (error.status === 404) {
+      return 'Site introuvable.';
+    }
+
+    return 'Impossible de charger les fermetures de ce site.';
+  }
+}


### PR DESCRIPTION
- ajout de la route /admin/fermetures ;
- création d’une page admin dédiée ;
- affichage des fermetures globales ;
- affichage des fermetures du site ;
- support ADMIN_GLOBAL ;
- support ADMIN_SITE ;
- carte Fermetures rendue cliquable depuis /admin ;
- gestion des états loading / erreur / vide ;
- affichage des fermetures date unique et période ;
- affichage du motif ou d’un message si aucun motif n’est renseigné.