### PR TITLE
issue 161 : Afficher la pénalité active dans l'espace joueur

### DIFF
--- a/frontend/src/app/core/me/me.models.ts
+++ b/frontend/src/app/core/me/me.models.ts
@@ -6,4 +6,5 @@ export interface MeProfile {
   type: PlayerType;
   siteId: number | null;
   solde: number;
+  penaliteJusqua?: string | null;
 }

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.css
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.css
@@ -59,6 +59,23 @@
   gap: 1rem;
 }
 
+.penalty-alert {
+  padding: 1rem 1.25rem;
+  border: 1px solid #f59e0b;
+  border-radius: 0.5rem;
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.penalty-alert h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.penalty-alert p {
+  margin: 0;
+}
+
 .info-section {
   padding: 1.5rem;
   border: 1px solid #d7e0eb;

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.html
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.html
@@ -11,6 +11,18 @@
     <p class="page-state is-error">{{ errorMessage() }}</p>
   } @else if (profile(); as profile) {
     <div class="page-grid">
+      @if (hasActivePenalty() && profile.penaliteJusqua) {
+        <section class="penalty-alert" role="alert">
+          <h2>P&eacute;nalit&eacute; active</h2>
+          <p>
+            Vous &ecirc;tes p&eacute;nalis&eacute; jusqu&rsquo;au
+            {{ profile.penaliteJusqua | date:'dd/MM/yyyy' }} &agrave;
+            {{ profile.penaliteJusqua | date:'HH:mm' }}.
+            Vous ne pouvez pas cr&eacute;er de nouveau match pendant cette p&eacute;riode.
+          </p>
+        </section>
+      }
+
       <section class="info-section">
         <h2>Informations personnelles</h2>
 

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.ts
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.ts
@@ -39,6 +39,15 @@ export class EspacePrivePageComponent implements OnInit {
     const profile = this.profile();
     return profile != null && profile.solde > 0;
   });
+  protected readonly hasActivePenalty = computed(() => {
+    const penaliteJusqua = this.profile()?.penaliteJusqua;
+
+    if (!penaliteJusqua) {
+      return false;
+    }
+
+    return new Date(penaliteJusqua).getTime() > Date.now();
+  });
   protected readonly regularisationItems = computed(() => this.regularisations().items);
   protected readonly totalTracable = computed(() => this.regularisations().totalTracable);
   protected readonly hasTraceableGap = computed(() => {


### PR DESCRIPTION
- Ajout du champ penaliteJusqua dans le modèle MeProfile.

- Affichage d’une alerte dans l’espace joueur lorsqu’une pénalité active est détectée.

- L’alerte s’affiche uniquement si penaliteJusqua existe et est dans le futur.

- Aucune alerte n’est affichée si penaliteJusqua est null, absent ou expiré.

- Formatage lisible de la date et de l’heure avec le pipe Angular date.

- Aucun blocage ajouté côté Angular.

- Aucun bouton masqué ou désactivé dans cette issue.

- Le backend reste responsable du vrai refus métier lors de la création d’un match.

