### PR TITLE
feat(admin): Ajouter la gestion des horaires par site côté admin

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -31,6 +31,12 @@ export const routes: Routes = [
       { path: 'matchs', component: PublicMatchesPageComponent, canActivate: [authGuard] },
       { path: 'admin', component: AdminPageComponent, canActivate: [authGuard] },
       { path: 'admin/fermetures', component: AdminClosuresPageComponent, canActivate: [authGuard] },
+      {
+        path: 'admin/horaires',
+        loadComponent: () => import('./features/admin/horaires/admin-schedules-page.component')
+          .then((m) => m.AdminSchedulesPageComponent),
+        canActivate: [authGuard]
+      },
       { path: 'admin/joueurs', component: AdminPlayersPageComponent, canActivate: [authGuard] },
       { path: 'admin/inscriptions', component: AdminRegistrationsPageComponent, canActivate: [authGuard] }
     ]

--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -72,6 +72,20 @@ export interface AdminSiteClosureResponse {
   motif: string | null;
 }
 
+export interface AdminSiteScheduleResponse {
+  id: number;
+  siteId: number;
+  annee: number;
+  heureOuverture: string;
+  heureFermeture: string;
+}
+
+export interface UpsertSiteScheduleRequest {
+  annee: number;
+  heureOuverture: string;
+  heureFermeture: string;
+}
+
 export interface CreateGlobalClosureRequest {
   date: string;
   motif?: string | null;

--- a/frontend/src/app/core/admin/admin.service.ts
+++ b/frontend/src/app/core/admin/admin.service.ts
@@ -7,6 +7,7 @@ import {
   AdminPlayerResponse,
   AdminSitePlayerResponse,
   AdminSiteClosureResponse,
+  AdminSiteScheduleResponse,
   AdminInfoResponse,
   PendingRegistrationItem,
   RegistrationDecisionResponse,
@@ -15,6 +16,7 @@ import {
   CreateSitePeriodClosureRequest,
   UpdateSiteDateClosureRequest,
   UpdateSitePeriodClosureRequest,
+  UpsertSiteScheduleRequest,
   ValidateRegistrationRequest
 } from './admin.models';
 
@@ -45,6 +47,39 @@ export class AdminService {
   getSiteClosures(siteId: number): Observable<AdminSiteClosureResponse[]> {
     return this.http.get<AdminSiteClosureResponse[]>(
       `${environment.apiBaseUrl}/admin/sites/${siteId}/fermetures`
+    );
+  }
+
+  getSiteSchedules(siteId: number): Observable<AdminSiteScheduleResponse[]> {
+    return this.http.get<AdminSiteScheduleResponse[]>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/horaires`
+    );
+  }
+
+  createSiteSchedule(
+    siteId: number,
+    payload: UpsertSiteScheduleRequest
+  ): Observable<AdminSiteScheduleResponse> {
+    return this.http.post<AdminSiteScheduleResponse>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/horaires`,
+      payload
+    );
+  }
+
+  updateSiteSchedule(
+    siteId: number,
+    scheduleId: number,
+    payload: UpsertSiteScheduleRequest
+  ): Observable<AdminSiteScheduleResponse> {
+    return this.http.put<AdminSiteScheduleResponse>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/horaires/${scheduleId}`,
+      payload
+    );
+  }
+
+  deleteSiteSchedule(siteId: number, scheduleId: number): Observable<void> {
+    return this.http.delete<void>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/horaires/${scheduleId}`
     );
   }
 

--- a/frontend/src/app/features/admin/admin-page.component.ts
+++ b/frontend/src/app/features/admin/admin-page.component.ts
@@ -100,8 +100,8 @@ export class AdminPageComponent implements OnInit {
     cards.push(
       { title: 'Joueurs', description: 'Consultez les joueurs enregistr\u00e9s dans votre p\u00e9rim\u00e8tre.', route: '/admin/joueurs' },
       { title: 'Fermetures', description: 'Consultez les fermetures globales et les fermetures de site.', route: '/admin/fermetures' },
-      { title: 'Statistiques', description: 'Module \u00e0 venir.' },
-      { title: 'Horaires', description: 'Module \u00e0 venir.' }
+      { title: 'Horaires', description: 'Consultez les horaires configur\u00e9s par site.', route: '/admin/horaires' },
+      { title: 'Statistiques', description: 'Module \u00e0 venir.' }
     );
 
     return cards;

--- a/frontend/src/app/features/admin/horaires/admin-schedules-page.component.css
+++ b/frontend/src/app/features/admin/horaires/admin-schedules-page.component.css
@@ -1,0 +1,263 @@
+.admin-schedules-page {
+  width: min(100%, 64rem);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  padding: 3rem 0;
+}
+
+.page-header,
+.form-header,
+.form-field,
+.schedules-list,
+.schedule-card,
+.schedule-form {
+  display: grid;
+}
+
+.page-header {
+  gap: 0.5rem;
+}
+
+.back-link {
+  width: fit-content;
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.page-eyebrow {
+  margin: 0;
+  color: #0f766e;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  color: #10233f;
+}
+
+.page-intro,
+.site-panel p,
+.form-header p {
+  margin: 0;
+  color: #526277;
+}
+
+.page-state,
+.site-panel,
+.schedule-form,
+.schedule-card {
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+}
+
+.page-state {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  color: #2c3a4b;
+}
+
+.page-state.is-error,
+.form-message.is-error {
+  border-color: #ef4444;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.page-state.is-success {
+  border-color: #86efac;
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.site-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
+  gap: 1rem;
+  align-items: end;
+  padding: 1.25rem;
+}
+
+.site-panel h2,
+.form-header h2,
+.form-header h3 {
+  margin: 0;
+  color: #10233f;
+  font-size: 1.1rem;
+}
+
+.site-select {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.site-select span,
+.form-field span,
+.schedule-heading span,
+.schedule-meta span {
+  color: #526277;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.site-select select,
+.form-field input {
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #10233f;
+  font: inherit;
+}
+
+.schedule-meta p,
+.schedule-form.is-inline {
+  background: #f8fbff;
+}
+
+.schedule-meta strong {
+  color: #10233f;
+}
+
+.schedule-form,
+.schedule-card {
+  gap: 1rem;
+  padding: 1.25rem;
+}
+
+.form-header {
+  gap: 0.25rem;
+}
+
+.form-grid,
+.schedule-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.9rem;
+}
+
+.form-field {
+  gap: 0.4rem;
+}
+
+.form-field small {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.form-actions,
+.schedule-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.button {
+  min-height: 2.5rem;
+  padding: 0.7rem 0.95rem;
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.button-primary {
+  background: #0f766e;
+  color: #ffffff;
+}
+
+.button-secondary {
+  border-color: #cbd5e1;
+  background: #ffffff;
+  color: #10233f;
+}
+
+.button-danger {
+  background: #b91c1c;
+  color: #ffffff;
+}
+
+.form-message,
+.confirmation-box {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 0.5rem;
+}
+
+.confirmation-box {
+  display: grid;
+  gap: 0.85rem;
+  border: 1px solid #fbbf24;
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.confirmation-box.is-danger {
+  border-color: #fca5a5;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.confirmation-box p,
+.schedule-meta p {
+  margin: 0;
+}
+
+.schedule-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.schedule-heading h2 {
+  margin: 0;
+  color: #10233f;
+  font-size: 1.35rem;
+}
+
+.schedule-meta p {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+}
+
+@media (max-width: 760px) {
+  .admin-schedules-page {
+    gap: 1rem;
+    padding: 2rem 0;
+  }
+
+  .site-panel,
+  .schedule-heading,
+  .schedule-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .schedule-heading {
+    display: grid;
+  }
+
+  .button {
+    width: 100%;
+  }
+}

--- a/frontend/src/app/features/admin/horaires/admin-schedules-page.component.html
+++ b/frontend/src/app/features/admin/horaires/admin-schedules-page.component.html
@@ -1,0 +1,245 @@
+<section class="admin-schedules-page">
+  <header class="page-header">
+    <p class="page-eyebrow">Administration</p>
+    <a routerLink="/admin" class="back-link">&larr; Retour &agrave; l&rsquo;administration</a>
+    <h1>Horaires</h1>
+    <p class="page-intro">Consultez et g&eacute;rez les horaires configur&eacute;s par site.</p>
+  </header>
+
+  @if (isLoading()) {
+    <p class="page-state">Chargement en cours...</p>
+  } @else if (errorMessage()) {
+    <p class="page-state is-error">{{ errorMessage() }}</p>
+  } @else {
+    @if (successMessage()) {
+      <p class="page-state is-success" role="status" aria-live="polite">{{ successMessage() }}</p>
+    }
+
+    <section class="site-panel">
+      <div>
+        <h2>Site</h2>
+        @if (selectedSiteName()) {
+          <p>{{ selectedSiteName() }}</p>
+        }
+      </div>
+
+      @if (isAdminGlobal()) {
+        <label class="site-select">
+          <span>Choisir un site</span>
+          <select [value]="selectedSiteId() ?? ''" (change)="onSiteChange($any($event.target).value)">
+            @for (site of sites(); track site.id) {
+              <option [value]="site.id">{{ site.nom }}</option>
+            }
+          </select>
+        </label>
+      }
+
+    </section>
+
+    @if (canManageSchedules()) {
+      <form class="schedule-form" [formGroup]="createScheduleForm" (ngSubmit)="requestCreateSchedule()">
+        <div class="form-header">
+          <h2>Cr&eacute;er un horaire</h2>
+          <p>Ajoutez une configuration annuelle pour le site courant.</p>
+        </div>
+
+        <div class="form-grid">
+          <label class="form-field">
+            <span>Ann&eacute;e</span>
+            <input type="number" formControlName="annee" inputmode="numeric">
+            @if (showCreateYearError()) {
+              <small>L&rsquo;ann&eacute;e est obligatoire.</small>
+            }
+          </label>
+
+          <label class="form-field">
+            <span>Heure d&rsquo;ouverture</span>
+            <input type="time" formControlName="heureOuverture">
+            @if (showCreateOpeningError()) {
+              <small>L&rsquo;heure d&rsquo;ouverture est obligatoire.</small>
+            }
+          </label>
+
+          <label class="form-field">
+            <span>Heure de fermeture</span>
+            <input type="time" formControlName="heureFermeture">
+            @if (showCreateClosingError()) {
+              <small>L&rsquo;heure de fermeture est obligatoire.</small>
+            }
+          </label>
+        </div>
+
+        @if (createError()) {
+          <p class="form-message is-error" role="alert">{{ createError() }}</p>
+        }
+
+        @if (pendingCreateConfirmation()) {
+          <div class="confirmation-box">
+            <p>Confirmer la cr&eacute;ation de cet horaire ?</p>
+            <div class="form-actions">
+              <button type="button" class="button button-primary" (click)="confirmCreateSchedule()" [disabled]="isSubmittingCreate()">
+                Confirmer
+              </button>
+              <button type="button" class="button button-secondary" (click)="cancelCreateConfirmation()" [disabled]="isSubmittingCreate()">
+                Annuler
+              </button>
+            </div>
+          </div>
+        } @else {
+          <div class="form-actions">
+            <button type="submit" class="button button-primary" [disabled]="isSubmittingCreate()">
+              Cr&eacute;er un horaire
+            </button>
+          </div>
+        }
+      </form>
+    }
+
+    @if (isLoadingSchedules()) {
+      <p class="page-state">Chargement des horaires...</p>
+    } @else if (schedulesError()) {
+      <p class="page-state is-error">{{ schedulesError() }}</p>
+    } @else if (hasNoSchedules()) {
+      <p class="page-state">Aucun horaire enregistr&eacute; pour ce site.</p>
+    } @else {
+      <div class="schedules-list">
+        @for (schedule of schedules(); track trackSchedule(schedule)) {
+          <article class="schedule-card">
+            <div class="schedule-heading">
+              <div>
+                <span>Ann&eacute;e</span>
+                <h2>{{ schedule.annee }}</h2>
+              </div>
+
+              <div class="schedule-actions">
+                <button
+                  type="button"
+                  class="button button-secondary"
+                  (click)="startEditSchedule(schedule)"
+                  [disabled]="isSubmittingUpdate() || deletingScheduleId() === schedule.id"
+                >
+                  Modifier
+                </button>
+                <button
+                  type="button"
+                  class="button button-danger"
+                  (click)="requestDeleteSchedule(schedule)"
+                  [disabled]="deletingScheduleId() === schedule.id"
+                >
+                  Supprimer
+                </button>
+              </div>
+            </div>
+
+            <div class="schedule-meta">
+              <p>
+                <span>Ouverture</span>
+                <strong>{{ formatTime(schedule.heureOuverture) }}</strong>
+              </p>
+
+              <p>
+                <span>Fermeture</span>
+                <strong>{{ formatTime(schedule.heureFermeture) }}</strong>
+              </p>
+            </div>
+
+            @if (isEditingSchedule(schedule.id)) {
+              <form class="schedule-form is-inline" [formGroup]="editScheduleForm" (ngSubmit)="requestUpdateSchedule(schedule)">
+                <div class="form-header">
+                  <h3>Modifier l&rsquo;horaire</h3>
+                </div>
+
+                <div class="form-grid">
+                  <label class="form-field">
+                    <span>Ann&eacute;e</span>
+                    <input type="number" formControlName="annee" inputmode="numeric">
+                    @if (showEditYearError()) {
+                      <small>L&rsquo;ann&eacute;e est obligatoire.</small>
+                    }
+                  </label>
+
+                  <label class="form-field">
+                    <span>Heure d&rsquo;ouverture</span>
+                    <input type="time" formControlName="heureOuverture">
+                    @if (showEditOpeningError()) {
+                      <small>L&rsquo;heure d&rsquo;ouverture est obligatoire.</small>
+                    }
+                  </label>
+
+                  <label class="form-field">
+                    <span>Heure de fermeture</span>
+                    <input type="time" formControlName="heureFermeture">
+                    @if (showEditClosingError()) {
+                      <small>L&rsquo;heure de fermeture est obligatoire.</small>
+                    }
+                  </label>
+                </div>
+
+                @if (updateError()) {
+                  <p class="form-message is-error" role="alert">{{ updateError() }}</p>
+                }
+
+                @if (isPendingUpdate(schedule.id)) {
+                  <div class="confirmation-box">
+                    <p>Confirmer la modification de cet horaire ?</p>
+                    <div class="form-actions">
+                      <button
+                        type="button"
+                        class="button button-primary"
+                        (click)="confirmUpdateSchedule(schedule)"
+                        [disabled]="isSubmittingUpdate()"
+                      >
+                        Confirmer
+                      </button>
+                      <button type="button" class="button button-secondary" (click)="cancelEditSchedule()" [disabled]="isSubmittingUpdate()">
+                        Annuler
+                      </button>
+                    </div>
+                  </div>
+                } @else {
+                  <div class="form-actions">
+                    <button type="submit" class="button button-primary" [disabled]="isSubmittingUpdate()">
+                      Enregistrer
+                    </button>
+                    <button type="button" class="button button-secondary" (click)="cancelEditSchedule()" [disabled]="isSubmittingUpdate()">
+                      Annuler
+                    </button>
+                  </div>
+                }
+              </form>
+            }
+
+            @if (isPendingDelete(schedule.id)) {
+              <div class="confirmation-box is-danger">
+                <p>{{ getDeleteConfirmationMessage(schedule) }}</p>
+
+                @if (deleteError()) {
+                  <p class="form-message is-error" role="alert">{{ deleteError() }}</p>
+                }
+
+                <div class="form-actions">
+                  <button
+                    type="button"
+                    class="button button-danger"
+                    (click)="confirmDeleteSchedule(schedule)"
+                    [disabled]="deletingScheduleId() === schedule.id"
+                  >
+                    Confirmer
+                  </button>
+                  <button
+                    type="button"
+                    class="button button-secondary"
+                    (click)="cancelDeleteConfirmation()"
+                    [disabled]="deletingScheduleId() === schedule.id"
+                  >
+                    Annuler
+                  </button>
+                </div>
+              </div>
+            }
+          </article>
+        }
+      </div>
+    }
+  }
+</section>

--- a/frontend/src/app/features/admin/horaires/admin-schedules-page.component.ts
+++ b/frontend/src/app/features/admin/horaires/admin-schedules-page.component.ts
@@ -1,0 +1,489 @@
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { finalize, map, of, switchMap } from 'rxjs';
+import {
+  AdminInfoResponse,
+  AdminSiteScheduleResponse,
+  UpsertSiteScheduleRequest
+} from '../../../core/admin/admin.models';
+import { AdminService } from '../../../core/admin/admin.service';
+import { ApiErrorResponse } from '../../../core/auth/auth.models';
+import { SiteOption } from '../../../core/sites/site.models';
+import { SitesService } from '../../../core/sites/sites.service';
+
+@Component({
+  selector: 'app-admin-schedules-page',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './admin-schedules-page.component.html',
+  styleUrl: './admin-schedules-page.component.css'
+})
+export class AdminSchedulesPageComponent implements OnInit {
+  private readonly adminService = inject(AdminService);
+  private readonly sitesService = inject(SitesService);
+  private readonly fb = inject(FormBuilder);
+
+  protected readonly adminInfo = signal<AdminInfoResponse | null>(null);
+  protected readonly sites = signal<SiteOption[]>([]);
+  protected readonly selectedSiteId = signal<number | null>(null);
+  protected readonly schedules = signal<AdminSiteScheduleResponse[]>([]);
+  protected readonly isLoading = signal(true);
+  protected readonly isLoadingSchedules = signal(false);
+  protected readonly errorMessage = signal('');
+  protected readonly schedulesError = signal('');
+  protected readonly successMessage = signal('');
+  protected readonly createError = signal('');
+  protected readonly updateError = signal('');
+  protected readonly deleteError = signal('');
+  protected readonly pendingCreateConfirmation = signal(false);
+  protected readonly activeEditScheduleId = signal<number | null>(null);
+  protected readonly pendingUpdateScheduleId = signal<number | null>(null);
+  protected readonly pendingDeleteScheduleId = signal<number | null>(null);
+  protected readonly isSubmittingCreate = signal(false);
+  protected readonly isSubmittingUpdate = signal(false);
+  protected readonly deletingScheduleId = signal<number | null>(null);
+
+  protected readonly createScheduleForm = this.fb.group({
+    annee: this.fb.nonNullable.control('', [Validators.required]),
+    heureOuverture: this.fb.nonNullable.control('', [Validators.required]),
+    heureFermeture: this.fb.nonNullable.control('', [Validators.required])
+  });
+
+  protected readonly editScheduleForm = this.fb.group({
+    annee: this.fb.nonNullable.control('', [Validators.required]),
+    heureOuverture: this.fb.nonNullable.control('', [Validators.required]),
+    heureFermeture: this.fb.nonNullable.control('', [Validators.required])
+  });
+
+  protected readonly isAdminGlobal = computed(() => this.adminInfo()?.adminType === 'GLOBAL');
+  protected readonly canManageSchedules = computed(() => this.getCurrentSiteId() != null);
+  protected readonly hasNoSchedules = computed(
+    () => !this.isLoadingSchedules() && !this.schedulesError() && this.schedules().length === 0
+  );
+
+  protected readonly selectedSiteName = computed(() => {
+    const adminInfo = this.adminInfo();
+
+    if (adminInfo?.adminType === 'SITE') {
+      return adminInfo.siteNom ?? 'Site administré';
+    }
+
+    const selectedSiteId = this.selectedSiteId();
+
+    if (selectedSiteId == null) {
+      return '';
+    }
+
+    return this.sites().find((site) => site.id === selectedSiteId)?.nom ?? `Site ${selectedSiteId}`;
+  });
+
+  ngOnInit(): void {
+    this.loadInitialData();
+  }
+
+  protected onSiteChange(value: string): void {
+    const siteId = Number(value);
+    this.resetActionState();
+
+    if (Number.isNaN(siteId)) {
+      this.selectedSiteId.set(null);
+      this.schedules.set([]);
+      this.schedulesError.set('');
+      return;
+    }
+
+    this.selectedSiteId.set(siteId);
+    this.loadSchedules(siteId);
+  }
+
+  protected requestCreateSchedule(): void {
+    this.successMessage.set('');
+    this.createError.set('');
+    this.pendingCreateConfirmation.set(false);
+
+    if (this.createScheduleForm.invalid) {
+      this.createScheduleForm.markAllAsTouched();
+      return;
+    }
+
+    if (this.getCurrentSiteId() == null) {
+      this.createError.set('Périmètre administrateur introuvable.');
+      return;
+    }
+
+    this.pendingCreateConfirmation.set(true);
+  }
+
+  protected confirmCreateSchedule(): void {
+    const siteId = this.getCurrentSiteId();
+
+    if (siteId == null) {
+      this.createError.set('Périmètre administrateur introuvable.');
+      return;
+    }
+
+    this.isSubmittingCreate.set(true);
+    this.createError.set('');
+
+    this.adminService
+      .createSiteSchedule(siteId, this.getCreatePayload())
+      .pipe(finalize(() => this.isSubmittingCreate.set(false)))
+      .subscribe({
+        next: () => {
+          this.successMessage.set('Horaire créé.');
+          this.pendingCreateConfirmation.set(false);
+          this.createScheduleForm.reset();
+          this.loadSchedules(siteId);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.createError.set(this.getErrorMessage(error, "Impossible de créer l'horaire."));
+        }
+      });
+  }
+
+  protected cancelCreateConfirmation(): void {
+    this.pendingCreateConfirmation.set(false);
+  }
+
+  protected startEditSchedule(schedule: AdminSiteScheduleResponse): void {
+    this.successMessage.set('');
+    this.updateError.set('');
+    this.deleteError.set('');
+    this.pendingUpdateScheduleId.set(null);
+    this.pendingDeleteScheduleId.set(null);
+    this.activeEditScheduleId.set(schedule.id);
+    this.editScheduleForm.setValue({
+      annee: String(schedule.annee),
+      heureOuverture: this.toTimeInputValue(schedule.heureOuverture),
+      heureFermeture: this.toTimeInputValue(schedule.heureFermeture)
+    });
+  }
+
+  protected requestUpdateSchedule(schedule: AdminSiteScheduleResponse): void {
+    this.successMessage.set('');
+    this.updateError.set('');
+    this.pendingUpdateScheduleId.set(null);
+
+    if (!this.isEditingSchedule(schedule.id)) {
+      this.startEditSchedule(schedule);
+    }
+
+    if (this.editScheduleForm.invalid) {
+      this.editScheduleForm.markAllAsTouched();
+      return;
+    }
+
+    if (this.getCurrentSiteId() == null) {
+      this.updateError.set('Périmètre administrateur introuvable.');
+      return;
+    }
+
+    this.pendingUpdateScheduleId.set(schedule.id);
+  }
+
+  protected confirmUpdateSchedule(schedule: AdminSiteScheduleResponse): void {
+    const siteId = this.getCurrentSiteId();
+
+    if (siteId == null) {
+      this.updateError.set('Périmètre administrateur introuvable.');
+      return;
+    }
+
+    this.isSubmittingUpdate.set(true);
+    this.updateError.set('');
+
+    this.adminService
+      .updateSiteSchedule(siteId, schedule.id, this.getEditPayload())
+      .pipe(finalize(() => this.isSubmittingUpdate.set(false)))
+      .subscribe({
+        next: () => {
+          this.successMessage.set('Horaire modifié.');
+          this.cancelEditSchedule();
+          this.loadSchedules(siteId);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.updateError.set(this.getErrorMessage(error, "Impossible de modifier l'horaire."));
+        }
+      });
+  }
+
+  protected cancelEditSchedule(): void {
+    this.activeEditScheduleId.set(null);
+    this.pendingUpdateScheduleId.set(null);
+    this.updateError.set('');
+    this.editScheduleForm.reset();
+  }
+
+  protected requestDeleteSchedule(schedule: AdminSiteScheduleResponse): void {
+    this.successMessage.set('');
+    this.deleteError.set('');
+    this.pendingDeleteScheduleId.set(schedule.id);
+    this.pendingUpdateScheduleId.set(null);
+  }
+
+  protected confirmDeleteSchedule(schedule: AdminSiteScheduleResponse): void {
+    const siteId = this.getCurrentSiteId();
+
+    if (siteId == null) {
+      this.deleteError.set('Périmètre administrateur introuvable.');
+      return;
+    }
+
+    this.deletingScheduleId.set(schedule.id);
+    this.deleteError.set('');
+
+    this.adminService
+      .deleteSiteSchedule(siteId, schedule.id)
+      .pipe(finalize(() => this.deletingScheduleId.set(null)))
+      .subscribe({
+        next: () => {
+          this.successMessage.set('Horaire supprimé.');
+          this.pendingDeleteScheduleId.set(null);
+          this.loadSchedules(siteId);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.deleteError.set(this.getErrorMessage(error, "Impossible de supprimer l'horaire."));
+        }
+      });
+  }
+
+  protected cancelDeleteConfirmation(): void {
+    this.pendingDeleteScheduleId.set(null);
+    this.deleteError.set('');
+  }
+
+  protected isEditingSchedule(scheduleId: number): boolean {
+    return this.activeEditScheduleId() === scheduleId;
+  }
+
+  protected isPendingUpdate(scheduleId: number): boolean {
+    return this.pendingUpdateScheduleId() === scheduleId;
+  }
+
+  protected isPendingDelete(scheduleId: number): boolean {
+    return this.pendingDeleteScheduleId() === scheduleId;
+  }
+
+  protected getDeleteConfirmationMessage(schedule: AdminSiteScheduleResponse): string {
+    const isOnlyScheduleForYear = this.schedules().filter((candidate) => candidate.annee === schedule.annee).length === 1;
+
+    if (isOnlyScheduleForYear) {
+      return "Confirmer la suppression de cet horaire ? Attention : c'est le seul horaire configuré pour cette année sur ce site. Les futures créations de matchs pour cette année pourraient être bloquées.";
+    }
+
+    return 'Confirmer la suppression de cet horaire ?';
+  }
+
+  protected showCreateYearError(): boolean {
+    return this.shouldShowFieldError(this.createScheduleForm.controls.annee);
+  }
+
+  protected showCreateOpeningError(): boolean {
+    return this.shouldShowFieldError(this.createScheduleForm.controls.heureOuverture);
+  }
+
+  protected showCreateClosingError(): boolean {
+    return this.shouldShowFieldError(this.createScheduleForm.controls.heureFermeture);
+  }
+
+  protected showEditYearError(): boolean {
+    return this.shouldShowFieldError(this.editScheduleForm.controls.annee);
+  }
+
+  protected showEditOpeningError(): boolean {
+    return this.shouldShowFieldError(this.editScheduleForm.controls.heureOuverture);
+  }
+
+  protected showEditClosingError(): boolean {
+    return this.shouldShowFieldError(this.editScheduleForm.controls.heureFermeture);
+  }
+
+  protected formatTime(value: string): string {
+    if (!value) {
+      return 'Non renseigné';
+    }
+
+    return value.length >= 5 ? value.slice(0, 5) : value;
+  }
+
+  protected trackSchedule(schedule: AdminSiteScheduleResponse): number {
+    return schedule.id;
+  }
+
+  private loadInitialData(): void {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+    this.schedulesError.set('');
+
+    this.adminService
+      .getInfo()
+      .pipe(
+        switchMap((adminInfo) => {
+          this.adminInfo.set(adminInfo);
+
+          if (adminInfo.adminType === 'GLOBAL') {
+            return this.sitesService.getSites();
+          }
+
+          if (adminInfo.siteId == null) {
+            throw new Error('Périmètre administrateur introuvable.');
+          }
+
+          return of([] as SiteOption[]);
+        }),
+        map((sites) => {
+          this.sites.set(sites);
+          return sites;
+        }),
+        finalize(() => this.isLoading.set(false))
+      )
+      .subscribe({
+        next: (sites) => {
+          const adminInfo = this.adminInfo();
+
+          if (adminInfo?.adminType === 'GLOBAL') {
+            this.initializeGlobalSiteSelection(sites);
+            return;
+          }
+
+          if (adminInfo?.adminType === 'SITE' && adminInfo.siteId != null) {
+            this.selectedSiteId.set(adminInfo.siteId);
+            this.loadSchedules(adminInfo.siteId);
+          }
+        },
+        error: (error: HttpErrorResponse | Error) => {
+          this.schedules.set([]);
+          this.errorMessage.set(this.getErrorMessage(error, "Impossible de charger la page des horaires."));
+        }
+      });
+  }
+
+  private initializeGlobalSiteSelection(sites: SiteOption[]): void {
+    if (sites.length === 0) {
+      this.selectedSiteId.set(null);
+      this.schedules.set([]);
+      this.errorMessage.set('Aucun site disponible.');
+      return;
+    }
+
+    const currentSiteId = this.selectedSiteId();
+    const selectedSiteId = currentSiteId != null && sites.some((site) => site.id === currentSiteId)
+      ? currentSiteId
+      : sites[0].id;
+
+    this.selectedSiteId.set(selectedSiteId);
+    this.loadSchedules(selectedSiteId);
+  }
+
+  private loadSchedules(siteId: number): void {
+    this.isLoadingSchedules.set(true);
+    this.schedulesError.set('');
+
+    this.adminService
+      .getSiteSchedules(siteId)
+      .pipe(finalize(() => this.isLoadingSchedules.set(false)))
+      .subscribe({
+        next: (schedules) => {
+          this.schedules.set(schedules);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.schedules.set([]);
+          this.schedulesError.set(this.getErrorMessage(error, 'Impossible de charger les horaires.'));
+        }
+      });
+  }
+
+  private resetActionState(): void {
+    this.successMessage.set('');
+    this.createError.set('');
+    this.updateError.set('');
+    this.deleteError.set('');
+    this.pendingCreateConfirmation.set(false);
+    this.pendingUpdateScheduleId.set(null);
+    this.pendingDeleteScheduleId.set(null);
+    this.activeEditScheduleId.set(null);
+    this.createScheduleForm.reset();
+    this.editScheduleForm.reset();
+  }
+
+  private getCurrentSiteId(): number | null {
+    const adminInfo = this.adminInfo();
+
+    if (adminInfo?.adminType === 'SITE') {
+      return adminInfo.siteId;
+    }
+
+    return this.selectedSiteId();
+  }
+
+  private getCreatePayload(): UpsertSiteScheduleRequest {
+    return this.getPayloadFromForm(this.createScheduleForm.getRawValue());
+  }
+
+  private getEditPayload(): UpsertSiteScheduleRequest {
+    return this.getPayloadFromForm(this.editScheduleForm.getRawValue());
+  }
+
+  private getPayloadFromForm(value: {
+    annee: string;
+    heureOuverture: string;
+    heureFermeture: string;
+  }): UpsertSiteScheduleRequest {
+    return {
+      annee: Number(value.annee),
+      heureOuverture: value.heureOuverture,
+      heureFermeture: value.heureFermeture
+    };
+  }
+
+  private toTimeInputValue(value: string): string {
+    return value.length >= 5 ? value.slice(0, 5) : value;
+  }
+
+  private shouldShowFieldError(control: { invalid: boolean; touched: boolean; dirty: boolean }): boolean {
+    return control.invalid && (control.touched || control.dirty);
+  }
+
+  private getErrorMessage(error: HttpErrorResponse | Error, fallback: string): string {
+    if (error instanceof HttpErrorResponse) {
+      if (error.status === 0) {
+        return 'Backend inaccessible.';
+      }
+
+      if (error.status === 401) {
+        return 'Authentification requise.';
+      }
+
+      if (error.status === 403) {
+        return 'Accès administrateur refusé.';
+      }
+
+      if (error.status === 404) {
+        return 'Site introuvable.';
+      }
+
+      const backendMessage = this.getBackendMessage(error);
+
+      return backendMessage || fallback;
+    }
+
+    return error.message || fallback;
+  }
+
+  private getBackendMessage(error: HttpErrorResponse): string {
+    const body = error.error as Partial<ApiErrorResponse> | string | null;
+
+    if (typeof body === 'string') {
+      return body;
+    }
+
+    if (body?.message) {
+      return body.message;
+    }
+
+    return '';
+  }
+}


### PR DESCRIPTION
- Ajout de la page /admin/horaires.

- Ajout de l’accès à la page Horaires depuis la zone admin.

- Ajout de la consultation des horaires par site.

- Ajout de la création d’un horaire pour un site.

- Ajout de la modification inline d’un horaire existant.

- Ajout de la suppression d’un horaire avec confirmation inline.

- Support ADMIN_GLOBAL avec sélection du site.

- Support ADMIN_SITE avec site imposé depuis le contexte admin.

- Ajout des messages de succès et des erreurs séparées par action.

- Ajout des confirmations inline pour création, modification et suppression.

- Ajout d’un message d’avertissement renforcé lors de la suppression d’un horaire annuel.


