### PR TITLE
issue 177 : Utiliser les horaires réels pour les créneaux de réservation

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/MatchController.java
@@ -2,6 +2,7 @@ package be.ephec.padel.backend.controller;
 
 import be.ephec.padel.backend.dto.request.CreateMatchRequest;
 import be.ephec.padel.backend.dto.response.ApiErrorDto;
+import be.ephec.padel.backend.dto.response.CreneauxMatchResponseDto;
 import be.ephec.padel.backend.dto.response.MatchDetailDto;
 import be.ephec.padel.backend.dto.response.MatchDto;
 import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
@@ -39,6 +40,27 @@ public class MatchController {
 
     public MatchController(MatchPadelService matchPadelService) {
         this.matchPadelService = matchPadelService;
+    }
+
+    @Operation(
+            summary = "Lister les creneaux reservables",
+            description = "Retourne les creneaux reservables pour un terrain et une date, selon l'utilisateur authentifie."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Creneaux recuperes"),
+            @ApiResponse(responseCode = "400", description = "Parametres invalides",
+                    content = @Content(schema = @Schema(implementation = ApiErrorDto.class))),
+            @ApiResponse(responseCode = "404", description = "Terrain introuvable",
+                    content = @Content(schema = @Schema(implementation = ApiErrorDto.class)))
+    })
+    @GetMapping("/creneaux")
+    public ResponseEntity<CreneauxMatchResponseDto> getCreneaux(
+            @RequestParam Long terrainId,
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date) {
+
+        return ResponseEntity.ok(matchPadelService.getCreneauxDisponibles(terrainId, date));
     }
 
     @Operation(

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/CreneauxMatchResponseDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/CreneauxMatchResponseDto.java
@@ -1,0 +1,22 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.util.List;
+
+public class CreneauxMatchResponseDto {
+
+    private List<String> creneaux;
+    private String message;
+
+    public CreneauxMatchResponseDto(List<String> creneaux, String message) {
+        this.creneaux = creneaux;
+        this.message = message;
+    }
+
+    public List<String> getCreneaux() {
+        return creneaux;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -1,6 +1,7 @@
 package be.ephec.padel.backend.service;
 
 import be.ephec.padel.backend.common.Tarifs;
+import be.ephec.padel.backend.dto.response.CreneauxMatchResponseDto;
 import be.ephec.padel.backend.dto.response.MatchDetailDto;
 import be.ephec.padel.backend.dto.response.MatchDto;
 import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
@@ -40,7 +41,10 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @Transactional
@@ -49,6 +53,16 @@ public class MatchPadelService {
     private static final long DUREE_MATCH_MIN = 90;
     private static final long BUFFER_MIN = 15;
     private static final long SLOT_MIN = DUREE_MATCH_MIN + BUFFER_MIN;
+    private static final long PAS_CRENEAU_MIN = 15;
+    private static final DateTimeFormatter CRENEAU_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+    private static final String MESSAGE_HORAIRE_MANQUANT =
+            "Aucun horaire n'est configure pour ce site et cette annee.";
+    private static final String MESSAGE_SITE_FERME =
+            "Aucun creneau disponible : le site est ferme a cette date.";
+    private static final String MESSAGE_AUCUN_CRENEAU =
+            "Aucun creneau disponible pour ce terrain et cette date.";
+    private static final String MESSAGE_RESERVATION_NON_AUTORISEE =
+            "Aucun creneau disponible : votre situation ne permet pas de reserver.";
 
     private final MatchPadelRepository matchPadelRepository;
     private final TerrainRepository terrainRepository;
@@ -123,7 +137,7 @@ public class MatchPadelService {
 
         Site site = terrain.getSite();
         DayOfWeek jour = dateDebut.getDayOfWeek();
-        if (site.getJoursFermeture().contains(jour)) {
+        if (estJourFermetureSite(site, jour)) {
             throw new BusinessException("Reservation impossible : site ferme ce jour-la.");
         }
 
@@ -169,11 +183,11 @@ public class MatchPadelService {
         Terrain terrain = terrainRepository.findById(terrainId)
                 .orElseThrow(() -> new NotFoundException("Terrain introuvable"));
 
-        if (organisateur.getSolde() != null && organisateur.getSolde().signum() > 0) {
+        if (aDette(organisateur)) {
             throw new BusinessException("Reservation impossible : dette en cours (" + organisateur.getSolde() + ").");
         }
 
-        if (organisateur.getPenaliteJusqua() != null && organisateur.getPenaliteJusqua().isAfter(now)) {
+        if (aPenaliteActive(organisateur, now)) {
             throw new BusinessException(
                     "Reservation impossible : penalite active jusqu'au "
                             + organisateur.getPenaliteJusqua().toLocalDate()
@@ -208,6 +222,113 @@ public class MatchPadelService {
         return saved;
     }
 
+    @Transactional(readOnly = true)
+    public CreneauxMatchResponseDto getCreneauxDisponibles(Long terrainId, LocalDate date) {
+        if (terrainId == null) {
+            throw new BusinessException("Terrain obligatoire");
+        }
+        if (date == null) {
+            throw new BusinessException("Date obligatoire");
+        }
+
+        Joueur joueur = currentUserFacade.getCurrentJoueur();
+        if (joueur == null) {
+            throw new BusinessException("Joueur obligatoire");
+        }
+
+        Terrain terrain = terrainRepository.findById(terrainId)
+                .orElseThrow(() -> new NotFoundException("Terrain introuvable"));
+
+        if (terrain.getSite() == null || terrain.getSite().getId() == null) {
+            throw new BusinessException("Terrain sans site associe.");
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        if (aDette(joueur) || aPenaliteActive(joueur, now)) {
+            return new CreneauxMatchResponseDto(List.of(), MESSAGE_RESERVATION_NON_AUTORISEE);
+        }
+
+        Site site = terrain.getSite();
+        Long siteId = site.getId();
+
+        HoraireSite horaire;
+        try {
+            horaire = horaireSiteService.getApplicable(siteId, date.atStartOfDay());
+        } catch (BusinessException exception) {
+            return new CreneauxMatchResponseDto(List.of(), MESSAGE_HORAIRE_MANQUANT);
+        }
+
+        if (estJourFermetureSite(site, date.getDayOfWeek())
+                || fermetureGlobaleRepository.existsByDate(date)
+                || fermetureSiteService.isDateFermeePourSite(siteId, date)) {
+            return new CreneauxMatchResponseDto(List.of(), MESSAGE_SITE_FERME);
+        }
+
+        LocalTime ouverture = horaire.getHeureOuverture();
+        LocalTime fermeture = horaire.getHeureFermeture();
+        LocalTime dernierDebut = fermeture.minusMinutes(SLOT_MIN);
+
+        if (dernierDebut.isBefore(ouverture)) {
+            return new CreneauxMatchResponseDto(List.of(), MESSAGE_AUCUN_CRENEAU);
+        }
+
+        LocalDateTime debutRecherche = date.atStartOfDay().minusMinutes(SLOT_MIN);
+        LocalDateTime finRecherche = date.plusDays(1).atStartOfDay().plusMinutes(SLOT_MIN);
+        List<MatchPadel> matchsProches = matchPadelRepository.findByTerrainIdAndDateDebutBetween(
+                terrainId,
+                debutRecherche,
+                finRecherche
+        );
+
+        List<String> creneaux = new ArrayList<>();
+
+        for (LocalTime heure = ouverture;
+             !heure.isAfter(dernierDebut);
+             heure = heure.plusMinutes(PAS_CRENEAU_MIN)) {
+
+            LocalDateTime dateDebut = date.atTime(heure);
+
+            if (!dateDebut.isAfter(now)) {
+                continue;
+            }
+
+            if (!peutReserverSurCreneau(joueur, terrain, dateDebut, now)) {
+                continue;
+            }
+
+            if (!estTerrainDisponible(matchsProches, dateDebut)) {
+                continue;
+            }
+
+            creneaux.add(heure.format(CRENEAU_FORMATTER));
+        }
+
+        return new CreneauxMatchResponseDto(
+                creneaux,
+                creneaux.isEmpty() ? MESSAGE_AUCUN_CRENEAU : null
+        );
+    }
+
+    private boolean aDette(Joueur joueur) {
+        return joueur.getSolde() != null && joueur.getSolde().signum() > 0;
+    }
+
+    private boolean aPenaliteActive(Joueur joueur, LocalDateTime now) {
+        return joueur.getPenaliteJusqua() != null && joueur.getPenaliteJusqua().isAfter(now);
+    }
+
+    private boolean peutReserverSurCreneau(Joueur joueur,
+                                           Terrain terrain,
+                                           LocalDateTime dateDebut,
+                                           LocalDateTime now) {
+        try {
+            verifierDroitReservation(joueur, terrain, dateDebut, now);
+            return true;
+        } catch (BusinessException exception) {
+            return false;
+        }
+    }
+
     private void verifierTerrainDisponible(Long terrainId, LocalDateTime newStart) {
         if (terrainId == null) {
             throw new BusinessException("Terrain obligatoire");
@@ -222,6 +343,14 @@ public class MatchPadelService {
         List<MatchPadel> candidats =
                 matchPadelRepository.findByTerrainIdAndDateDebutBetween(terrainId, from, to);
 
+        if (!estTerrainDisponible(candidats, newStart)) {
+            throw new BusinessException(
+                    "Terrain indisponible : un match est deja prevu sur ce terrain (1h30 + 15 minutes de battement)."
+            );
+        }
+    }
+
+    private boolean estTerrainDisponible(List<MatchPadel> candidats, LocalDateTime newStart) {
         LocalDateTime newEndBuffer = newStart.plusMinutes(SLOT_MIN);
 
         for (MatchPadel existing : candidats) {
@@ -234,11 +363,16 @@ public class MatchPadelService {
             boolean overlap = existingStart.isBefore(newEndBuffer) && newStart.isBefore(existingEndBuffer);
 
             if (overlap) {
-                throw new BusinessException(
-                        "Terrain indisponible : un match est deja prevu sur ce terrain (1h30 + 15 minutes de battement)."
-                );
+                return false;
             }
         }
+
+        return true;
+    }
+
+    private boolean estJourFermetureSite(Site site, DayOfWeek jour) {
+        Set<DayOfWeek> joursFermeture = site.getJoursFermeture();
+        return joursFermeture != null && joursFermeture.contains(jour);
     }
 
     private void verifierDroitReservation(Joueur organisateur,

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
@@ -1,6 +1,7 @@
 package be.ephec.padel.backend.unit.service;
 
 import be.ephec.padel.backend.common.Tarifs;
+import be.ephec.padel.backend.dto.response.CreneauxMatchResponseDto;
 import be.ephec.padel.backend.dto.response.MatchDetailDto;
 import be.ephec.padel.backend.dto.response.MatchDto;
 import be.ephec.padel.backend.dto.response.PublicMatchSummaryDto;
@@ -119,6 +120,36 @@ class MatchPadelServiceTest {
 
         when(horaireSiteService.getApplicable(eq(1L), any(LocalDateTime.class)))
                 .thenReturn(horaire);
+    }
+
+    private Terrain stubTerrainPourCreneaux(Long terrainId, Long siteId, LocalDate date) {
+        return stubTerrainPourCreneaux(terrainId, siteId, date, LocalTime.of(8, 0), LocalTime.of(22, 0));
+    }
+
+    private Terrain stubTerrainPourCreneaux(
+            Long terrainId,
+            Long siteId,
+            LocalDate date,
+            LocalTime heureOuverture,
+            LocalTime heureFermeture) {
+        Terrain terrain = mock(Terrain.class);
+        Site site = mock(Site.class);
+        HoraireSite horaire = mock(HoraireSite.class);
+
+        when(terrain.getSite()).thenReturn(site);
+        when(site.getId()).thenReturn(siteId);
+        when(site.getJoursFermeture()).thenReturn(Set.of());
+        when(horaire.getHeureOuverture()).thenReturn(heureOuverture);
+        when(horaire.getHeureFermeture()).thenReturn(heureFermeture);
+
+        when(terrainRepo.findById(terrainId)).thenReturn(Optional.of(terrain));
+        when(horaireSiteService.getApplicable(siteId, date.atStartOfDay())).thenReturn(horaire);
+        when(fermetureGlobaleRepo.existsByDate(date)).thenReturn(false);
+        when(fermetureSiteService.isDateFermeePourSite(siteId, date)).thenReturn(false);
+        when(matchRepo.findByTerrainIdAndDateDebutBetween(eq(terrainId), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(List.of());
+
+        return terrain;
     }
 
     private Joueur stubOrgaGlobalSansDette(String matricule) {
@@ -1215,6 +1246,149 @@ class MatchPadelServiceTest {
         assertTrue(ex.getMessage().toLowerCase().contains("site"));
         verify(fermetureSiteService).isDateFermeePourSite(99L, date.toLocalDate());
         verifyNoInteractions(matchRepo, participationRepo, soldeService, paiementService);
+    }
+
+    @Test
+    void getCreneauxDisponibles_horaire_8_22_retourne_dernier_20_15_et_pas_22_00() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        stubTerrainPourCreneaux(1L, 1L, date);
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().contains("08:00"));
+        assertTrue(response.getCreneaux().contains("20:15"));
+        assertFalse(response.getCreneaux().contains("20:30"));
+        assertFalse(response.getCreneaux().contains("22:00"));
+        assertNull(response.getMessage());
+    }
+
+    @Test
+    void getCreneauxDisponibles_horaire_8_23_retourne_dernier_21_15() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        stubTerrainPourCreneaux(1L, 1L, date, LocalTime.of(8, 0), LocalTime.of(23, 0));
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().contains("21:15"));
+        assertFalse(response.getCreneaux().contains("21:30"));
+        assertFalse(response.getCreneaux().contains("23:00"));
+        assertEquals("21:15", response.getCreneaux().get(response.getCreneaux().size() - 1));
+        assertNull(response.getMessage());
+    }
+
+    @Test
+    void getCreneauxDisponibles_horaire_manquant_retourne_200_metier_liste_vide_message() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        Terrain terrain = mock(Terrain.class);
+        Site site = mock(Site.class);
+        when(terrain.getSite()).thenReturn(site);
+        when(site.getId()).thenReturn(1L);
+        when(terrainRepo.findById(1L)).thenReturn(Optional.of(terrain));
+        when(horaireSiteService.getApplicable(1L, date.atStartOfDay()))
+                .thenThrow(new BusinessException("Aucun horaire configure"));
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Aucun horaire n'est configure pour ce site et cette annee.", response.getMessage());
+        verify(matchRepo, never()).findByTerrainIdAndDateDebutBetween(anyLong(), any(), any());
+    }
+
+    @Test
+    void getCreneauxDisponibles_fermeture_globale_retourne_liste_vide_message_site_ferme() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        stubTerrainPourCreneaux(1L, 1L, date);
+        when(fermetureGlobaleRepo.existsByDate(date)).thenReturn(true);
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Aucun creneau disponible : le site est ferme a cette date.", response.getMessage());
+        verify(matchRepo, never()).findByTerrainIdAndDateDebutBetween(anyLong(), any(), any());
+    }
+
+    @Test
+    void getCreneauxDisponibles_jour_fermeture_site_retourne_liste_vide_message_site_ferme() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        Terrain terrain = stubTerrainPourCreneaux(1L, 1L, date);
+        when(terrain.getSite().getJoursFermeture()).thenReturn(Set.of(date.getDayOfWeek()));
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Aucun creneau disponible : le site est ferme a cette date.", response.getMessage());
+        verify(matchRepo, never()).findByTerrainIdAndDateDebutBetween(anyLong(), any(), any());
+    }
+
+    @Test
+    void getCreneauxDisponibles_fermeture_site_exceptionnelle_retourne_liste_vide_message_site_ferme() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        stubTerrainPourCreneaux(1L, 1L, date);
+        when(fermetureSiteService.isDateFermeePourSite(1L, date)).thenReturn(true);
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Aucun creneau disponible : le site est ferme a cette date.", response.getMessage());
+        verify(matchRepo, never()).findByTerrainIdAndDateDebutBetween(anyLong(), any(), any());
+    }
+
+    @Test
+    void getCreneauxDisponibles_terrain_occupe_retire_les_creneaux_chevauchants() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        stubTerrainPourCreneaux(1L, 1L, date);
+        MatchPadel existing = mock(MatchPadel.class);
+        when(existing.getDateDebut()).thenReturn(date.atTime(10, 0));
+        when(matchRepo.findByTerrainIdAndDateDebutBetween(eq(1L), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(List.of(existing));
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().contains("08:15"));
+        assertFalse(response.getCreneaux().contains("08:30"));
+        assertFalse(response.getCreneaux().contains("10:00"));
+        assertFalse(response.getCreneaux().contains("11:30"));
+        assertTrue(response.getCreneaux().contains("11:45"));
+    }
+
+    @Test
+    void getCreneauxDisponibles_libre_trop_loin_retourne_liste_vide() {
+        LocalDate date = LocalDate.of(2026, 4, 15);
+        stubTerrainPourCreneaux(1L, 1L, date);
+        stubCurrentJoueur("L0001", TypeJoueur.LIBRE, BigDecimal.ZERO);
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Aucun creneau disponible pour ce terrain et cette date.", response.getMessage());
+    }
+
+    @Test
+    void getCreneauxDisponibles_joueur_site_hors_site_retourne_liste_vide() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        stubTerrainPourCreneaux(1L, 2L, date);
+
+        Joueur joueur = stubCurrentJoueur("S0001", TypeJoueur.SITE, BigDecimal.ZERO);
+        Site siteJoueur = mock(Site.class);
+        when(siteJoueur.getId()).thenReturn(1L);
+        when(joueur.getSite()).thenReturn(siteJoueur);
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Aucun creneau disponible pour ce terrain et cette date.", response.getMessage());
+    }
+
+    @Test
+    void getCreneauxDisponibles_date_du_jour_ne_propose_pas_les_heures_passees() {
+        LocalDate date = LocalDate.of(2026, 3, 24);
+        stubTerrainPourCreneaux(1L, 1L, date);
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertFalse(response.getCreneaux().contains("08:00"));
+        assertFalse(response.getCreneaux().contains("11:00"));
+        assertTrue(response.getCreneaux().contains("11:15"));
     }
 }
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
@@ -2,6 +2,7 @@ package be.ephec.padel.backend.web.controller;
 
 import be.ephec.padel.backend.config.SecurityConfig;
 import be.ephec.padel.backend.controller.MatchController;
+import be.ephec.padel.backend.dto.response.CreneauxMatchResponseDto;
 import be.ephec.padel.backend.dto.response.MatchDetailDto;
 import be.ephec.padel.backend.dto.response.MatchDto;
 import be.ephec.padel.backend.dto.response.ParticipantDto;
@@ -30,6 +31,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -162,6 +164,51 @@ class MatchControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getCreneaux_sansAuth_401() throws Exception {
+        mvc.perform(get("/api/v1/matchs/creneaux")
+                        .param("terrainId", "1")
+                        .param("date", "2030-01-01"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getCreneaux_auth_200_et_json() throws Exception {
+        LocalDate date = LocalDate.of(2030, 1, 1);
+        when(matchPadelService.getCreneauxDisponibles(1L, date))
+                .thenReturn(new CreneauxMatchResponseDto(List.of("08:00", "08:15", "20:15"), null));
+
+        mvc.perform(get("/api/v1/matchs/creneaux")
+                        .param("terrainId", "1")
+                        .param("date", "2030-01-01"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.creneaux[0]").value("08:00"))
+                .andExpect(jsonPath("$.creneaux[2]").value("20:15"))
+                .andExpect(jsonPath("$.message").value(nullValue()));
+
+        verify(matchPadelService).getCreneauxDisponibles(1L, date);
+    }
+
+    @Test
+    void getCreneaux_horaire_manquant_200_liste_vide_message() throws Exception {
+        LocalDate date = LocalDate.of(2030, 1, 1);
+        when(matchPadelService.getCreneauxDisponibles(1L, date))
+                .thenReturn(new CreneauxMatchResponseDto(
+                        List.of(),
+                        "Aucun horaire n'est configure pour ce site et cette annee."
+                ));
+
+        mvc.perform(get("/api/v1/matchs/creneaux")
+                        .param("terrainId", "1")
+                        .param("date", "2030-01-01"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.creneaux").isArray())
+                .andExpect(jsonPath("$.creneaux").isEmpty())
+                .andExpect(jsonPath("$.message").value("Aucun horaire n'est configure pour ce site et cette annee."));
     }
 
     @Test

--- a/frontend/src/app/core/matches/create-match.models.ts
+++ b/frontend/src/app/core/matches/create-match.models.ts
@@ -20,3 +20,8 @@ export interface CreatedMatch {
   montantPaye: number;
   resteAPayer: number;
 }
+
+export interface MatchSlotsResponse {
+  creneaux: string[];
+  message: string | null;
+}

--- a/frontend/src/app/core/matches/match-creation.service.ts
+++ b/frontend/src/app/core/matches/match-creation.service.ts
@@ -1,8 +1,8 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { CreateMatchPayload, CreatedMatch } from './create-match.models';
+import { CreateMatchPayload, CreatedMatch, MatchSlotsResponse } from './create-match.models';
 
 @Injectable({ providedIn: 'root' })
 export class MatchCreationService {
@@ -10,5 +10,13 @@ export class MatchCreationService {
 
   createMatch(payload: CreateMatchPayload): Observable<CreatedMatch> {
     return this.http.post<CreatedMatch>(`${environment.apiBaseUrl}/matchs`, payload);
+  }
+
+  getCreneaux(terrainId: number, date: string): Observable<MatchSlotsResponse> {
+    const params = new HttpParams()
+      .set('terrainId', terrainId)
+      .set('date', date);
+
+    return this.http.get<MatchSlotsResponse>(`${environment.apiBaseUrl}/matchs/creneaux`, { params });
   }
 }

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.html
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.html
@@ -106,10 +106,16 @@
             <span>Heure</span>
             <select formControlName="heure">
               <option value="">Sélectionner une heure</option>
-              @for (slot of timeSlots; track slot) {
+              @if (isLoadingSlots()) {
+                <option value="" disabled>Chargement des creneaux...</option>
+              }
+              @for (slot of availableSlots(); track slot) {
                 <option [value]="slot">{{ slot }}</option>
               }
             </select>
+            @if (slotsMessage()) {
+              <small class="field-error">{{ slotsMessage() }}</small>
+            }
             @if (getFieldError('heure')) {
               <small class="field-error">{{ getFieldError('heure') }}</small>
             }

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.ts
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.ts
@@ -5,7 +5,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { finalize } from 'rxjs';
-import { CreatedMatch, CreateMatchPayload, MatchVisibility } from '../../../core/matches/create-match.models';
+import {
+  CreatedMatch,
+  CreateMatchPayload,
+  MatchSlotsResponse,
+  MatchVisibility
+} from '../../../core/matches/create-match.models';
 import { MatchCreationService } from '../../../core/matches/match-creation.service';
 import { SiteOption } from '../../../core/sites/site.models';
 import { SitesService } from '../../../core/sites/sites.service';
@@ -40,19 +45,21 @@ export class CreateMatchPageComponent implements OnInit {
   protected readonly terrains = signal<TerrainOption[]>([]);
   protected readonly isLoadingSites = signal(true);
   protected readonly isLoadingTerrains = signal(false);
+  protected readonly isLoadingSlots = signal(false);
   protected readonly isSubmitting = signal(false);
   protected readonly globalErrorMessage = signal('');
+  protected readonly slotsMessage = signal('');
   protected readonly successMessage = signal('');
   protected readonly createdMatch = signal<CreatedMatch | null>(null);
   protected readonly backendFieldErrors = signal<Record<string, string>>({});
   protected readonly friendlyErrorDetails = signal<FriendlyErrorDetail[]>([]);
-  protected readonly timeSlots = this.buildTimeSlots();
+  protected readonly availableSlots = signal<string[]>([]);
 
   protected readonly form = this.fb.nonNullable.group({
     siteId: [null as number | null, Validators.required],
     terrainId: [{ value: null as number | null, disabled: true }, Validators.required],
     date: ['', Validators.required],
-    heure: ['', Validators.required],
+    heure: [{ value: '', disabled: true }, Validators.required],
     visibilite: ['PUBLIC' as MatchVisibility, Validators.required]
   });
 
@@ -63,6 +70,7 @@ export class CreateMatchPageComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((siteId) => {
         this.form.controls.terrainId.reset(null);
+        this.resetSlots();
         this.backendFieldErrors.set({});
         this.friendlyErrorDetails.set([]);
 
@@ -75,13 +83,29 @@ export class CreateMatchPageComponent implements OnInit {
         this.form.controls.terrainId.disable();
         this.loadTerrains(siteId);
       });
+
+    this.form.controls.terrainId.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.resetSelectedHour();
+        this.refreshSlots();
+      });
+
+    this.form.controls.date.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.resetSelectedHour();
+        this.refreshSlots();
+      });
   }
 
   protected canSubmit(): boolean {
     return (
       this.form.valid &&
+      this.form.controls.heure.enabled &&
       !this.isLoadingSites() &&
       !this.isLoadingTerrains() &&
+      !this.isLoadingSlots() &&
       !this.isSubmitting()
     );
   }
@@ -94,7 +118,7 @@ export class CreateMatchPageComponent implements OnInit {
     this.backendFieldErrors.set({});
     this.friendlyErrorDetails.set([]);
 
-    if (this.isLoadingSites() || this.isLoadingTerrains() || this.isSubmitting()) {
+    if (this.isLoadingSites() || this.isLoadingTerrains() || this.isLoadingSlots() || this.isSubmitting()) {
       return;
     }
 
@@ -118,7 +142,7 @@ export class CreateMatchPageComponent implements OnInit {
           this.createdMatch.set(createdMatch);
           this.successMessage.set('Match créé avec succès.');
           this.form.controls.date.reset('');
-          this.form.controls.heure.reset('');
+          this.resetSlots();
           this.form.controls.visibilite.setValue('PUBLIC');
           this.form.controls.terrainId.reset(null);
         },
@@ -164,6 +188,10 @@ export class CreateMatchPageComponent implements OnInit {
       hints.push('Chargement des terrains en cours.');
     }
 
+    if (this.isLoadingSlots()) {
+      hints.push('Chargement des creneaux en cours.');
+    }
+
     if (this.isSubmitting()) {
       hints.push('Création en cours...');
     }
@@ -184,6 +212,17 @@ export class CreateMatchPageComponent implements OnInit {
 
     if (this.form.controls.date.hasError('required')) {
       hints.push('Sélectionnez une date.');
+    }
+
+    if (
+      this.form.controls.terrainId.value != null &&
+      this.form.controls.date.value &&
+      this.form.controls.heure.disabled &&
+      !this.isLoadingSlots()
+    ) {
+      hints.push('Aucun creneau disponible.');
+    } else if (this.form.controls.heure.disabled) {
+      hints.push('Selectionnez un terrain et une date pour charger les creneaux.');
     }
 
     if (this.form.controls.heure.hasError('required')) {
@@ -235,6 +274,7 @@ export class CreateMatchPageComponent implements OnInit {
             this.form.controls.terrainId.enable();
           } else {
             this.form.controls.terrainId.disable();
+            this.resetSlots();
           }
         },
         error: (error: HttpErrorResponse) => {
@@ -243,6 +283,7 @@ export class CreateMatchPageComponent implements OnInit {
           );
           this.terrains.set([]);
           this.form.controls.terrainId.disable();
+          this.resetSlots();
         }
       });
   }
@@ -259,6 +300,74 @@ export class CreateMatchPageComponent implements OnInit {
       dateDebut: `${date}T${heure}:00`,
       visibilite
     };
+  }
+
+  private refreshSlots(): void {
+    const { terrainId, date } = this.form.getRawValue();
+
+    if (terrainId == null || !date) {
+      this.resetSlots();
+      return;
+    }
+
+    this.availableSlots.set([]);
+    this.slotsMessage.set('');
+    this.form.controls.heure.disable();
+    this.isLoadingSlots.set(true);
+
+    const requestTerrainId = terrainId;
+    const requestDate = date;
+
+    this.matchCreationService
+      .getCreneaux(requestTerrainId, requestDate)
+      .pipe(finalize(() => this.isLoadingSlots.set(false)))
+      .subscribe({
+        next: (response) => {
+          const current = this.form.getRawValue();
+          if (current.terrainId !== requestTerrainId || current.date !== requestDate) {
+            return;
+          }
+
+          this.applySlotsResponse(response);
+        },
+        error: (error: HttpErrorResponse) => {
+          const current = this.form.getRawValue();
+          if (current.terrainId !== requestTerrainId || current.date !== requestDate) {
+            return;
+          }
+
+          this.availableSlots.set([]);
+          this.form.controls.heure.disable();
+          this.slotsMessage.set(
+            error.status === 0 ? 'Backend inaccessible.' : 'Impossible de charger les creneaux.'
+          );
+        }
+      });
+  }
+
+  private applySlotsResponse(response: MatchSlotsResponse): void {
+    const slots = response.creneaux ?? [];
+
+    this.availableSlots.set(slots);
+    this.slotsMessage.set(response.message ?? '');
+
+    if (slots.length > 0) {
+      this.form.controls.heure.enable();
+    } else {
+      this.form.controls.heure.disable();
+    }
+  }
+
+  private resetSelectedHour(): void {
+    this.form.controls.heure.reset('');
+  }
+
+  private resetSlots(): void {
+    this.availableSlots.set([]);
+    this.slotsMessage.set('');
+    this.isLoadingSlots.set(false);
+    this.form.controls.heure.reset('');
+    this.form.controls.heure.disable();
   }
 
   private handleSubmitError(error: HttpErrorResponse): void {
@@ -366,21 +475,4 @@ export class CreateMatchPageComponent implements OnInit {
     return friendlyDetails;
   }
 
-  private buildTimeSlots(): string[] {
-    const slots: string[] = [];
-    const openingHour = 8;
-    const closingHour = 22;
-
-    for (let hour = openingHour; hour < closingHour; hour += 1) {
-      for (let minute = 0; minute < 60; minute += 15) {
-        const hh = hour.toString().padStart(2, '0');
-        const mm = minute.toString().padStart(2, '0');
-        slots.push(`${hh}:${mm}`);
-      }
-    }
-
-    slots.push(`${closingHour.toString().padStart(2, '0')}:00`);
-
-    return slots;
-  }
 }

--- a/frontend/src/app/features/matches/public-matches/public-matches-page.component.ts
+++ b/frontend/src/app/features/matches/public-matches/public-matches-page.component.ts
@@ -35,9 +35,9 @@ export class PublicMatchesPageComponent implements OnInit {
   protected readonly errorMessage = signal('');
   protected readonly displayFilterOptions = DISPLAY_FILTER_OPTIONS;
   protected readonly filters = signal({
-    from: '2026-01-01',
-    to: '2026-04-30',
-    siteId: '1'
+    from: '',
+    to: '',
+    siteId: ''
   });
   protected readonly selectedDisplayFilter = signal<PublicMatchDisplayFilter>('TOUS');
   protected readonly filteredMatches = computed(() => {


### PR DESCRIPTION
- Suppression des filtres arbitraires dans la vue des matchs publics.

- Suppression des heures hardcodées côté Angular dans la création de match.

- Ajout de l’endpoint authentifié GET /api/v1/matchs/creneaux.

- Génération backend des créneaux à partir des horaires réels du site, de l’année, du terrain et du joueur connecté.

- Prise en compte de la durée du match de 90 minutes et du buffer de 15 minutes.

- Exclusion des créneaux dépassant l’heure de fermeture du site.

- Prise en compte des fermetures globales, fermetures de site, jours de fermeture récurrents, occupation terrain, dette, pénalité et règles GLOBAL/SITE/LIBRE.

- Le frontend affiche uniquement les créneaux retournés par l’API.

- Le POST /api/v1/matchs reste la validation finale stricte.

- Ajout de tests backend pour le cas joueur SITE hors de son site via GET /creneaux.

- Tests backend ciblés validés : 70 tests OK.

