### PR TITLE
160 backend exposer la pénalité active du joueur

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/JoueurDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/JoueurDto.java
@@ -2,6 +2,7 @@ package be.ephec.padel.backend.dto.response;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 public class JoueurDto {
 
@@ -10,13 +11,20 @@ public class JoueurDto {
     private TypeJoueur type;
     private Long siteId;
     private BigDecimal solde;
+    private LocalDateTime penaliteJusqua;
 
-    public JoueurDto(String matricule, String nom, TypeJoueur type, Long siteId, BigDecimal solde) {
+    public JoueurDto(String matricule,
+                     String nom,
+                     TypeJoueur type,
+                     Long siteId,
+                     BigDecimal solde,
+                     LocalDateTime penaliteJusqua) {
         this.matricule = matricule;
         this.nom = nom;
         this.type = type;
         this.siteId = siteId;
         this.solde = solde;
+        this.penaliteJusqua = penaliteJusqua;
     }
 
     public String getMatricule() { return matricule; }
@@ -24,4 +32,5 @@ public class JoueurDto {
     public TypeJoueur getType() { return type; }
     public Long getSiteId() { return siteId; }
     public BigDecimal getSolde() { return solde; }
+    public LocalDateTime getPenaliteJusqua() { return penaliteJusqua; }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/mapper/JoueurMapper.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/mapper/JoueurMapper.java
@@ -26,7 +26,8 @@ public final class JoueurMapper {
                 joueur.getNom(),
                 joueur.getType(),
                 siteId,
-                solde
+                solde,
+                joueur.getPenaliteJusqua()
         );
     }
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MeControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MeControllerTest.java
@@ -32,6 +32,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -72,7 +73,23 @@ class MeControllerTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.matricule").value("G0001"))
                 .andExpect(jsonPath("$.nom").value("Alice"))
-                .andExpect(jsonPath("$.type").value("GLOBAL"));
+                .andExpect(jsonPath("$.type").value("GLOBAL"))
+                .andExpect(jsonPath("$.penaliteJusqua").value(nullValue()));
+    }
+
+    @Test
+    void getMe_expose_penalite_jusqua_si_presente() throws Exception {
+        Joueur joueur = new Joueur("G0001", "Alice", TypeJoueur.GLOBAL);
+        joueur.setPenaliteJusqua(LocalDateTime.of(2030, 1, 10, 12, 30));
+
+        when(joueurService.getCurrentJoueurProfile())
+                .thenReturn(joueur);
+
+        mvc.perform(get("/api/v1/me"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.matricule").value("G0001"))
+                .andExpect(jsonPath("$.penaliteJusqua").value("2030-01-10T12:30:00"));
     }
 
     @Test


### PR DESCRIPTION
- Ajout du champ penaliteJusqua dans JoueurDto.

- Exposition de la date/heure de fin de pénalité via GET /api/v1/me.

- Mapping de Joueur.penaliteJusqua dans JoueurMapper.

- Exposition également disponible dans les endpoints admin utilisant JoueurDto, notamment GET /api/v1/joueurs.

- Vérification préalable que GET /api/v1/joueurs est réservé à ADMIN_GLOBAL.

- Aucun ajout de logique métier de pénalité.

- Aucun ajout de penaliteActive dans cette issue.

- Aucun changement frontend, sécurité, base de données, scheduler ou logique J-1.

- Ajout/adaptation des tests MeControllerTest pour vérifier le cas sans pénalité et le cas avec pénalité.

- Vérification des tests MeControllerTest et JoueurControllerTest.