### PR TITLE
feat(admin): ajout modification fermetures site

### DIFF
--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -87,3 +87,14 @@ export interface CreateSitePeriodClosureRequest {
   dateFin: string;
   motif?: string | null;
 }
+
+export interface UpdateSiteDateClosureRequest {
+  date: string;
+  motif?: string | null;
+}
+
+export interface UpdateSitePeriodClosureRequest {
+  dateDebut: string;
+  dateFin: string;
+  motif?: string | null;
+}

--- a/frontend/src/app/core/admin/admin.service.ts
+++ b/frontend/src/app/core/admin/admin.service.ts
@@ -13,6 +13,8 @@ import {
   CreateGlobalClosureRequest,
   CreateSiteDateClosureRequest,
   CreateSitePeriodClosureRequest,
+  UpdateSiteDateClosureRequest,
+  UpdateSitePeriodClosureRequest,
   ValidateRegistrationRequest
 } from './admin.models';
 
@@ -77,6 +79,28 @@ export class AdminService {
   deleteSiteClosure(siteId: number, closureId: number): Observable<void> {
     return this.http.delete<void>(
       `${environment.apiBaseUrl}/admin/sites/${siteId}/fermetures/${closureId}`
+    );
+  }
+
+  updateSiteDateClosure(
+    siteId: number,
+    closureId: number,
+    payload: UpdateSiteDateClosureRequest
+  ): Observable<AdminSiteClosureResponse> {
+    return this.http.put<AdminSiteClosureResponse>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/fermetures/${closureId}/date`,
+      payload
+    );
+  }
+
+  updateSitePeriodClosure(
+    siteId: number,
+    closureId: number,
+    payload: UpdateSitePeriodClosureRequest
+  ): Observable<AdminSiteClosureResponse> {
+    return this.http.put<AdminSiteClosureResponse>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/fermetures/${closureId}/periode`,
+      payload
     );
   }
 

--- a/frontend/src/app/features/admin/fermetures/admin-closures-page.component.css
+++ b/frontend/src/app/features/admin/fermetures/admin-closures-page.component.css
@@ -131,6 +131,10 @@
   background: #f8fbff;
 }
 
+.closure-form.edit-form {
+  background: #ffffff;
+}
+
 .form-header {
   gap: 0.25rem;
 }

--- a/frontend/src/app/features/admin/fermetures/admin-closures-page.component.html
+++ b/frontend/src/app/features/admin/fermetures/admin-closures-page.component.html
@@ -237,6 +237,10 @@
             <p class="page-state is-error">{{ siteDeleteError() }}</p>
           }
 
+          @if (siteUpdateError()) {
+            <p class="page-state is-error">{{ siteUpdateError() }}</p>
+          }
+
           @if (hasNoSiteClosures()) {
             <p class="page-state">Aucune fermeture enregistr&eacute;e pour ce site.</p>
           } @else {
@@ -253,6 +257,15 @@
                     <div class="closure-actions">
                       <button
                         type="button"
+                        class="button button-secondary"
+                        (click)="openSiteClosureEdit(closure)"
+                        [disabled]="updatingSiteClosureId() === closure.id || deletingSiteClosureId() === closure.id"
+                      >
+                        Modifier
+                      </button>
+
+                      <button
+                        type="button"
                         class="button button-danger"
                         (click)="requestSiteClosureDeletion(closure)"
                         [disabled]="deletingSiteClosureId() === closure.id"
@@ -260,6 +273,99 @@
                         Supprimer
                       </button>
                     </div>
+                  }
+
+                  @if (isEditingSiteClosure(closure.id)) {
+                    <form class="closure-form edit-form" [formGroup]="editSiteClosureForm" (ngSubmit)="requestSiteClosureUpdate(closure)">
+                      <div class="form-header">
+                        <h3>Modifier la fermeture</h3>
+                        <p>Choisissez une date unique ou une p&eacute;riode.</p>
+                      </div>
+
+                      <div class="form-grid">
+                        <label class="form-field">
+                          <span>Type</span>
+                          <select formControlName="mode">
+                            @for (mode of siteClosureModes; track mode.value) {
+                              <option [value]="mode.value">{{ mode.label }}</option>
+                            }
+                          </select>
+                        </label>
+
+                        @if (isEditSiteClosureMode('date')) {
+                          <label class="form-field">
+                            <span>Date</span>
+                            <input type="date" formControlName="date">
+                            @if (showEditDateError()) {
+                              <small>La date est obligatoire.</small>
+                            }
+                          </label>
+                        } @else {
+                          <label class="form-field">
+                            <span>Date de d&eacute;but</span>
+                            <input type="date" formControlName="dateDebut">
+                            @if (showEditDateDebutError()) {
+                              <small>La date de d&eacute;but est obligatoire.</small>
+                            }
+                          </label>
+
+                          <label class="form-field">
+                            <span>Date de fin</span>
+                            <input type="date" formControlName="dateFin">
+                            @if (showEditDateFinError()) {
+                              <small>La date de fin est obligatoire.</small>
+                            }
+                          </label>
+                        }
+
+                        <label class="form-field">
+                          <span>Motif</span>
+                          <input type="text" formControlName="motif" placeholder="Optionnel">
+                        </label>
+                      </div>
+
+                      @if (isPendingEdit(closure.id)) {
+                        <div class="confirmation-box">
+                          <p>Confirmer la modification de cette fermeture ? Des matchs futurs peuvent &ecirc;tre impact&eacute;s.</p>
+                          <div class="form-actions">
+                            <button
+                              type="button"
+                              class="button button-primary"
+                              (click)="confirmSiteClosureUpdate()"
+                              [disabled]="updatingSiteClosureId() === closure.id"
+                            >
+                              Confirmer
+                            </button>
+                            <button
+                              type="button"
+                              class="button button-secondary"
+                              (click)="cancelEditConfirmation()"
+                              [disabled]="updatingSiteClosureId() === closure.id"
+                            >
+                              Annuler
+                            </button>
+                          </div>
+                        </div>
+                      } @else {
+                        <div class="form-actions">
+                          <button
+                            type="submit"
+                            class="button button-primary"
+                            [disabled]="updatingSiteClosureId() === closure.id"
+                          >
+                            Enregistrer
+                          </button>
+                          <button
+                            type="button"
+                            class="button button-secondary"
+                            (click)="cancelSiteClosureEdit()"
+                            [disabled]="updatingSiteClosureId() === closure.id"
+                          >
+                            Annuler
+                          </button>
+                        </div>
+                      }
+                    </form>
                   }
 
                   @if (isPendingSiteDelete(closure.id)) {

--- a/frontend/src/app/features/admin/fermetures/admin-closures-page.component.ts
+++ b/frontend/src/app/features/admin/fermetures/admin-closures-page.component.ts
@@ -10,7 +10,9 @@ import {
   AdminSiteClosureResponse,
   CreateGlobalClosureRequest,
   CreateSiteDateClosureRequest,
-  CreateSitePeriodClosureRequest
+  CreateSitePeriodClosureRequest,
+  UpdateSiteDateClosureRequest,
+  UpdateSitePeriodClosureRequest
 } from '../../../core/admin/admin.models';
 import { AdminService } from '../../../core/admin/admin.service';
 import { ApiErrorResponse } from '../../../core/auth/auth.models';
@@ -23,6 +25,7 @@ type PendingDeleteAction =
   | { type: 'global'; id: number }
   | { type: 'site'; id: number }
   | null;
+type PendingEditAction = { id: number; mode: SiteClosureMode } | null;
 
 @Component({
   selector: 'app-admin-closures-page',
@@ -52,12 +55,16 @@ export class AdminClosuresPageComponent implements OnInit {
   protected readonly siteCreateError = signal('');
   protected readonly globalDeleteError = signal('');
   protected readonly siteDeleteError = signal('');
+  protected readonly siteUpdateError = signal('');
   protected readonly pendingAction = signal<PendingClosureAction>(null);
   protected readonly pendingDeleteAction = signal<PendingDeleteAction>(null);
+  protected readonly pendingEditAction = signal<PendingEditAction>(null);
+  protected readonly activeEditClosureId = signal<number | null>(null);
   protected readonly isSubmittingGlobalClosure = signal(false);
   protected readonly isSubmittingSiteClosure = signal(false);
   protected readonly deletingGlobalClosureId = signal<number | null>(null);
   protected readonly deletingSiteClosureId = signal<number | null>(null);
+  protected readonly updatingSiteClosureId = signal<number | null>(null);
 
   protected readonly siteClosureModes: Array<{ value: SiteClosureMode; label: string }> = [
     { value: 'date', label: 'Date unique' },
@@ -70,6 +77,14 @@ export class AdminClosuresPageComponent implements OnInit {
   });
 
   protected readonly siteClosureForm = this.fb.group({
+    mode: this.fb.nonNullable.control<SiteClosureMode>('date', [Validators.required]),
+    date: this.fb.control<string | null>(null, [Validators.required]),
+    dateDebut: this.fb.control<string | null>(null),
+    dateFin: this.fb.control<string | null>(null),
+    motif: this.fb.control<string | null>(null)
+  });
+
+  protected readonly editSiteClosureForm = this.fb.group({
     mode: this.fb.nonNullable.control<SiteClosureMode>('date', [Validators.required]),
     date: this.fb.control<string | null>(null, [Validators.required]),
     dateDebut: this.fb.control<string | null>(null),
@@ -114,6 +129,12 @@ export class AdminClosuresPageComponent implements OnInit {
       this.applySiteModeValidators(mode);
     });
 
+    this.editSiteClosureForm.controls.mode.valueChanges.subscribe((mode) => {
+      this.pendingEditAction.set(null);
+      this.siteUpdateError.set('');
+      this.applyEditModeValidators(mode);
+    });
+
     this.loadClosures();
   }
 
@@ -125,14 +146,17 @@ export class AdminClosuresPageComponent implements OnInit {
       this.siteClosures.set([]);
       this.pendingAction.set(null);
       this.pendingDeleteAction.set(null);
+      this.cancelSiteClosureEdit();
       return;
     }
 
     this.selectedSiteId.set(siteId);
     this.pendingAction.set(null);
     this.pendingDeleteAction.set(null);
+    this.cancelSiteClosureEdit();
     this.siteCreateError.set('');
     this.siteDeleteError.set('');
+    this.siteUpdateError.set('');
     this.loadSiteClosures(siteId);
   }
 
@@ -155,6 +179,7 @@ export class AdminClosuresPageComponent implements OnInit {
     this.siteCreateError.set('');
     this.pendingAction.set(null);
     this.pendingDeleteAction.set(null);
+    this.cancelSiteClosureEdit();
     this.applySiteModeValidators(this.siteClosureForm.controls.mode.value);
 
     if (this.getCurrentSiteId() == null) {
@@ -200,6 +225,7 @@ export class AdminClosuresPageComponent implements OnInit {
     this.successMessage.set('');
     this.globalDeleteError.set('');
     this.pendingAction.set(null);
+    this.cancelSiteClosureEdit();
     this.pendingDeleteAction.set({ type: 'global', id: closure.id });
   }
 
@@ -207,6 +233,7 @@ export class AdminClosuresPageComponent implements OnInit {
     this.successMessage.set('');
     this.siteDeleteError.set('');
     this.pendingAction.set(null);
+    this.cancelSiteClosureEdit();
     this.pendingDeleteAction.set({ type: 'site', id: closure.id });
   }
 
@@ -241,6 +268,96 @@ export class AdminClosuresPageComponent implements OnInit {
     return this.isAdminGlobal();
   }
 
+  protected openSiteClosureEdit(closure: AdminSiteClosureResponse): void {
+    this.successMessage.set('');
+    this.siteUpdateError.set('');
+    this.pendingAction.set(null);
+    this.pendingDeleteAction.set(null);
+    this.pendingEditAction.set(null);
+    this.activeEditClosureId.set(closure.id);
+
+    if (closure.date) {
+      this.editSiteClosureForm.reset({
+        mode: 'date',
+        date: closure.date,
+        dateDebut: null,
+        dateFin: null,
+        motif: closure.motif
+      });
+      this.applyEditModeValidators('date');
+      return;
+    }
+
+    this.editSiteClosureForm.reset({
+      mode: 'period',
+      date: null,
+      dateDebut: closure.dateDebut,
+      dateFin: closure.dateFin,
+      motif: closure.motif
+    });
+    this.applyEditModeValidators('period');
+  }
+
+  protected cancelSiteClosureEdit(): void {
+    this.activeEditClosureId.set(null);
+    this.pendingEditAction.set(null);
+    this.siteUpdateError.set('');
+    this.editSiteClosureForm.reset({
+      mode: 'date',
+      date: null,
+      dateDebut: null,
+      dateFin: null,
+      motif: null
+    });
+    this.applyEditModeValidators('date');
+  }
+
+  protected requestSiteClosureUpdate(closure: AdminSiteClosureResponse): void {
+    this.successMessage.set('');
+    this.siteUpdateError.set('');
+    this.pendingEditAction.set(null);
+    this.applyEditModeValidators(this.editSiteClosureForm.controls.mode.value);
+
+    if (this.getCurrentSiteId() == null) {
+      this.siteUpdateError.set('Aucun site disponible pour cette modification.');
+      return;
+    }
+
+    if (this.editSiteClosureForm.invalid) {
+      this.editSiteClosureForm.markAllAsTouched();
+      return;
+    }
+
+    this.pendingEditAction.set({ id: closure.id, mode: this.editSiteClosureForm.controls.mode.value });
+  }
+
+  protected cancelEditConfirmation(): void {
+    this.pendingEditAction.set(null);
+  }
+
+  protected confirmSiteClosureUpdate(): void {
+    const action = this.pendingEditAction();
+
+    if (!action) {
+      return;
+    }
+
+    if (action.mode === 'date') {
+      this.updateSiteClosureAsDate(action.id);
+      return;
+    }
+
+    this.updateSiteClosureAsPeriod(action.id);
+  }
+
+  protected isEditingSiteClosure(id: number): boolean {
+    return this.activeEditClosureId() === id;
+  }
+
+  protected isPendingEdit(id: number): boolean {
+    return this.pendingEditAction()?.id === id;
+  }
+
   protected showGlobalDateError(): boolean {
     const control = this.globalClosureForm.controls.date;
     return control.invalid && (control.dirty || control.touched);
@@ -263,6 +380,25 @@ export class AdminClosuresPageComponent implements OnInit {
 
   protected isSiteClosureMode(mode: SiteClosureMode): boolean {
     return this.siteClosureForm.controls.mode.value === mode;
+  }
+
+  protected isEditSiteClosureMode(mode: SiteClosureMode): boolean {
+    return this.editSiteClosureForm.controls.mode.value === mode;
+  }
+
+  protected showEditDateError(): boolean {
+    const control = this.editSiteClosureForm.controls.date;
+    return this.editSiteClosureForm.controls.mode.value === 'date' && control.invalid && (control.dirty || control.touched);
+  }
+
+  protected showEditDateDebutError(): boolean {
+    const control = this.editSiteClosureForm.controls.dateDebut;
+    return this.editSiteClosureForm.controls.mode.value === 'period' && control.invalid && (control.dirty || control.touched);
+  }
+
+  protected showEditDateFinError(): boolean {
+    const control = this.editSiteClosureForm.controls.dateFin;
+    return this.editSiteClosureForm.controls.mode.value === 'period' && control.invalid && (control.dirty || control.touched);
   }
 
   protected getGlobalClosureTrack(closure: AdminGlobalClosureResponse): number {
@@ -478,10 +614,99 @@ export class AdminClosuresPageComponent implements OnInit {
       });
   }
 
+  private updateSiteClosureAsDate(id: number): void {
+    const siteId = this.getCurrentSiteId();
+    const date = this.editSiteClosureForm.controls.date.value;
+
+    if (siteId == null) {
+      this.siteUpdateError.set('Aucun site disponible pour cette modification.');
+      this.pendingEditAction.set(null);
+      return;
+    }
+
+    if (!date) {
+      this.editSiteClosureForm.controls.date.markAsTouched();
+      this.pendingEditAction.set(null);
+      return;
+    }
+
+    const payload: UpdateSiteDateClosureRequest = {
+      date,
+      motif: this.normalizeMotif(this.editSiteClosureForm.controls.motif.value)
+    };
+
+    this.submitSiteClosureUpdate(siteId, id, this.adminService.updateSiteDateClosure(siteId, id, payload));
+  }
+
+  private updateSiteClosureAsPeriod(id: number): void {
+    const siteId = this.getCurrentSiteId();
+    const dateDebut = this.editSiteClosureForm.controls.dateDebut.value;
+    const dateFin = this.editSiteClosureForm.controls.dateFin.value;
+
+    if (siteId == null) {
+      this.siteUpdateError.set('Aucun site disponible pour cette modification.');
+      this.pendingEditAction.set(null);
+      return;
+    }
+
+    if (!dateDebut || !dateFin) {
+      this.editSiteClosureForm.markAllAsTouched();
+      this.pendingEditAction.set(null);
+      return;
+    }
+
+    const payload: UpdateSitePeriodClosureRequest = {
+      dateDebut,
+      dateFin,
+      motif: this.normalizeMotif(this.editSiteClosureForm.controls.motif.value)
+    };
+
+    this.submitSiteClosureUpdate(siteId, id, this.adminService.updateSitePeriodClosure(siteId, id, payload));
+  }
+
+  private submitSiteClosureUpdate(siteId: number, id: number, request$: Observable<unknown>): void {
+    this.updatingSiteClosureId.set(id);
+    this.siteUpdateError.set('');
+
+    request$
+      .pipe(finalize(() => this.updatingSiteClosureId.set(null)))
+      .subscribe({
+        next: () => {
+          this.activeEditClosureId.set(null);
+          this.pendingEditAction.set(null);
+          this.successMessage.set('Fermeture du site modifi\u00e9e.');
+          this.loadSiteClosures(siteId);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.siteUpdateError.set(this.getUpdateErrorMessage(error, 'Impossible de modifier la fermeture du site.'));
+        }
+      });
+  }
+
   private applySiteModeValidators(mode: SiteClosureMode): void {
     const dateControl = this.siteClosureForm.controls.date;
     const dateDebutControl = this.siteClosureForm.controls.dateDebut;
     const dateFinControl = this.siteClosureForm.controls.dateFin;
+
+    if (mode === 'date') {
+      dateControl.setValidators([Validators.required]);
+      dateDebutControl.clearValidators();
+      dateFinControl.clearValidators();
+    } else {
+      dateControl.clearValidators();
+      dateDebutControl.setValidators([Validators.required]);
+      dateFinControl.setValidators([Validators.required]);
+    }
+
+    dateControl.updateValueAndValidity({ emitEvent: false });
+    dateDebutControl.updateValueAndValidity({ emitEvent: false });
+    dateFinControl.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private applyEditModeValidators(mode: SiteClosureMode): void {
+    const dateControl = this.editSiteClosureForm.controls.date;
+    const dateDebutControl = this.editSiteClosureForm.controls.dateDebut;
+    const dateFinControl = this.editSiteClosureForm.controls.dateFin;
 
     if (mode === 'date') {
       dateControl.setValidators([Validators.required]);
@@ -624,6 +849,32 @@ export class AdminClosuresPageComponent implements OnInit {
   }
 
   private getDeleteErrorMessage(error: HttpErrorResponse, fallbackMessage: string): string {
+    const apiError = this.normalizeApiErrorBody(error.error);
+
+    if (error.status === 0) {
+      return 'Backend inaccessible.';
+    }
+
+    if (error.status === 401) {
+      return 'Authentification requise.';
+    }
+
+    if (error.status === 403) {
+      return 'Acc\u00e8s refus\u00e9.';
+    }
+
+    if (error.status === 404) {
+      return apiError.message || 'Fermeture introuvable.';
+    }
+
+    if (apiError.details) {
+      return Object.values(apiError.details).join(' ');
+    }
+
+    return apiError.message || fallbackMessage;
+  }
+
+  private getUpdateErrorMessage(error: HttpErrorResponse, fallbackMessage: string): string {
     const apiError = this.normalizeApiErrorBody(error.error);
 
     if (error.status === 0) {


### PR DESCRIPTION
- Ajout de la modification des fermetures de site depuis la page /admin/fermetures.

- Ajout d’un bouton Modifier uniquement sur les fermetures de site.

- Ajout d’un formulaire inline prérempli dans la carte concernée.

- Support de la modification date unique vers date unique.

- Support de la modification période vers période.

- Support de la conversion date unique vers période.

- Support de la conversion période vers date unique.

- Ajout d’une confirmation inline obligatoire avant enregistrement.

- Ajout des appels PUT dans AdminService.


=