### PR TITLE
issue 163 : Améliorer l'avertissement de risque de pénalité J-1

### DIFF
--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.html
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.html
@@ -78,7 +78,10 @@
           </dl>
 
           @if (match.risquePenaliteJ1) {
-            <p class="risk-message">Risque de p&eacute;nalit&eacute; J-1</p>
+            <p class="risk-message">
+              Attention : ce match priv&eacute; est incomplet. S&rsquo;il reste incomplet &agrave; J-1,
+              il pourra devenir public et une p&eacute;nalit&eacute; pourra &ecirc;tre appliqu&eacute;e.
+            </p>
           }
 
           <a [routerLink]="['/matchs', match.id]" class="detail-link">Voir le d&eacute;tail</a>


### PR DESCRIPTION
- Amélioration du message d’avertissement sur la page Mes matchs organisés.

- Utilisation du champ existant risquePenaliteJ1 fourni par le backend.

- Remplacement du message court “Risque de pénalité J-1” par un message explicatif clair.

- Le message indique qu’un match privé incomplet peut devenir public à J-1 et qu’une pénalité peut être appliquée.

- Aucun recalcul de la règle J-1 côté Angular.

