### PR TITLE
175 backend ajout d' un joueur pénalisé de démonstration seed

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeeder.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/seed/DevDataSeeder.java
@@ -134,11 +134,15 @@ public class DevDataSeeder {
         Joueur joueurSiteNord = ensureJoueur("S9001", "Joueur Site Nord Demo", TypeJoueur.SITE, siteNord, ZERO);
         Joueur joueurLibre = ensureJoueur("L9001", "Joueur Libre Demo", TypeJoueur.LIBRE, null, ZERO);
         Joueur joueurSiteSud = ensureJoueur("S9002", "Joueur Site Sud Demo", TypeJoueur.SITE, siteSud, ZERO);
+        Joueur joueurPenalise = ensureJoueur("S9003", "Joueur Penalise Demo", TypeJoueur.SITE, siteNord, ZERO);
+        joueurPenalise.setPenaliteJusqua(LocalDate.now(clock).plusDays(7).atTime(23, 59));
+        joueurRepository.save(joueurPenalise);
 
         ensurePlayerUser("joueur.global.dev", joueurGlobal);
         ensurePlayerUser("joueur.site.dev", joueurSiteNord);
         ensurePlayerUser("joueur.libre.dev", joueurLibre);
         ensurePlayerUser("joueur.site.sud.dev", joueurSiteSud);
+        ensurePlayerUser("joueur.penalise.dev", joueurPenalise);
 
         LocalDate today = LocalDate.now(clock);
 
@@ -221,8 +225,9 @@ public class DevDataSeeder {
                 - joueur.site.dev / {}
                 - joueur.libre.dev / {}
                 - joueur.site.sud.dev / {}
+                - joueur.penalise.dev / {}
                 Support ADMIN_SITE garanti uniquement sur DB locale propre / vide.
-                """, PLAYER_PASSWORD, PLAYER_PASSWORD, PLAYER_PASSWORD, PLAYER_PASSWORD);
+                """, PLAYER_PASSWORD, PLAYER_PASSWORD, PLAYER_PASSWORD, PLAYER_PASSWORD, PLAYER_PASSWORD);
     }
 
     private void validateAdminBootstrapOrderAndConfiguration() {

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -175,7 +175,7 @@ public class MatchPadelService {
 
         if (organisateur.getPenaliteJusqua() != null && organisateur.getPenaliteJusqua().isAfter(now)) {
             throw new BusinessException(
-                    "RÃ©servation impossible : pÃ©nalitÃ© activÃ© jusqu'au "
+                    "Reservation impossible : penalite active jusqu'au "
                             + organisateur.getPenaliteJusqua().toLocalDate()
                             + " inclus."
             );

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.ts
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.ts
@@ -327,6 +327,11 @@ export class CreateMatchPageComponent implements OnInit {
 
   private normalizeForSearch(value: string): string {
     return value
+      .replace(/ÃƒÂ©|Ã©/g, 'e')
+      .replace(/ÃƒÂ¨|Ã¨/g, 'e')
+      .replace(/ÃƒÂª|Ãª/g, 'e')
+      .replace(/ÃƒÂ |Ã /g, 'a')
+      .replace(/ÃƒÂ§|Ã§/g, 'c')
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '')
       .toLowerCase();


### PR DESCRIPTION
- Ajout d’un joueur pénalisé de démonstration dans le seed local/dev.

- Création du joueur S9003 - Joueur Penalise Demo rattaché au Site Nord.

- Création du compte joueur.penalise.dev / joueur123.

- Ajout d’une pénalité active dynamique via Clock.

- Le joueur permet de tester l’alerte dans l’espace joueur.

- Le joueur permet de tester le refus de création de match par pénalité.

- Le joueur apparaît dans la consultation admin des joueurs pénalisés pour ADMIN_GLOBAL et ADMIN_SITE.

- Aucune modification de logique métier, sécurité, endpoints, frontend ou base de données.