### PR TITLE
issue 164 : "Ajouter la consultation admin des joueurs pénalisés

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/JoueurAdminDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/JoueurAdminDto.java
@@ -3,6 +3,7 @@ package be.ephec.padel.backend.dto.response;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 public class JoueurAdminDto {
 
@@ -10,16 +11,23 @@ public class JoueurAdminDto {
     private final String nom;
     private final TypeJoueur type;
     private final BigDecimal solde;
+    private final LocalDateTime penaliteJusqua;
 
-    public JoueurAdminDto(String matricule, String nom, TypeJoueur type, BigDecimal solde) {
+    public JoueurAdminDto(String matricule,
+                          String nom,
+                          TypeJoueur type,
+                          BigDecimal solde,
+                          LocalDateTime penaliteJusqua) {
         this.matricule = matricule;
         this.nom = nom;
         this.type = type;
         this.solde = solde;
+        this.penaliteJusqua = penaliteJusqua;
     }
 
     public String getMatricule() { return matricule; }
     public String getNom() { return nom; }
     public TypeJoueur getType() { return type; }
     public BigDecimal getSolde() { return solde; }
+    public LocalDateTime getPenaliteJusqua() { return penaliteJusqua; }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminSiteService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminSiteService.java
@@ -48,7 +48,8 @@ public class AdminSiteService {
                 joueur.getMatricule(),
                 joueur.getNom(),
                 joueur.getType(),
-                joueur.getSolde()
+                joueur.getSolde(),
+                joueur.getPenaliteJusqua()
         );
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/integration/AdminPerimetreSiteIntegrationTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/integration/AdminPerimetreSiteIntegrationTest.java
@@ -17,8 +17,11 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -65,6 +68,7 @@ class AdminPerimetreSiteIntegrationTest extends SqlServerTestContainerConfig {
         // Joueurs (constructeurs car pas de setMatricule)
         Joueur j1 = new Joueur("J001", "Dupont", TypeJoueur.SITE, site1);
         j1.setSolde(new BigDecimal("15.00"));
+        j1.setPenaliteJusqua(LocalDateTime.of(2030, 1, 10, 12, 30));
         joueurRepository.save(j1);
 
         Joueur j2 = new Joueur("J002", "Martin", TypeJoueur.SITE, site2);
@@ -76,7 +80,10 @@ class AdminPerimetreSiteIntegrationTest extends SqlServerTestContainerConfig {
     @WithMockUser(username = "adminSite1", roles = {"ADMIN_SITE"})
     void adminSite1_peutAcceder_aSonSite_200() throws Exception {
         mockMvc.perform(get("/api/v1/admin/sites/1/joueurs"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].matricule").value("J001"))
+                .andExpect(jsonPath("$[0].penaliteJusqua").value("2030-01-10T12:30:00"));
     }
 
     @Test
@@ -90,6 +97,9 @@ class AdminPerimetreSiteIntegrationTest extends SqlServerTestContainerConfig {
     @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
     void adminGlobal_peutAcceder_aTousLesSites_200() throws Exception {
         mockMvc.perform(get("/api/v1/admin/sites/2/joueurs"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].matricule").value("J002"))
+                .andExpect(jsonPath("$[0].penaliteJusqua").value(nullValue()));
     }
 }

--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -13,6 +13,7 @@ export interface AdminPlayerResponse {
   type: RegistrationSubscriptionType;
   siteId: number | null;
   solde: number | null;
+  penaliteJusqua?: string | null;
 }
 
 export interface AdminSitePlayerResponse {
@@ -20,6 +21,7 @@ export interface AdminSitePlayerResponse {
   nom: string;
   type: RegistrationSubscriptionType;
   solde: number | null;
+  penaliteJusqua?: string | null;
 }
 
 export interface AdminPlayerListItem {
@@ -29,6 +31,7 @@ export interface AdminPlayerListItem {
   siteId: number | null;
   siteNom: string | null;
   solde: number | null;
+  penaliteJusqua?: string | null;
 }
 
 export interface PendingRegistrationItem {

--- a/frontend/src/app/features/admin/joueurs/admin-players-page.component.css
+++ b/frontend/src/app/features/admin/joueurs/admin-players-page.component.css
@@ -66,6 +66,32 @@
   gap: 1rem;
 }
 
+.penalized-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.section-heading {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+  color: #10233f;
+  font-size: 1.35rem;
+}
+
+.section-heading p {
+  margin: 0;
+  color: #526277;
+}
+
+.penalized-list {
+  display: grid;
+  gap: 0.9rem;
+}
+
 .player-card {
   display: grid;
   gap: 1rem;
@@ -76,12 +102,22 @@
   box-shadow: 0 18px 38px rgba(15, 23, 42, 0.06);
 }
 
+.penalized-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid #f59e0b;
+  border-radius: 0.5rem;
+  background: #fffbeb;
+}
+
 .player-heading {
   display: grid;
   gap: 0.35rem;
 }
 
-.player-heading h2 {
+.player-heading h2,
+.player-heading h3 {
   margin: 0;
   color: #10233f;
   font-size: 1.25rem;
@@ -117,6 +153,15 @@
 
 .player-meta strong {
   color: #10233f;
+}
+
+.player-meta .penalty-date {
+  border-color: #fbbf24;
+  background: #fff7ed;
+}
+
+.penalty-date strong {
+  color: #92400e;
 }
 
 @media (max-width: 760px) {

--- a/frontend/src/app/features/admin/joueurs/admin-players-page.component.html
+++ b/frontend/src/app/features/admin/joueurs/admin-players-page.component.html
@@ -17,6 +17,51 @@
       <p class="page-state">Aucun joueur trouv&eacute; dans votre p&eacute;rim&egrave;tre.</p>
     }
 
+    <section class="penalized-section">
+      <div class="section-heading">
+        <h2>Joueurs actuellement p&eacute;nalis&eacute;s</h2>
+        <p>Consultez les joueurs dont la p&eacute;nalit&eacute; est active.</p>
+      </div>
+
+      @if (penalizedPlayers().length === 0) {
+        <p class="page-state">Aucun joueur actuellement p&eacute;nalis&eacute;.</p>
+      } @else {
+        <div class="penalized-list">
+          @for (player of penalizedPlayers(); track player.matricule) {
+            <article class="penalized-card">
+              <div class="player-heading">
+                <h3>{{ player.nom }}</h3>
+                <p class="player-id">{{ player.matricule }}</p>
+              </div>
+
+              <div class="player-meta">
+                <p>
+                  <span>Type</span>
+                  <strong>{{ getTypeLabel(player.type) }}</strong>
+                </p>
+
+                @if (hasSite(player)) {
+                  <p>
+                    <span>Site</span>
+                    <strong>{{ player.siteNom }}</strong>
+                  </p>
+                }
+
+                <p class="penalty-date">
+                  <span>P&eacute;nalit&eacute;</span>
+                  <strong>
+                    P&eacute;nalis&eacute; jusqu&rsquo;au
+                    {{ player.penaliteJusqua | date:'dd/MM/yyyy' }}
+                    &agrave; {{ player.penaliteJusqua | date:'HH:mm' }}
+                  </strong>
+                </p>
+              </div>
+            </article>
+          }
+        </div>
+      }
+    </section>
+
     <div class="players-list">
       @for (player of players(); track player.matricule) {
         <article class="player-card">

--- a/frontend/src/app/features/admin/joueurs/admin-players-page.component.ts
+++ b/frontend/src/app/features/admin/joueurs/admin-players-page.component.ts
@@ -36,6 +36,10 @@ export class AdminPlayersPageComponent implements OnInit {
 
   protected readonly isEmpty = computed(() => !this.isLoading() && !this.errorMessage() && this.players().length === 0);
 
+  protected readonly penalizedPlayers = computed(() =>
+    this.players().filter((player) => this.hasActivePenalty(player))
+  );
+
   protected readonly playersCountMessage = computed(() => {
     const count = this.players().length;
 
@@ -80,6 +84,14 @@ export class AdminPlayersPageComponent implements OnInit {
     }
 
     return `${this.currencyFormatter.format(solde)} \u20ac`;
+  }
+
+  protected hasActivePenalty(player: AdminPlayerListItem): boolean {
+    if (!player.penaliteJusqua) {
+      return false;
+    }
+
+    return new Date(player.penaliteJusqua).getTime() > Date.now();
   }
 
   private loadPlayers(): void {
@@ -129,7 +141,8 @@ export class AdminPlayersPageComponent implements OnInit {
       type: player.type,
       siteId: player.siteId,
       siteNom: player.siteId == null ? null : siteNames.get(player.siteId) ?? null,
-      solde: player.solde
+      solde: player.solde,
+      penaliteJusqua: player.penaliteJusqua ?? null
     }));
   }
 
@@ -140,7 +153,8 @@ export class AdminPlayersPageComponent implements OnInit {
       type: player.type,
       siteId: adminInfo.siteId,
       siteNom: adminInfo.siteNom,
-      solde: player.solde
+      solde: player.solde,
+      penaliteJusqua: player.penaliteJusqua ?? null
     }));
   }
 


### PR DESCRIPTION
- Ajout de l’exposition de penaliteJusqua dans JoueurAdminDto pour les administrateurs de site.

- Mapping de Joueur.penaliteJusqua dans AdminSiteService.

- Conservation des droits existants : ADMIN_SITE reste limité à son site et ADMIN_GLOBAL conserve l’accès global.

- Ajout de penaliteJusqua dans les modèles frontend admin joueurs.

- Ajout d’une section “Joueurs actuellement pénalisés” dans /admin/joueurs.

- Affichage des joueurs pénalisés pour ADMIN_GLOBAL et ADMIN_SITE.

- Filtrage frontend uniquement pour l’affichage des pénalités actives.

- Formatage lisible de la date et de l’heure de fin de pénalité.

- Conservation de la liste complète des joueurs.

- Aucune action ajoutée pour lever ou modifier une pénalité.

- Aucune modification de la logique métier, des endpoints, de la sécurité ou de la base de données.

- Tests backend ciblés validés.

- Build frontend validé.