### PR TITLE
feat(admin): création jour des fermetures globales et sites

### DIFF
--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -71,3 +71,19 @@ export interface AdminSiteClosureResponse {
   dateFin: string | null;
   motif: string | null;
 }
+
+export interface CreateGlobalClosureRequest {
+  date: string;
+  motif?: string | null;
+}
+
+export interface CreateSiteDateClosureRequest {
+  date: string;
+  motif?: string | null;
+}
+
+export interface CreateSitePeriodClosureRequest {
+  dateDebut: string;
+  dateFin: string;
+  motif?: string | null;
+}

--- a/frontend/src/app/core/admin/admin.service.ts
+++ b/frontend/src/app/core/admin/admin.service.ts
@@ -10,6 +10,9 @@ import {
   AdminInfoResponse,
   PendingRegistrationItem,
   RegistrationDecisionResponse,
+  CreateGlobalClosureRequest,
+  CreateSiteDateClosureRequest,
+  CreateSitePeriodClosureRequest,
   ValidateRegistrationRequest
 } from './admin.models';
 
@@ -40,6 +43,30 @@ export class AdminService {
   getSiteClosures(siteId: number): Observable<AdminSiteClosureResponse[]> {
     return this.http.get<AdminSiteClosureResponse[]>(
       `${environment.apiBaseUrl}/admin/sites/${siteId}/fermetures`
+    );
+  }
+
+  createGlobalClosure(payload: CreateGlobalClosureRequest): Observable<AdminGlobalClosureResponse> {
+    return this.http.post<AdminGlobalClosureResponse>(`${environment.apiBaseUrl}/fermetures-globales`, payload);
+  }
+
+  createSiteDateClosure(
+    siteId: number,
+    payload: CreateSiteDateClosureRequest
+  ): Observable<AdminSiteClosureResponse> {
+    return this.http.post<AdminSiteClosureResponse>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/fermetures/date`,
+      payload
+    );
+  }
+
+  createSitePeriodClosure(
+    siteId: number,
+    payload: CreateSitePeriodClosureRequest
+  ): Observable<AdminSiteClosureResponse> {
+    return this.http.post<AdminSiteClosureResponse>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/fermetures/periode`,
+      payload
     );
   }
 

--- a/frontend/src/app/features/admin/fermetures/admin-closures-page.component.css
+++ b/frontend/src/app/features/admin/fermetures/admin-closures-page.component.css
@@ -23,7 +23,10 @@
 }
 
 .back-link:focus-visible,
-.site-picker select:focus-visible {
+.site-picker select:focus-visible,
+.form-field input:focus-visible,
+.form-field select:focus-visible,
+.button:focus-visible {
   outline: 2px solid #8fd3c1;
   outline-offset: 2px;
 }
@@ -63,10 +66,20 @@
   color: #b91c1c;
 }
 
+.page-state.is-success {
+  border-color: #86efac;
+  background: #f0fdf4;
+  color: #166534;
+}
+
 .closures-layout,
 .closures-section,
 .closures-list,
-.section-heading {
+.section-heading,
+.closure-form,
+.form-header,
+.form-field,
+.confirmation-box {
   display: grid;
 }
 
@@ -108,6 +121,120 @@
   background: #ffffff;
   color: #10233f;
   font: inherit;
+}
+
+.closure-form {
+  gap: 0.9rem;
+  padding: 1.25rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #f8fbff;
+}
+
+.form-header {
+  gap: 0.25rem;
+}
+
+.form-header h3 {
+  margin: 0;
+  color: #10233f;
+  font-size: 1.05rem;
+}
+
+.form-header p {
+  margin: 0;
+  color: #526277;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.85rem;
+}
+
+.form-field {
+  gap: 0.35rem;
+}
+
+.form-field span {
+  color: #526277;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.form-field input,
+.form-field select {
+  min-height: 2.65rem;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid #bac7d6;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #10233f;
+  font: inherit;
+}
+
+.form-field small,
+.form-message {
+  color: #b91c1c;
+  font-size: 0.86rem;
+}
+
+.form-message {
+  margin: 0;
+}
+
+.confirmation-box {
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid #facc15;
+  border-radius: 0.5rem;
+  background: #fffbeb;
+}
+
+.confirmation-box p {
+  margin: 0;
+  color: #713f12;
+  font-weight: 700;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.button {
+  min-height: 2.5rem;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.button-primary {
+  background: #0f766e;
+  color: #ffffff;
+}
+
+.button-primary:hover:not(:disabled) {
+  background: #115e59;
+}
+
+.button-secondary {
+  border-color: #bac7d6;
+  background: #ffffff;
+  color: #10233f;
+}
+
+.button-secondary:hover:not(:disabled) {
+  background: #eef4fb;
 }
 
 .closures-list {
@@ -166,5 +293,9 @@
 
   .closure-card {
     padding: 1.1rem;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/app/features/admin/fermetures/admin-closures-page.component.html
+++ b/frontend/src/app/features/admin/fermetures/admin-closures-page.component.html
@@ -11,11 +11,63 @@
   } @else if (errorMessage()) {
     <p class="page-state is-error">{{ errorMessage() }}</p>
   } @else {
+    @if (successMessage()) {
+      <p class="page-state is-success" role="status" aria-live="polite">{{ successMessage() }}</p>
+    }
+
     <div class="closures-layout">
       <section class="closures-section">
         <div class="section-heading">
           <h2>Fermetures globales</h2>
         </div>
+
+        @if (isAdminGlobal()) {
+          <form class="closure-form" [formGroup]="globalClosureForm" (ngSubmit)="requestGlobalClosureCreation()">
+            <div class="form-header">
+              <h3>Cr&eacute;er une fermeture globale</h3>
+              <p>Une fermeture globale concerne tous les sites.</p>
+            </div>
+
+            <div class="form-grid">
+              <label class="form-field">
+                <span>Date</span>
+                <input type="date" formControlName="date">
+                @if (showGlobalDateError()) {
+                  <small>La date est obligatoire.</small>
+                }
+              </label>
+
+              <label class="form-field">
+                <span>Motif</span>
+                <input type="text" formControlName="motif" placeholder="Optionnel">
+              </label>
+            </div>
+
+            @if (globalCreateError()) {
+              <p class="form-message is-error" role="alert">{{ globalCreateError() }}</p>
+            }
+
+            @if (isPendingAction('global')) {
+              <div class="confirmation-box">
+                <p>Confirmer la cr&eacute;ation de cette fermeture ? Des matchs futurs peuvent &ecirc;tre annul&eacute;s.</p>
+                <div class="form-actions">
+                  <button type="button" class="button button-primary" (click)="confirmPendingAction()" [disabled]="isSubmittingGlobalClosure()">
+                    Confirmer
+                  </button>
+                  <button type="button" class="button button-secondary" (click)="cancelPendingAction()" [disabled]="isSubmittingGlobalClosure()">
+                    Annuler
+                  </button>
+                </div>
+              </div>
+            } @else {
+              <div class="form-actions">
+                <button type="submit" class="button button-primary" [disabled]="isSubmittingGlobalClosure()">
+                  Cr&eacute;er une fermeture globale
+                </button>
+              </div>
+            }
+          </form>
+        }
 
         @if (globalClosuresError()) {
           <p class="page-state is-error">{{ globalClosuresError() }}</p>
@@ -55,6 +107,81 @@
             <p class="site-scope">{{ siteScopeLabel() }}</p>
           }
         </div>
+
+        @if (canCreateSiteClosure()) {
+          <form class="closure-form" [formGroup]="siteClosureForm" (ngSubmit)="requestSiteClosureCreation()">
+            <div class="form-header">
+              <h3>Cr&eacute;er une fermeture de site</h3>
+              <p>La fermeture sera appliqu&eacute;e au site affich&eacute; dans cette section.</p>
+            </div>
+
+            <div class="form-grid">
+              <label class="form-field">
+                <span>Type</span>
+                <select formControlName="mode">
+                  @for (mode of siteClosureModes; track mode.value) {
+                    <option [value]="mode.value">{{ mode.label }}</option>
+                  }
+                </select>
+              </label>
+
+              @if (isSiteClosureMode('date')) {
+                <label class="form-field">
+                  <span>Date</span>
+                  <input type="date" formControlName="date">
+                  @if (showSiteDateError()) {
+                    <small>La date est obligatoire.</small>
+                  }
+                </label>
+              } @else {
+                <label class="form-field">
+                  <span>Date de d&eacute;but</span>
+                  <input type="date" formControlName="dateDebut">
+                  @if (showSiteDateDebutError()) {
+                    <small>La date de d&eacute;but est obligatoire.</small>
+                  }
+                </label>
+
+                <label class="form-field">
+                  <span>Date de fin</span>
+                  <input type="date" formControlName="dateFin">
+                  @if (showSiteDateFinError()) {
+                    <small>La date de fin est obligatoire.</small>
+                  }
+                </label>
+              }
+
+              <label class="form-field">
+                <span>Motif</span>
+                <input type="text" formControlName="motif" placeholder="Optionnel">
+              </label>
+            </div>
+
+            @if (siteCreateError()) {
+              <p class="form-message is-error" role="alert">{{ siteCreateError() }}</p>
+            }
+
+            @if (isPendingAction('site-date') || isPendingAction('site-period')) {
+              <div class="confirmation-box">
+                <p>Confirmer la cr&eacute;ation de cette fermeture ? Des matchs futurs peuvent &ecirc;tre annul&eacute;s.</p>
+                <div class="form-actions">
+                  <button type="button" class="button button-primary" (click)="confirmPendingAction()" [disabled]="isSubmittingSiteClosure()">
+                    Confirmer
+                  </button>
+                  <button type="button" class="button button-secondary" (click)="cancelPendingAction()" [disabled]="isSubmittingSiteClosure()">
+                    Annuler
+                  </button>
+                </div>
+              </div>
+            } @else {
+              <div class="form-actions">
+                <button type="submit" class="button button-primary" [disabled]="isSubmittingSiteClosure()">
+                  Cr&eacute;er la fermeture
+                </button>
+              </div>
+            }
+          </form>
+        }
 
         @if (isAdminGlobal() && sites().length === 0) {
           <p class="page-state">Aucun site disponible.</p>

--- a/frontend/src/app/features/admin/fermetures/admin-closures-page.component.ts
+++ b/frontend/src/app/features/admin/fermetures/admin-closures-page.component.ts
@@ -1,27 +1,36 @@
 import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { finalize, forkJoin, of, switchMap } from 'rxjs';
+import { finalize, forkJoin, Observable, of, switchMap } from 'rxjs';
 import {
   AdminGlobalClosureResponse,
   AdminInfoResponse,
-  AdminSiteClosureResponse
+  AdminSiteClosureResponse,
+  CreateGlobalClosureRequest,
+  CreateSiteDateClosureRequest,
+  CreateSitePeriodClosureRequest
 } from '../../../core/admin/admin.models';
 import { AdminService } from '../../../core/admin/admin.service';
+import { ApiErrorResponse } from '../../../core/auth/auth.models';
 import { SiteOption } from '../../../core/sites/site.models';
 import { SitesService } from '../../../core/sites/sites.service';
+
+type SiteClosureMode = 'date' | 'period';
+type PendingClosureAction = 'global' | 'site-date' | 'site-period' | null;
 
 @Component({
   selector: 'app-admin-closures-page',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
   templateUrl: './admin-closures-page.component.html',
   styleUrl: './admin-closures-page.component.css'
 })
 export class AdminClosuresPageComponent implements OnInit {
   private readonly adminService = inject(AdminService);
   private readonly sitesService = inject(SitesService);
+  private readonly fb = inject(FormBuilder);
 
   protected readonly adminInfo = signal<AdminInfoResponse | null>(null);
   protected readonly globalClosures = signal<AdminGlobalClosureResponse[]>([]);
@@ -34,12 +43,37 @@ export class AdminClosuresPageComponent implements OnInit {
   protected readonly errorMessage = signal('');
   protected readonly globalClosuresError = signal('');
   protected readonly siteClosuresError = signal('');
+  protected readonly successMessage = signal('');
+  protected readonly globalCreateError = signal('');
+  protected readonly siteCreateError = signal('');
+  protected readonly pendingAction = signal<PendingClosureAction>(null);
+  protected readonly isSubmittingGlobalClosure = signal(false);
+  protected readonly isSubmittingSiteClosure = signal(false);
+
+  protected readonly siteClosureModes: Array<{ value: SiteClosureMode; label: string }> = [
+    { value: 'date', label: 'Date unique' },
+    { value: 'period', label: 'P\u00e9riode' }
+  ];
+
+  protected readonly globalClosureForm = this.fb.group({
+    date: this.fb.nonNullable.control('', [Validators.required]),
+    motif: this.fb.control<string | null>(null)
+  });
+
+  protected readonly siteClosureForm = this.fb.group({
+    mode: this.fb.nonNullable.control<SiteClosureMode>('date', [Validators.required]),
+    date: this.fb.control<string | null>(null, [Validators.required]),
+    dateDebut: this.fb.control<string | null>(null),
+    dateFin: this.fb.control<string | null>(null),
+    motif: this.fb.control<string | null>(null)
+  });
 
   protected readonly isAdminGlobal = computed(() => this.adminInfo()?.adminType === 'GLOBAL');
   protected readonly hasNoGlobalClosures = computed(() => !this.globalClosuresError() && this.globalClosures().length === 0);
   protected readonly hasNoSiteClosures = computed(
     () => !this.siteClosuresError() && !this.isLoadingSiteClosures() && this.siteClosures().length === 0
   );
+  protected readonly canCreateSiteClosure = computed(() => this.getCurrentSiteId() != null);
 
   protected readonly selectedSiteName = computed(() => {
     const selectedSiteId = this.selectedSiteId();
@@ -62,6 +96,14 @@ export class AdminClosuresPageComponent implements OnInit {
   });
 
   ngOnInit(): void {
+    this.applySiteModeValidators(this.siteClosureForm.controls.mode.value);
+
+    this.siteClosureForm.controls.mode.valueChanges.subscribe((mode) => {
+      this.pendingAction.set(null);
+      this.siteCreateError.set('');
+      this.applySiteModeValidators(mode);
+    });
+
     this.loadClosures();
   }
 
@@ -71,11 +113,98 @@ export class AdminClosuresPageComponent implements OnInit {
     if (Number.isNaN(siteId)) {
       this.selectedSiteId.set(null);
       this.siteClosures.set([]);
+      this.pendingAction.set(null);
       return;
     }
 
     this.selectedSiteId.set(siteId);
+    this.pendingAction.set(null);
+    this.siteCreateError.set('');
     this.loadSiteClosures(siteId);
+  }
+
+  protected requestGlobalClosureCreation(): void {
+    this.successMessage.set('');
+    this.globalCreateError.set('');
+    this.pendingAction.set(null);
+
+    if (this.globalClosureForm.invalid) {
+      this.globalClosureForm.markAllAsTouched();
+      this.globalCreateError.set('La date est obligatoire.');
+      return;
+    }
+
+    this.pendingAction.set('global');
+  }
+
+  protected requestSiteClosureCreation(): void {
+    this.successMessage.set('');
+    this.siteCreateError.set('');
+    this.pendingAction.set(null);
+    this.applySiteModeValidators(this.siteClosureForm.controls.mode.value);
+
+    if (this.getCurrentSiteId() == null) {
+      this.siteCreateError.set('Aucun site disponible pour cette fermeture.');
+      return;
+    }
+
+    if (this.siteClosureForm.invalid) {
+      this.siteClosureForm.markAllAsTouched();
+      this.siteCreateError.set(this.getSiteFormValidationMessage());
+      return;
+    }
+
+    this.pendingAction.set(this.siteClosureForm.controls.mode.value === 'date' ? 'site-date' : 'site-period');
+  }
+
+  protected cancelPendingAction(): void {
+    this.pendingAction.set(null);
+  }
+
+  protected confirmPendingAction(): void {
+    const action = this.pendingAction();
+
+    if (action === 'global') {
+      this.confirmGlobalClosureCreation();
+      return;
+    }
+
+    if (action === 'site-date') {
+      this.confirmSiteDateClosureCreation();
+      return;
+    }
+
+    if (action === 'site-period') {
+      this.confirmSitePeriodClosureCreation();
+    }
+  }
+
+  protected isPendingAction(action: PendingClosureAction): boolean {
+    return this.pendingAction() === action;
+  }
+
+  protected showGlobalDateError(): boolean {
+    const control = this.globalClosureForm.controls.date;
+    return control.invalid && (control.dirty || control.touched);
+  }
+
+  protected showSiteDateError(): boolean {
+    const control = this.siteClosureForm.controls.date;
+    return this.siteClosureForm.controls.mode.value === 'date' && control.invalid && (control.dirty || control.touched);
+  }
+
+  protected showSiteDateDebutError(): boolean {
+    const control = this.siteClosureForm.controls.dateDebut;
+    return this.siteClosureForm.controls.mode.value === 'period' && control.invalid && (control.dirty || control.touched);
+  }
+
+  protected showSiteDateFinError(): boolean {
+    const control = this.siteClosureForm.controls.dateFin;
+    return this.siteClosureForm.controls.mode.value === 'period' && control.invalid && (control.dirty || control.touched);
+  }
+
+  protected isSiteClosureMode(mode: SiteClosureMode): boolean {
+    return this.siteClosureForm.controls.mode.value === mode;
   }
 
   protected getGlobalClosureTrack(closure: AdminGlobalClosureResponse): number {
@@ -119,6 +248,176 @@ export class AdminClosuresPageComponent implements OnInit {
       month: '2-digit',
       year: 'numeric'
     }).format(date);
+  }
+
+  private confirmGlobalClosureCreation(): void {
+    if (this.globalClosureForm.invalid) {
+      this.globalClosureForm.markAllAsTouched();
+      this.globalCreateError.set('La date est obligatoire.');
+      this.pendingAction.set(null);
+      return;
+    }
+
+    const rawValue = this.globalClosureForm.getRawValue();
+    const payload: CreateGlobalClosureRequest = {
+      date: rawValue.date,
+      motif: this.normalizeMotif(rawValue.motif)
+    };
+
+    this.isSubmittingGlobalClosure.set(true);
+    this.globalCreateError.set('');
+
+    this.adminService
+      .createGlobalClosure(payload)
+      .pipe(finalize(() => this.isSubmittingGlobalClosure.set(false)))
+      .subscribe({
+        next: () => {
+          this.pendingAction.set(null);
+          this.globalClosureForm.reset({ date: '', motif: null });
+          this.successMessage.set('Fermeture globale cr\u00e9\u00e9e.');
+          this.loadGlobalClosures();
+        },
+        error: (error: HttpErrorResponse) => {
+          this.globalCreateError.set(this.getCreateErrorMessage(error, 'Impossible de cr\u00e9er la fermeture globale.'));
+        }
+      });
+  }
+
+  private confirmSiteDateClosureCreation(): void {
+    const siteId = this.getCurrentSiteId();
+    const date = this.siteClosureForm.controls.date.value;
+
+    if (siteId == null) {
+      this.siteCreateError.set('Aucun site disponible pour cette fermeture.');
+      this.pendingAction.set(null);
+      return;
+    }
+
+    if (!date) {
+      this.siteClosureForm.controls.date.markAsTouched();
+      this.siteCreateError.set('La date est obligatoire.');
+      this.pendingAction.set(null);
+      return;
+    }
+
+    const payload: CreateSiteDateClosureRequest = {
+      date,
+      motif: this.normalizeMotif(this.siteClosureForm.controls.motif.value)
+    };
+
+    this.submitSiteClosure(siteId, this.adminService.createSiteDateClosure(siteId, payload));
+  }
+
+  private confirmSitePeriodClosureCreation(): void {
+    const siteId = this.getCurrentSiteId();
+    const dateDebut = this.siteClosureForm.controls.dateDebut.value;
+    const dateFin = this.siteClosureForm.controls.dateFin.value;
+
+    if (siteId == null) {
+      this.siteCreateError.set('Aucun site disponible pour cette fermeture.');
+      this.pendingAction.set(null);
+      return;
+    }
+
+    if (!dateDebut || !dateFin) {
+      this.siteClosureForm.markAllAsTouched();
+      this.siteCreateError.set('La p\u00e9riode doit contenir une date de d\u00e9but et une date de fin.');
+      this.pendingAction.set(null);
+      return;
+    }
+
+    const payload: CreateSitePeriodClosureRequest = {
+      dateDebut,
+      dateFin,
+      motif: this.normalizeMotif(this.siteClosureForm.controls.motif.value)
+    };
+
+    this.submitSiteClosure(siteId, this.adminService.createSitePeriodClosure(siteId, payload));
+  }
+
+  private submitSiteClosure(siteId: number, request$: Observable<unknown>): void {
+    this.isSubmittingSiteClosure.set(true);
+    this.siteCreateError.set('');
+
+    request$
+      .pipe(finalize(() => this.isSubmittingSiteClosure.set(false)))
+      .subscribe({
+        next: () => {
+          this.pendingAction.set(null);
+          this.siteClosureForm.reset({
+            mode: 'date',
+            date: null,
+            dateDebut: null,
+            dateFin: null,
+            motif: null
+          });
+          this.applySiteModeValidators('date');
+          this.successMessage.set('Fermeture du site cr\u00e9\u00e9e.');
+          this.loadSiteClosures(siteId);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.siteCreateError.set(this.getCreateErrorMessage(error, 'Impossible de cr\u00e9er la fermeture du site.'));
+        }
+      });
+  }
+
+  private loadGlobalClosures(): void {
+    this.globalClosuresError.set('');
+
+    this.adminService
+      .getGlobalClosures()
+      .subscribe({
+        next: (closures) => {
+          this.globalClosures.set(closures);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.globalClosures.set([]);
+          this.globalClosuresError.set(this.getPageErrorMessage(error));
+        }
+      });
+  }
+
+  private applySiteModeValidators(mode: SiteClosureMode): void {
+    const dateControl = this.siteClosureForm.controls.date;
+    const dateDebutControl = this.siteClosureForm.controls.dateDebut;
+    const dateFinControl = this.siteClosureForm.controls.dateFin;
+
+    if (mode === 'date') {
+      dateControl.setValidators([Validators.required]);
+      dateDebutControl.clearValidators();
+      dateFinControl.clearValidators();
+    } else {
+      dateControl.clearValidators();
+      dateDebutControl.setValidators([Validators.required]);
+      dateFinControl.setValidators([Validators.required]);
+    }
+
+    dateControl.updateValueAndValidity({ emitEvent: false });
+    dateDebutControl.updateValueAndValidity({ emitEvent: false });
+    dateFinControl.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private getCurrentSiteId(): number | null {
+    const adminInfo = this.adminInfo();
+
+    if (adminInfo?.adminType === 'SITE') {
+      return adminInfo.siteId;
+    }
+
+    return this.selectedSiteId();
+  }
+
+  private normalizeMotif(value: string | null | undefined): string | null {
+    const trimmedValue = value?.trim();
+    return trimmedValue ? trimmedValue : null;
+  }
+
+  private getSiteFormValidationMessage(): string {
+    if (this.siteClosureForm.controls.mode.value === 'date') {
+      return 'La date est obligatoire.';
+    }
+
+    return 'La p\u00e9riode doit contenir une date de d\u00e9but et une date de fin.';
   }
 
   private loadClosures(): void {
@@ -203,6 +502,48 @@ export class AdminClosuresPageComponent implements OnInit {
           this.siteClosuresError.set(this.getSiteClosuresErrorMessage(error));
         }
       });
+  }
+
+  private getCreateErrorMessage(error: HttpErrorResponse, fallbackMessage: string): string {
+    const apiError = this.normalizeApiErrorBody(error.error);
+
+    if (error.status === 0) {
+      return 'Backend inaccessible.';
+    }
+
+    if (error.status === 401) {
+      return 'Authentification requise.';
+    }
+
+    if (error.status === 403) {
+      return 'Acc\u00e8s refus\u00e9.';
+    }
+
+    if (error.status === 404) {
+      return apiError.message || 'Site introuvable.';
+    }
+
+    if (apiError.details) {
+      return Object.values(apiError.details).join(' ');
+    }
+
+    return apiError.message || fallbackMessage;
+  }
+
+  private normalizeApiErrorBody(raw: unknown): Partial<ApiErrorResponse> {
+    if (typeof raw === 'string') {
+      try {
+        return JSON.parse(raw) as Partial<ApiErrorResponse>;
+      } catch {
+        return { message: raw };
+      }
+    }
+
+    if (raw && typeof raw === 'object') {
+      return raw as Partial<ApiErrorResponse>;
+    }
+
+    return {};
   }
 
   private getPageErrorMessage(error: HttpErrorResponse): string {


### PR DESCRIPTION
- ajout de la création des fermetures globales et des fermetures de site depuis l’interface admin.
- ajout des formulaires Angular 
- appels API via AdminService 
- la confirmation inline avant création
- les messages de succès/erreur 
- le rechargement ciblé des listes concernées.

