### PR TITLE
feat(admin): Ajouter les statistiques admin

### DIFF
--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/security/JwtAuthenticationFilterTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/security/JwtAuthenticationFilterTest.java
@@ -7,6 +7,7 @@ import be.ephec.padel.backend.model.entities.User;
 import be.ephec.padel.backend.model.enums.SecurityRole;
 import be.ephec.padel.backend.repository.UserRepository;
 import be.ephec.padel.backend.security.JwtService;
+import be.ephec.padel.backend.service.AdminInfoService;
 import be.ephec.padel.backend.service.AdminStatsService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +45,9 @@ class JwtAuthenticationFilterTest {
 
     @MockitoBean
     AdminStatsService adminStatsService;
+
+    @MockitoBean
+    AdminInfoService adminInfoService;
 
     @MockitoBean
     UserRepository userRepository;

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -37,6 +37,12 @@ export const routes: Routes = [
           .then((m) => m.AdminSchedulesPageComponent),
         canActivate: [authGuard]
       },
+      {
+        path: 'admin/statistiques',
+        loadComponent: () => import('./features/admin/statistiques/admin-statistics-page.component')
+          .then((m) => m.AdminStatisticsPageComponent),
+        canActivate: [authGuard]
+      },
       { path: 'admin/joueurs', component: AdminPlayersPageComponent, canActivate: [authGuard] },
       { path: 'admin/inscriptions', component: AdminRegistrationsPageComponent, canActivate: [authGuard] }
     ]

--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -80,6 +80,23 @@ export interface AdminSiteScheduleResponse {
   heureFermeture: string;
 }
 
+export interface AdminCaStatsResponse {
+  caTotal: number;
+  from: string;
+  to: string;
+}
+
+export interface AdminMatchsStatsResponse {
+  nbMatchs: number;
+  from: string;
+  to: string;
+}
+
+export interface AdminDettesStatsResponse {
+  detteTotale: number;
+  nbJoueursEnDette: number;
+}
+
 export interface UpsertSiteScheduleRequest {
   annee: number;
   heureOuverture: string;

--- a/frontend/src/app/core/admin/admin.service.ts
+++ b/frontend/src/app/core/admin/admin.service.ts
@@ -3,11 +3,14 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import {
+  AdminCaStatsResponse,
+  AdminDettesStatsResponse,
   AdminGlobalClosureResponse,
   AdminPlayerResponse,
   AdminSitePlayerResponse,
   AdminSiteClosureResponse,
   AdminSiteScheduleResponse,
+  AdminMatchsStatsResponse,
   AdminInfoResponse,
   PendingRegistrationItem,
   RegistrationDecisionResponse,
@@ -53,6 +56,46 @@ export class AdminService {
   getSiteSchedules(siteId: number): Observable<AdminSiteScheduleResponse[]> {
     return this.http.get<AdminSiteScheduleResponse[]>(
       `${environment.apiBaseUrl}/admin/sites/${siteId}/horaires`
+    );
+  }
+
+  getGlobalCaStats(from: string, to: string): Observable<AdminCaStatsResponse> {
+    return this.http.get<AdminCaStatsResponse>(`${environment.apiBaseUrl}/admin/stats/ca`, {
+      params: { from, to }
+    });
+  }
+
+  getGlobalMatchsStats(from: string, to: string): Observable<AdminMatchsStatsResponse> {
+    return this.http.get<AdminMatchsStatsResponse>(`${environment.apiBaseUrl}/admin/stats/matchs`, {
+      params: { from, to }
+    });
+  }
+
+  getGlobalDettesStats(): Observable<AdminDettesStatsResponse> {
+    return this.http.get<AdminDettesStatsResponse>(`${environment.apiBaseUrl}/admin/stats/dettes`);
+  }
+
+  getSiteCaStats(siteId: number, from: string, to: string): Observable<AdminCaStatsResponse> {
+    return this.http.get<AdminCaStatsResponse>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/stats/ca`,
+      { params: { from, to } }
+    );
+  }
+
+  getSiteMatchsStats(
+    siteId: number,
+    from: string,
+    to: string
+  ): Observable<AdminMatchsStatsResponse> {
+    return this.http.get<AdminMatchsStatsResponse>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/stats/matchs`,
+      { params: { from, to } }
+    );
+  }
+
+  getSiteDettesStats(siteId: number): Observable<AdminDettesStatsResponse> {
+    return this.http.get<AdminDettesStatsResponse>(
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/stats/dettes`
     );
   }
 

--- a/frontend/src/app/features/admin/admin-page.component.ts
+++ b/frontend/src/app/features/admin/admin-page.component.ts
@@ -101,7 +101,7 @@ export class AdminPageComponent implements OnInit {
       { title: 'Joueurs', description: 'Consultez les joueurs enregistr\u00e9s dans votre p\u00e9rim\u00e8tre.', route: '/admin/joueurs' },
       { title: 'Fermetures', description: 'Consultez les fermetures globales et les fermetures de site.', route: '/admin/fermetures' },
       { title: 'Horaires', description: 'Consultez les horaires configur\u00e9s par site.', route: '/admin/horaires' },
-      { title: 'Statistiques', description: 'Module \u00e0 venir.' }
+      { title: 'Statistiques', description: "Consultez le chiffre d'affaires, les matchs et les dettes.", route: '/admin/statistiques' }
     );
 
     return cards;

--- a/frontend/src/app/features/admin/statistiques/admin-statistics-page.component.css
+++ b/frontend/src/app/features/admin/statistiques/admin-statistics-page.component.css
@@ -1,0 +1,208 @@
+.admin-statistics-page {
+  width: min(100%, 64rem);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  padding: 3rem 0;
+}
+
+.page-header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.back-link {
+  width: fit-content;
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.back-link:focus-visible {
+  outline: 2px solid #8fd3c1;
+  outline-offset: 2px;
+}
+
+.page-eyebrow {
+  margin: 0;
+  color: #0f766e;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  color: #10233f;
+}
+
+.page-intro {
+  margin: 0;
+  color: #526277;
+}
+
+.page-state {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #2c3a4b;
+}
+
+.page-state.is-error {
+  border-color: #ef4444;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.filters-panel {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) auto;
+  gap: 1rem;
+  align-items: end;
+  padding: 1.5rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.06);
+}
+
+.scope-block {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.scope-block span,
+.form-field span,
+.stat-card span {
+  color: #526277;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.scope-block strong {
+  color: #10233f;
+  font-size: 1.15rem;
+}
+
+.scope-select {
+  min-width: 13rem;
+}
+
+.period-form {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  align-items: end;
+}
+
+.period-help {
+  flex-basis: 100%;
+  margin: 0;
+  color: #526277;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.form-field input,
+.form-field select {
+  min-height: 2.75rem;
+  padding: 0 0.8rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #10233f;
+  font: inherit;
+}
+
+.form-field input:focus,
+.form-field select:focus {
+  border-color: #0f766e;
+  outline: 2px solid #ccfbf1;
+}
+
+.button {
+  min-height: 2.75rem;
+  padding: 0 1rem;
+  border: 0;
+  border-radius: 0.5rem;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.button-primary {
+  background: #0f766e;
+  color: #ffffff;
+}
+
+.button-primary:hover:not(:disabled) {
+  background: #115e59;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  min-height: 10rem;
+  display: grid;
+  align-content: start;
+  gap: 0.65rem;
+  padding: 1.5rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.06);
+}
+
+.stat-card strong {
+  color: #10233f;
+  font-size: 2rem;
+  line-height: 1.15;
+}
+
+.stat-card p {
+  margin: 0;
+  color: #526277;
+}
+
+@media (max-width: 760px) {
+  .admin-statistics-page {
+    gap: 1rem;
+    padding: 2rem 0;
+  }
+
+  .filters-panel {
+    grid-template-columns: 1fr;
+    padding: 1.25rem;
+  }
+
+  .scope-select,
+  .period-form,
+  .period-form .form-field,
+  .period-form .button {
+    width: 100%;
+  }
+
+  .stat-card {
+    padding: 1.25rem;
+  }
+}

--- a/frontend/src/app/features/admin/statistiques/admin-statistics-page.component.html
+++ b/frontend/src/app/features/admin/statistiques/admin-statistics-page.component.html
@@ -1,0 +1,87 @@
+<section class="admin-statistics-page">
+  <header class="page-header">
+    <p class="page-eyebrow">Administration</p>
+    <a routerLink="/admin" class="back-link">&larr; Retour &agrave; l&rsquo;administration</a>
+    <h1>Statistiques</h1>
+    <p class="page-intro">Consultez les statistiques disponibles dans votre p&eacute;rim&egrave;tre.</p>
+  </header>
+
+  @if (isLoading()) {
+    <p class="page-state">Chargement en cours...</p>
+  } @else if (errorMessage()) {
+    <p class="page-state is-error">{{ errorMessage() }}</p>
+  } @else {
+    <section class="filters-panel">
+      <div class="scope-block">
+        <span>P&eacute;rim&egrave;tre</span>
+        <strong>{{ selectedScopeLabel() }}</strong>
+      </div>
+
+      @if (isAdminGlobal()) {
+        <label class="form-field scope-select">
+          <span>Vue</span>
+          <select [value]="selectedSiteId() ?? 'global'" (change)="onScopeChange($any($event.target).value)">
+            <option value="global">Tous les sites</option>
+            @for (site of sites(); track trackSite(site)) {
+              <option [value]="site.id">{{ site.nom }}</option>
+            }
+          </select>
+        </label>
+      }
+
+      <form class="period-form" [formGroup]="periodForm" (ngSubmit)="refreshStats()">
+        <p class="period-help">
+          La p&eacute;riode s&rsquo;applique au chiffre d&rsquo;affaires et au nombre de matchs. Les dettes affichent l&rsquo;&eacute;tat actuel.
+        </p>
+
+        <label class="form-field">
+          <span>Du</span>
+          <input type="date" formControlName="from">
+        </label>
+
+        <label class="form-field">
+          <span>Au</span>
+          <input type="date" formControlName="to">
+        </label>
+
+        <button type="submit" class="button button-primary" [disabled]="isLoadingStats()">
+          Actualiser
+        </button>
+      </form>
+    </section>
+
+    @if (isLoadingStats()) {
+      <p class="page-state">Chargement des statistiques...</p>
+    } @else if (statsError()) {
+      <p class="page-state is-error">{{ statsError() }}</p>
+    } @else if (hasStats()) {
+      <div class="stats-grid">
+        <article class="stat-card">
+          <span>Chiffre d&rsquo;affaires</span>
+          <strong>{{ formatCurrency(caStats()?.caTotal) }}</strong>
+          <p>Encaissements sur la p&eacute;riode.</p>
+        </article>
+
+        <article class="stat-card">
+          <span>Matchs</span>
+          <strong>{{ formatNumber(matchsStats()?.nbMatchs) }}</strong>
+          <p>Matchs sur la p&eacute;riode.</p>
+        </article>
+
+        <article class="stat-card">
+          <span>Dette totale</span>
+          <strong>{{ formatCurrency(dettesStats()?.detteTotale) }}</strong>
+          <p>Solde total restant d&ucirc;.</p>
+        </article>
+
+        <article class="stat-card">
+          <span>Joueurs en dette</span>
+          <strong>{{ formatNumber(dettesStats()?.nbJoueursEnDette) }}</strong>
+          <p>Joueurs avec un solde ouvert.</p>
+        </article>
+      </div>
+    } @else {
+      <p class="page-state">Aucune statistique charg&eacute;e.</p>
+    }
+  }
+</section>

--- a/frontend/src/app/features/admin/statistiques/admin-statistics-page.component.ts
+++ b/frontend/src/app/features/admin/statistiques/admin-statistics-page.component.ts
@@ -1,0 +1,301 @@
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { finalize, forkJoin, of, switchMap } from 'rxjs';
+import {
+  AdminCaStatsResponse,
+  AdminDettesStatsResponse,
+  AdminInfoResponse,
+  AdminMatchsStatsResponse
+} from '../../../core/admin/admin.models';
+import { AdminService } from '../../../core/admin/admin.service';
+import { ApiErrorResponse } from '../../../core/auth/auth.models';
+import { SiteOption } from '../../../core/sites/site.models';
+import { SitesService } from '../../../core/sites/sites.service';
+
+@Component({
+  selector: 'app-admin-statistics-page',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './admin-statistics-page.component.html',
+  styleUrl: './admin-statistics-page.component.css'
+})
+export class AdminStatisticsPageComponent implements OnInit {
+  private readonly adminService = inject(AdminService);
+  private readonly sitesService = inject(SitesService);
+  private readonly fb = inject(FormBuilder);
+
+  protected readonly adminInfo = signal<AdminInfoResponse | null>(null);
+  protected readonly sites = signal<SiteOption[]>([]);
+  protected readonly selectedSiteId = signal<number | null>(null);
+  protected readonly caStats = signal<AdminCaStatsResponse | null>(null);
+  protected readonly matchsStats = signal<AdminMatchsStatsResponse | null>(null);
+  protected readonly dettesStats = signal<AdminDettesStatsResponse | null>(null);
+  protected readonly isLoading = signal(true);
+  protected readonly isLoadingStats = signal(false);
+  protected readonly errorMessage = signal('');
+  protected readonly statsError = signal('');
+
+  protected readonly periodForm = this.fb.group({
+    from: this.fb.nonNullable.control(this.getFirstDayOfCurrentMonth(), [Validators.required]),
+    to: this.fb.nonNullable.control(this.getToday(), [Validators.required])
+  });
+
+  protected readonly isAdminGlobal = computed(() => this.adminInfo()?.adminType === 'GLOBAL');
+  protected readonly hasStats = computed(
+    () => this.caStats() !== null && this.matchsStats() !== null && this.dettesStats() !== null
+  );
+
+  protected readonly selectedScopeLabel = computed(() => {
+    const adminInfo = this.adminInfo();
+
+    if (adminInfo?.adminType === 'SITE') {
+      return adminInfo.siteNom ?? 'Site administr\u00e9';
+    }
+
+    const selectedSiteId = this.selectedSiteId();
+
+    if (selectedSiteId == null) {
+      return 'Tous les sites';
+    }
+
+    return this.sites().find((site) => site.id === selectedSiteId)?.nom ?? `Site ${selectedSiteId}`;
+  });
+
+  ngOnInit(): void {
+    this.loadInitialData();
+  }
+
+  protected onScopeChange(value: string): void {
+    if (value === 'global') {
+      this.selectedSiteId.set(null);
+      this.loadStats();
+      return;
+    }
+
+    const siteId = Number(value);
+
+    if (Number.isNaN(siteId)) {
+      this.selectedSiteId.set(null);
+      return;
+    }
+
+    this.selectedSiteId.set(siteId);
+    this.loadStats();
+  }
+
+  protected refreshStats(): void {
+    if (this.periodForm.invalid) {
+      this.periodForm.markAllAsTouched();
+      this.statsError.set('S\u00e9lectionnez une date de d\u00e9but et une date de fin.');
+      return;
+    }
+
+    if (!this.isPeriodValid()) {
+      this.statsError.set('La date de d\u00e9but doit \u00eatre ant\u00e9rieure ou \u00e9gale \u00e0 la date de fin.');
+      return;
+    }
+
+    this.loadStats();
+  }
+
+  protected formatCurrency(value: number | null | undefined): string {
+    return new Intl.NumberFormat('fr-BE', {
+      style: 'currency',
+      currency: 'EUR'
+    }).format(Number(value ?? 0));
+  }
+
+  protected formatNumber(value: number | null | undefined): string {
+    return new Intl.NumberFormat('fr-BE').format(Number(value ?? 0));
+  }
+
+  protected trackSite(site: SiteOption): number {
+    return site.id;
+  }
+
+  private loadInitialData(): void {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+    this.statsError.set('');
+
+    this.adminService
+      .getInfo()
+      .pipe(
+        switchMap((adminInfo) => {
+          this.adminInfo.set(adminInfo);
+
+          if (adminInfo.adminType === 'GLOBAL') {
+            return this.sitesService.getSites();
+          }
+
+          if (adminInfo.siteId == null) {
+            throw new Error('P\u00e9rim\u00e8tre administrateur introuvable.');
+          }
+
+          this.selectedSiteId.set(adminInfo.siteId);
+          return of([] as SiteOption[]);
+        }),
+        finalize(() => this.isLoading.set(false))
+      )
+      .subscribe({
+        next: (sites) => {
+          this.sites.set(sites);
+
+          if (this.adminInfo()?.adminType === 'GLOBAL') {
+            this.selectedSiteId.set(null);
+          }
+
+          this.loadStats();
+        },
+        error: (error: HttpErrorResponse | Error) => {
+          this.clearStats();
+          this.errorMessage.set(this.getErrorMessage(error, 'Impossible de charger la page statistiques.'));
+        }
+      });
+  }
+
+  private loadStats(): void {
+    const from = this.periodForm.controls.from.value;
+    const to = this.periodForm.controls.to.value;
+
+    if (!from || !to) {
+      this.statsError.set('S\u00e9lectionnez une date de d\u00e9but et une date de fin.');
+      return;
+    }
+
+    if (!this.isPeriodValid()) {
+      this.statsError.set('La date de d\u00e9but doit \u00eatre ant\u00e9rieure ou \u00e9gale \u00e0 la date de fin.');
+      return;
+    }
+
+    const adminInfo = this.adminInfo();
+
+    if (!adminInfo) {
+      this.statsError.set('Informations administrateur indisponibles.');
+      return;
+    }
+
+    const siteId = this.getCurrentSiteId();
+
+    if (adminInfo.adminType === 'SITE' && siteId == null) {
+      this.statsError.set('P\u00e9rim\u00e8tre administrateur introuvable.');
+      return;
+    }
+
+    const request = adminInfo.adminType === 'GLOBAL' && siteId == null
+      ? forkJoin({
+          ca: this.adminService.getGlobalCaStats(from, to),
+          matchs: this.adminService.getGlobalMatchsStats(from, to),
+          dettes: this.adminService.getGlobalDettesStats()
+        })
+      : forkJoin({
+          ca: this.adminService.getSiteCaStats(siteId as number, from, to),
+          matchs: this.adminService.getSiteMatchsStats(siteId as number, from, to),
+          dettes: this.adminService.getSiteDettesStats(siteId as number)
+        });
+
+    this.isLoadingStats.set(true);
+    this.statsError.set('');
+
+    request
+      .pipe(finalize(() => this.isLoadingStats.set(false)))
+      .subscribe({
+        next: ({ ca, matchs, dettes }) => {
+          this.caStats.set(ca);
+          this.matchsStats.set(matchs);
+          this.dettesStats.set(dettes);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.clearStats();
+          this.statsError.set(this.getErrorMessage(error, 'Impossible de charger les statistiques.'));
+        }
+      });
+  }
+
+  private getCurrentSiteId(): number | null {
+    const adminInfo = this.adminInfo();
+
+    if (adminInfo?.adminType === 'SITE') {
+      return adminInfo.siteId;
+    }
+
+    return this.selectedSiteId();
+  }
+
+  private clearStats(): void {
+    this.caStats.set(null);
+    this.matchsStats.set(null);
+    this.dettesStats.set(null);
+  }
+
+  private isPeriodValid(): boolean {
+    const from = this.periodForm.controls.from.value;
+    const to = this.periodForm.controls.to.value;
+
+    return Boolean(from && to && from <= to);
+  }
+
+  private getFirstDayOfCurrentMonth(): string {
+    const now = new Date();
+    return this.toDateInputValue(new Date(now.getFullYear(), now.getMonth(), 1));
+  }
+
+  private getToday(): string {
+    return this.toDateInputValue(new Date());
+  }
+
+  private toDateInputValue(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+
+    return `${year}-${month}-${day}`;
+  }
+
+  private getErrorMessage(error: HttpErrorResponse | Error, fallback: string): string {
+    if (error instanceof HttpErrorResponse) {
+      if (error.status === 0) {
+        return 'Backend inaccessible.';
+      }
+
+      const backendMessage = this.getBackendMessage(error);
+
+      if (backendMessage) {
+        return backendMessage;
+      }
+
+      if (error.status === 401) {
+        return 'Authentification requise.';
+      }
+
+      if (error.status === 403) {
+        return 'Acc\u00e8s administrateur refus\u00e9.';
+      }
+
+      if (error.status === 404) {
+        return 'Site introuvable.';
+      }
+
+      return fallback;
+    }
+
+    return error.message || fallback;
+  }
+
+  private getBackendMessage(error: HttpErrorResponse): string {
+    const body = error.error as Partial<ApiErrorResponse> | string | null;
+
+    if (typeof body === 'string') {
+      return body;
+    }
+
+    if (body?.message) {
+      return body.message;
+    }
+
+    return '';
+  }
+}


### PR DESCRIPTION
- Ajout de la page /admin/statistiques.

- Ajout de l’accès aux statistiques depuis la zone admin.

- Affichage du chiffre d’affaires sur une période.

- Affichage du nombre de matchs sur une période.

- Affichage de la dette totale actuelle.

- Affichage du nombre de joueurs en dette.

- Support ADMIN_GLOBAL avec vue globale et sélection de site.

- Support ADMIN_SITE limité à son site administré.

- Ajout des filtres de période Du / Au.

- Clarification UX : la période s’applique au chiffre d’affaires et aux matchs, les dettes affichent l’état actuel.

- Ajout d’une validation frontend simple pour empêcher une période invalide.

- Affichage des erreurs backend si disponibles.

- Aucun calcul métier complexe côté Angular.
