### PR TITLE
issue 179 : Ajouter la consultation des sites et horaires

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/config/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
                             .requestMatchers(HttpMethod.GET, "/api/v1/sites/**").permitAll()
                             .requestMatchers("/api/v1/admin/inscriptions/**").hasRole("ADMIN_GLOBAL")
                             .requestMatchers("/api/v1/admin/stats/**").hasRole("ADMIN_GLOBAL")
-                            .requestMatchers("/api/v1/admin/sites/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")
+                            .requestMatchers("/api/v1/admin/sites", "/api/v1/admin/sites/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")
                             .requestMatchers("/api/v1/admin/**").hasAnyRole("ADMIN_GLOBAL", "ADMIN_SITE")
                             .requestMatchers(HttpMethod.GET, "/api/v1/joueurs").hasRole("ADMIN_GLOBAL")
                             .requestMatchers(HttpMethod.POST, "/api/v1/joueurs").hasRole("ADMIN_GLOBAL")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminSiteController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminSiteController.java
@@ -3,6 +3,7 @@ package be.ephec.padel.backend.controller;
 import be.ephec.padel.backend.dto.response.AdminCaStatsDto;
 import be.ephec.padel.backend.dto.response.AdminDettesStatsDto;
 import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
+import be.ephec.padel.backend.dto.response.AdminSiteConsultationDto;
 import be.ephec.padel.backend.dto.response.JoueurAdminDto;
 import be.ephec.padel.backend.service.AdminSiteService;
 import be.ephec.padel.backend.service.AdminSiteStatsService;
@@ -27,6 +28,11 @@ public class AdminSiteController {
                                AdminSiteStatsService adminSiteStatsService) {
         this.adminSiteService = adminSiteService;
         this.adminSiteStatsService = adminSiteStatsService;
+    }
+
+    @GetMapping
+    public List<AdminSiteConsultationDto> getSites() {
+        return adminSiteService.getSitesConsultables();
     }
 
     @GetMapping("/{siteId}/joueurs")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminSiteConsultationDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminSiteConsultationDto.java
@@ -1,0 +1,53 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Set;
+
+public class AdminSiteConsultationDto {
+
+    private Long id;
+    private String nom;
+    private String ville;
+    private Set<DayOfWeek> joursFermeture;
+    private List<TerrainDto> terrains;
+    private List<HoraireSiteDto> horaires;
+
+    public AdminSiteConsultationDto(Long id,
+                                    String nom,
+                                    String ville,
+                                    Set<DayOfWeek> joursFermeture,
+                                    List<TerrainDto> terrains,
+                                    List<HoraireSiteDto> horaires) {
+        this.id = id;
+        this.nom = nom;
+        this.ville = ville;
+        this.joursFermeture = joursFermeture;
+        this.terrains = terrains;
+        this.horaires = horaires;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNom() {
+        return nom;
+    }
+
+    public String getVille() {
+        return ville;
+    }
+
+    public Set<DayOfWeek> getJoursFermeture() {
+        return joursFermeture;
+    }
+
+    public List<TerrainDto> getTerrains() {
+        return terrains;
+    }
+
+    public List<HoraireSiteDto> getHoraires() {
+        return horaires;
+    }
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/CreneauxMatchResponseDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/CreneauxMatchResponseDto.java
@@ -1,15 +1,36 @@
 package be.ephec.padel.backend.dto.response;
 
+import java.time.LocalTime;
 import java.util.List;
 
 public class CreneauxMatchResponseDto {
 
     private List<String> creneaux;
     private String message;
+    private Integer annee;
+    private LocalTime heureOuverture;
+    private LocalTime heureFermeture;
+    private Long dureeMatchMinutes;
+    private Long bufferMinutes;
 
     public CreneauxMatchResponseDto(List<String> creneaux, String message) {
+        this(creneaux, message, null, null, null, null, null);
+    }
+
+    public CreneauxMatchResponseDto(List<String> creneaux,
+                                    String message,
+                                    Integer annee,
+                                    LocalTime heureOuverture,
+                                    LocalTime heureFermeture,
+                                    Long dureeMatchMinutes,
+                                    Long bufferMinutes) {
         this.creneaux = creneaux;
         this.message = message;
+        this.annee = annee;
+        this.heureOuverture = heureOuverture;
+        this.heureFermeture = heureFermeture;
+        this.dureeMatchMinutes = dureeMatchMinutes;
+        this.bufferMinutes = bufferMinutes;
     }
 
     public List<String> getCreneaux() {
@@ -18,5 +39,25 @@ public class CreneauxMatchResponseDto {
 
     public String getMessage() {
         return message;
+    }
+
+    public Integer getAnnee() {
+        return annee;
+    }
+
+    public LocalTime getHeureOuverture() {
+        return heureOuverture;
+    }
+
+    public LocalTime getHeureFermeture() {
+        return heureFermeture;
+    }
+
+    public Long getDureeMatchMinutes() {
+        return dureeMatchMinutes;
+    }
+
+    public Long getBufferMinutes() {
+        return bufferMinutes;
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminSiteService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminSiteService.java
@@ -1,10 +1,18 @@
 package be.ephec.padel.backend.service;
 
+import be.ephec.padel.backend.dto.response.AdminSiteConsultationDto;
+import be.ephec.padel.backend.dto.response.HoraireSiteDto;
 import be.ephec.padel.backend.dto.response.JoueurAdminDto;
+import be.ephec.padel.backend.dto.response.TerrainDto;
 import be.ephec.padel.backend.exception.NotFoundException;
+import be.ephec.padel.backend.model.entities.HoraireSite;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.repository.HoraireSiteRepository;
 import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
 import be.ephec.padel.backend.security.ServiceAutorisationAdmin;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,16 +25,35 @@ public class AdminSiteService {
 
     private final SiteRepository siteRepository;
     private final JoueurRepository joueurRepository;
+    private final TerrainRepository terrainRepository;
+    private final HoraireSiteRepository horaireSiteRepository;
     private final ServiceAutorisationAdmin serviceAutorisationAdmin;
 
     public AdminSiteService(
             SiteRepository siteRepository,
             JoueurRepository joueurRepository,
+            TerrainRepository terrainRepository,
+            HoraireSiteRepository horaireSiteRepository,
             ServiceAutorisationAdmin serviceAutorisationAdmin
     ) {
         this.siteRepository = siteRepository;
         this.joueurRepository = joueurRepository;
+        this.terrainRepository = terrainRepository;
+        this.horaireSiteRepository = horaireSiteRepository;
         this.serviceAutorisationAdmin = serviceAutorisationAdmin;
+    }
+
+    public List<AdminSiteConsultationDto> getSitesConsultables() {
+        Long siteAdministreId = serviceAutorisationAdmin.getSiteAdministreId();
+
+        List<Site> sites = siteAdministreId == null
+                ? siteRepository.findAll()
+                : List.of(siteRepository.findById(siteAdministreId)
+                        .orElseThrow(() -> new NotFoundException("Site admin introuvable: " + siteAdministreId)));
+
+        return sites.stream()
+                .map(this::toAdminSiteConsultationDto)
+                .toList();
     }
 
     public List<JoueurAdminDto> getJoueursBySite(Long siteId) {
@@ -50,6 +77,43 @@ public class AdminSiteService {
                 joueur.getType(),
                 joueur.getSolde(),
                 joueur.getPenaliteJusqua()
+        );
+    }
+
+    private AdminSiteConsultationDto toAdminSiteConsultationDto(Site site) {
+        Long siteId = site.getId();
+        List<TerrainDto> terrains = terrainRepository.findBySite_Id(siteId).stream()
+                .map(this::toTerrainDto)
+                .toList();
+        List<HoraireSiteDto> horaires = horaireSiteRepository.findBySiteIdOrderByAnneeAsc(siteId).stream()
+                .map(this::toHoraireSiteDto)
+                .toList();
+
+        return new AdminSiteConsultationDto(
+                site.getId(),
+                site.getNom(),
+                site.getVille(),
+                site.getJoursFermeture(),
+                terrains,
+                horaires
+        );
+    }
+
+    private TerrainDto toTerrainDto(Terrain terrain) {
+        return new TerrainDto(
+                terrain.getId(),
+                terrain.getNom(),
+                terrain.getSite().getId()
+        );
+    }
+
+    private HoraireSiteDto toHoraireSiteDto(HoraireSite horaire) {
+        return new HoraireSiteDto(
+                horaire.getId(),
+                horaire.getSite().getId(),
+                horaire.getAnnee(),
+                horaire.getHeureOuverture(),
+                horaire.getHeureFermeture()
         );
     }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MatchPadelService.java
@@ -56,13 +56,31 @@ public class MatchPadelService {
     private static final long PAS_CRENEAU_MIN = 15;
     private static final DateTimeFormatter CRENEAU_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     private static final String MESSAGE_HORAIRE_MANQUANT =
-            "Aucun horaire n'est configure pour ce site et cette annee.";
+            "Aucun horaire n'est configuré pour ce site et cette année.";
     private static final String MESSAGE_SITE_FERME =
-            "Aucun creneau disponible : le site est ferme a cette date.";
+            "Le site est fermé à cette date. Aucun créneau n'est disponible.";
     private static final String MESSAGE_AUCUN_CRENEAU =
-            "Aucun creneau disponible pour ce terrain et cette date.";
-    private static final String MESSAGE_RESERVATION_NON_AUTORISEE =
-            "Aucun creneau disponible : votre situation ne permet pas de reserver.";
+            "Aucun créneau disponible pour ce terrain et cette date.";
+    private static final String MESSAGE_DETTE =
+            "Vous ne pouvez pas réserver tant qu'un solde est dû.";
+    private static final String MESSAGE_PENALITE =
+            "Vous ne pouvez pas réserver pendant votre période de pénalité.";
+    private static final String MESSAGE_GLOBAL_TROP_LOIN =
+            "Vous pouvez réserver au maximum 3 semaines à l'avance.";
+    private static final String MESSAGE_SITE_TROP_LOIN =
+            "Vous pouvez réserver au maximum 2 semaines à l'avance.";
+    private static final String MESSAGE_LIBRE_TROP_LOIN =
+            "Vous pouvez réserver au maximum 5 jours à l'avance.";
+    private static final String MESSAGE_SITE_HORS_PERIMETRE =
+            "Votre abonnement SITE permet de réserver uniquement sur votre site.";
+    private static final String MESSAGE_TERRAIN_OCCUPE =
+            "Tous les créneaux de cette date sont déjà occupés pour ce terrain.";
+    private static final String MESSAGE_PLUS_DE_CRENEAU_AUJOURDHUI =
+            "Il n'y a plus de créneau disponible aujourd'hui pour ce terrain.";
+    private static final String MESSAGE_DATE_PASSEE =
+            "La date choisie est passée.";
+    private static final String MESSAGE_HORAIRE_TROP_COURT =
+            "L'horaire du site ne permet pas de placer un match complet à cette date.";
 
     private final MatchPadelRepository matchPadelRepository;
     private final TerrainRepository terrainRepository;
@@ -123,22 +141,22 @@ public class MatchPadelService {
 
     private void verifierFermetureGlobale(LocalDateTime dateDebut) {
         if (dateDebut == null) {
-            throw new BusinessException("Date de debut obligatoire");
+            throw new BusinessException("Date de début obligatoire");
         }
         if (fermetureGlobaleRepository.existsByDate(dateDebut.toLocalDate())) {
-            throw new BusinessException("Reservation impossible : fermeture globale (jour ferie).");
+            throw new BusinessException("Réservation impossible : fermeture globale (jour férié).");
         }
     }
 
     private void verifierOuvertureSite(Terrain terrain, LocalDateTime dateDebut) {
         if (terrain == null || terrain.getSite() == null) {
-            throw new BusinessException("Terrain sans site associe.");
+            throw new BusinessException("Terrain sans site associé.");
         }
 
         Site site = terrain.getSite();
         DayOfWeek jour = dateDebut.getDayOfWeek();
         if (estJourFermetureSite(site, jour)) {
-            throw new BusinessException("Reservation impossible : site ferme ce jour-la.");
+            throw new BusinessException("Réservation impossible : site fermé ce jour-là.");
         }
 
         HoraireSite horaire = horaireSiteService.getApplicable(site.getId(), dateDebut);
@@ -149,11 +167,11 @@ public class MatchPadelService {
         LocalTime end = dateDebut.plusMinutes(SLOT_MIN).toLocalTime();
 
         if (end.isBefore(start)) {
-            throw new BusinessException("Reservation impossible : le creneau depasse minuit.");
+            throw new BusinessException("Réservation impossible : le créneau dépasse minuit.");
         }
 
         if (start.isBefore(ouverture) || end.isAfter(fermeture)) {
-            throw new BusinessException("Reservation impossible : en dehors des horaires d'ouverture.");
+            throw new BusinessException("Réservation impossible : en dehors des horaires d'ouverture.");
         }
     }
 
@@ -169,27 +187,27 @@ public class MatchPadelService {
             throw new BusinessException("Terrain obligatoire");
         }
         if (dateDebut == null) {
-            throw new BusinessException("Date debut obligatoire");
+            throw new BusinessException("Date début obligatoire");
         }
         if (visibilite == null) {
-            throw new BusinessException("Visibilite obligatoire");
+            throw new BusinessException("Visibilité obligatoire");
         }
 
         LocalDateTime now = LocalDateTime.now(clock);
         if (!dateDebut.isAfter(now)) {
-            throw new BusinessException("La date du match doit etre dans le futur.");
+            throw new BusinessException("La date du match doit être dans le futur.");
         }
 
         Terrain terrain = terrainRepository.findById(terrainId)
                 .orElseThrow(() -> new NotFoundException("Terrain introuvable"));
 
         if (aDette(organisateur)) {
-            throw new BusinessException("Reservation impossible : dette en cours (" + organisateur.getSolde() + ").");
+            throw new BusinessException("Réservation impossible : dette en cours (" + organisateur.getSolde() + ").");
         }
 
         if (aPenaliteActive(organisateur, now)) {
             throw new BusinessException(
-                    "Reservation impossible : penalite active jusqu'au "
+                    "Réservation impossible : pénalité active jusqu'au "
                             + organisateur.getPenaliteJusqua().toLocalDate()
                             + " inclus."
             );
@@ -240,12 +258,15 @@ public class MatchPadelService {
                 .orElseThrow(() -> new NotFoundException("Terrain introuvable"));
 
         if (terrain.getSite() == null || terrain.getSite().getId() == null) {
-            throw new BusinessException("Terrain sans site associe.");
+            throw new BusinessException("Terrain sans site associé.");
         }
 
         LocalDateTime now = LocalDateTime.now(clock);
-        if (aDette(joueur) || aPenaliteActive(joueur, now)) {
-            return new CreneauxMatchResponseDto(List.of(), MESSAGE_RESERVATION_NON_AUTORISEE);
+        if (aDette(joueur)) {
+            return creerReponseCreneaux(List.of(), MESSAGE_DETTE, date, null);
+        }
+        if (aPenaliteActive(joueur, now)) {
+            return creerReponseCreneaux(List.of(), MESSAGE_PENALITE, date, null);
         }
 
         Site site = terrain.getSite();
@@ -255,13 +276,13 @@ public class MatchPadelService {
         try {
             horaire = horaireSiteService.getApplicable(siteId, date.atStartOfDay());
         } catch (BusinessException exception) {
-            return new CreneauxMatchResponseDto(List.of(), MESSAGE_HORAIRE_MANQUANT);
+            return creerReponseCreneaux(List.of(), MESSAGE_HORAIRE_MANQUANT, date, null);
         }
 
         if (estJourFermetureSite(site, date.getDayOfWeek())
                 || fermetureGlobaleRepository.existsByDate(date)
                 || fermetureSiteService.isDateFermeePourSite(siteId, date)) {
-            return new CreneauxMatchResponseDto(List.of(), MESSAGE_SITE_FERME);
+            return creerReponseCreneaux(List.of(), MESSAGE_SITE_FERME, date, null);
         }
 
         LocalTime ouverture = horaire.getHeureOuverture();
@@ -269,7 +290,7 @@ public class MatchPadelService {
         LocalTime dernierDebut = fermeture.minusMinutes(SLOT_MIN);
 
         if (dernierDebut.isBefore(ouverture)) {
-            return new CreneauxMatchResponseDto(List.of(), MESSAGE_AUCUN_CRENEAU);
+            return creerReponseCreneaux(List.of(), MESSAGE_HORAIRE_TROP_COURT, date, horaire);
         }
 
         LocalDateTime debutRecherche = date.atStartOfDay().minusMinutes(SLOT_MIN);
@@ -281,31 +302,95 @@ public class MatchPadelService {
         );
 
         List<String> creneaux = new ArrayList<>();
+        int nbCreneauxCandidats = 0;
+        int nbCreneauxFuturs = 0;
+        int nbCreneauxAutorises = 0;
+        int nbCreneauxOccupes = 0;
+        String premierMessageDroit = null;
 
         for (LocalTime heure = ouverture;
              !heure.isAfter(dernierDebut);
              heure = heure.plusMinutes(PAS_CRENEAU_MIN)) {
 
+            nbCreneauxCandidats++;
             LocalDateTime dateDebut = date.atTime(heure);
 
             if (!dateDebut.isAfter(now)) {
                 continue;
             }
 
-            if (!peutReserverSurCreneau(joueur, terrain, dateDebut, now)) {
+            nbCreneauxFuturs++;
+
+            String messageDroit = getMessageIndisponibiliteReservation(joueur, terrain, dateDebut, now);
+            if (messageDroit != null) {
+                if (premierMessageDroit == null) {
+                    premierMessageDroit = messageDroit;
+                }
                 continue;
             }
 
+            nbCreneauxAutorises++;
+
             if (!estTerrainDisponible(matchsProches, dateDebut)) {
+                nbCreneauxOccupes++;
                 continue;
             }
 
             creneaux.add(heure.format(CRENEAU_FORMATTER));
         }
 
+        return creerReponseCreneaux(
+                creneaux,
+                creneaux.isEmpty()
+                        ? determinerMessageAucunCreneau(
+                                date,
+                                nbCreneauxCandidats,
+                                nbCreneauxFuturs,
+                                nbCreneauxAutorises,
+                                nbCreneauxOccupes,
+                                premierMessageDroit
+                        )
+                        : null,
+                date,
+                horaire
+        );
+    }
+
+    private String determinerMessageAucunCreneau(LocalDate date,
+                                                 int nbCreneauxCandidats,
+                                                 int nbCreneauxFuturs,
+                                                 int nbCreneauxAutorises,
+                                                 int nbCreneauxOccupes,
+                                                 String messageDroit) {
+        LocalDate today = LocalDate.now(clock);
+
+        if (nbCreneauxCandidats > 0 && nbCreneauxFuturs == 0) {
+            return date.isBefore(today) ? MESSAGE_DATE_PASSEE : MESSAGE_PLUS_DE_CRENEAU_AUJOURDHUI;
+        }
+
+        if (nbCreneauxFuturs > 0 && messageDroit != null && nbCreneauxAutorises == 0) {
+            return messageDroit;
+        }
+
+        if (nbCreneauxAutorises > 0 && nbCreneauxOccupes == nbCreneauxAutorises) {
+            return MESSAGE_TERRAIN_OCCUPE;
+        }
+
+        return MESSAGE_AUCUN_CRENEAU;
+    }
+
+    private CreneauxMatchResponseDto creerReponseCreneaux(List<String> creneaux,
+                                                          String message,
+                                                          LocalDate date,
+                                                          HoraireSite horaire) {
         return new CreneauxMatchResponseDto(
                 creneaux,
-                creneaux.isEmpty() ? MESSAGE_AUCUN_CRENEAU : null
+                message,
+                date == null ? null : date.getYear(),
+                horaire == null ? null : horaire.getHeureOuverture(),
+                horaire == null ? null : horaire.getHeureFermeture(),
+                DUREE_MATCH_MIN,
+                BUFFER_MIN
         );
     }
 
@@ -317,16 +402,37 @@ public class MatchPadelService {
         return joueur.getPenaliteJusqua() != null && joueur.getPenaliteJusqua().isAfter(now);
     }
 
-    private boolean peutReserverSurCreneau(Joueur joueur,
-                                           Terrain terrain,
-                                           LocalDateTime dateDebut,
-                                           LocalDateTime now) {
+    private String getMessageIndisponibiliteReservation(Joueur joueur,
+                                                        Terrain terrain,
+                                                        LocalDateTime dateDebut,
+                                                        LocalDateTime now) {
         try {
             verifierDroitReservation(joueur, terrain, dateDebut, now);
-            return true;
+            return null;
         } catch (BusinessException exception) {
-            return false;
+            return toMessageCreneauDroitReservation(exception.getMessage());
         }
+    }
+
+    private String toMessageCreneauDroitReservation(String message) {
+        if (message == null) {
+            return MESSAGE_AUCUN_CRENEAU;
+        }
+
+        if (message.contains("3 semaines")) {
+            return MESSAGE_GLOBAL_TROP_LOIN;
+        }
+        if (message.contains("2 semaines")) {
+            return MESSAGE_SITE_TROP_LOIN;
+        }
+        if (message.contains("5 jours")) {
+            return MESSAGE_LIBRE_TROP_LOIN;
+        }
+        if (message.contains("ne peut réserver que sur son site")) {
+            return MESSAGE_SITE_HORS_PERIMETRE;
+        }
+
+        return MESSAGE_AUCUN_CRENEAU;
     }
 
     private void verifierTerrainDisponible(Long terrainId, LocalDateTime newStart) {
@@ -334,7 +440,7 @@ public class MatchPadelService {
             throw new BusinessException("Terrain obligatoire");
         }
         if (newStart == null) {
-            throw new BusinessException("Date de debut obligatoire");
+            throw new BusinessException("Date de début obligatoire");
         }
 
         LocalDateTime from = newStart.minusMinutes(SLOT_MIN);
@@ -345,7 +451,7 @@ public class MatchPadelService {
 
         if (!estTerrainDisponible(candidats, newStart)) {
             throw new BusinessException(
-                    "Terrain indisponible : un match est deja prevu sur ce terrain (1h30 + 15 minutes de battement)."
+                    "Terrain indisponible : un match est déjà prévu sur ce terrain (1h30 + 15 minutes de battement)."
             );
         }
     }
@@ -387,29 +493,29 @@ public class MatchPadelService {
         switch (type) {
             case GLOBAL -> {
                 if (dateDebut.isAfter(now.plusWeeks(3))) {
-                    throw new BusinessException("Un membre GLOBAL peut reserver au maximum 3 semaines a l'avance.");
+                    throw new BusinessException("Un membre GLOBAL peut réserver au maximum 3 semaines à l'avance.");
                 }
             }
             case SITE -> {
                 if (dateDebut.isAfter(now.plusWeeks(2))) {
-                    throw new BusinessException("Un membre SITE peut reserver au maximum 2 semaines a l'avance.");
+                    throw new BusinessException("Un membre SITE peut réserver au maximum 2 semaines à l'avance.");
                 }
                 if (organisateur.getSite() == null) {
-                    throw new BusinessException("Joueur SITE sans site associe.");
+                    throw new BusinessException("Joueur SITE sans site associé.");
                 }
                 if (terrain.getSite() == null) {
-                    throw new BusinessException("Terrain sans site associe.");
+                    throw new BusinessException("Terrain sans site associé.");
                 }
 
                 Long siteJoueur = organisateur.getSite().getId();
                 Long siteTerrain = terrain.getSite().getId();
                 if (!siteJoueur.equals(siteTerrain)) {
-                    throw new BusinessException("Un membre SITE ne peut reserver que sur son site.");
+                    throw new BusinessException("Un membre SITE ne peut réserver que sur son site.");
                 }
             }
             case LIBRE -> {
                 if (dateDebut.isAfter(now.plusDays(5))) {
-                    throw new BusinessException("Un membre LIBRE peut reserver au maximum 5 jours a l'avance.");
+                    throw new BusinessException("Un membre LIBRE peut réserver au maximum 5 jours à l'avance.");
                 }
             }
             default -> throw new BusinessException("Type joueur inconnu.");
@@ -418,17 +524,17 @@ public class MatchPadelService {
 
     private void verifierFermetureSite(Terrain terrain, LocalDateTime dateDebut) {
         if (terrain == null || terrain.getSite() == null || terrain.getSite().getId() == null) {
-            throw new BusinessException("Terrain sans site associe.");
+            throw new BusinessException("Terrain sans site associé.");
         }
         if (dateDebut == null) {
-            throw new BusinessException("Date de debut obligatoire");
+            throw new BusinessException("Date de début obligatoire");
         }
 
         Long siteId = terrain.getSite().getId();
         LocalDate date = dateDebut.toLocalDate();
 
         if (fermetureSiteService.isDateFermeePourSite(siteId, date)) {
-            throw new BusinessException("RÃ©servation impossible : site fermÃ© Ã  cette date.");
+            throw new BusinessException("Réservation impossible : site fermé à cette date.");
         }
     }
 
@@ -437,7 +543,7 @@ public class MatchPadelService {
                                                                LocalDate to,
                                                                Long siteId) {
         if (from != null && to != null && from.isAfter(to)) {
-            throw new BusinessException("Le parametre 'from' doit etre anterieur ou egal a 'to'.");
+            throw new BusinessException("Le paramètre 'from' doit être antérieur ou égal à 'to'.");
         }
 
         LocalDateTime fromDateTime = (from != null)

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminSiteServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminSiteServiceTest.java
@@ -1,0 +1,115 @@
+package be.ephec.padel.backend.unit.service;
+
+import be.ephec.padel.backend.dto.response.AdminSiteConsultationDto;
+import be.ephec.padel.backend.model.entities.HoraireSite;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.repository.HoraireSiteRepository;
+import be.ephec.padel.backend.repository.JoueurRepository;
+import be.ephec.padel.backend.repository.SiteRepository;
+import be.ephec.padel.backend.repository.TerrainRepository;
+import be.ephec.padel.backend.security.ServiceAutorisationAdmin;
+import be.ephec.padel.backend.service.AdminSiteService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AdminSiteServiceTest {
+
+    private SiteRepository siteRepository;
+    private JoueurRepository joueurRepository;
+    private TerrainRepository terrainRepository;
+    private HoraireSiteRepository horaireSiteRepository;
+    private ServiceAutorisationAdmin serviceAutorisationAdmin;
+    private AdminSiteService service;
+
+    @BeforeEach
+    void setup() {
+        siteRepository = mock(SiteRepository.class);
+        joueurRepository = mock(JoueurRepository.class);
+        terrainRepository = mock(TerrainRepository.class);
+        horaireSiteRepository = mock(HoraireSiteRepository.class);
+        serviceAutorisationAdmin = mock(ServiceAutorisationAdmin.class);
+
+        service = new AdminSiteService(
+                siteRepository,
+                joueurRepository,
+                terrainRepository,
+                horaireSiteRepository,
+                serviceAutorisationAdmin
+        );
+    }
+
+    @Test
+    void getSitesConsultables_adminGlobal_retourne_tous_les_sites_avec_terrains_et_horaires() {
+        Site site1 = site(1L, "Site 1", "Bruxelles", Set.of(DayOfWeek.MONDAY));
+        Site site2 = site(2L, "Site 2", "Liege", Set.of());
+
+        when(serviceAutorisationAdmin.getSiteAdministreId()).thenReturn(null);
+        when(siteRepository.findAll()).thenReturn(List.of(site1, site2));
+        when(terrainRepository.findBySite_Id(1L)).thenReturn(List.of(terrain(10L, "Terrain A", site1)));
+        when(terrainRepository.findBySite_Id(2L)).thenReturn(List.of(terrain(20L, "Terrain B", site2)));
+        when(horaireSiteRepository.findBySiteIdOrderByAnneeAsc(1L))
+                .thenReturn(List.of(horaire(100L, site1, 2026, 8, 22)));
+        when(horaireSiteRepository.findBySiteIdOrderByAnneeAsc(2L))
+                .thenReturn(List.of(horaire(200L, site2, 2027, 9, 21)));
+
+        List<AdminSiteConsultationDto> result = service.getSitesConsultables();
+
+        assertEquals(2, result.size());
+        assertEquals("Site 1", result.get(0).getNom());
+        assertTrue(result.get(0).getJoursFermeture().contains(DayOfWeek.MONDAY));
+        assertEquals("Terrain A", result.get(0).getTerrains().get(0).getNom());
+        assertEquals(2026, result.get(0).getHoraires().get(0).getAnnee());
+        assertEquals("Site 2", result.get(1).getNom());
+    }
+
+    @Test
+    void getSitesConsultables_adminSite_retourne_uniquement_son_site() {
+        Site site1 = site(1L, "Site 1", "Bruxelles", Set.of(DayOfWeek.SUNDAY));
+
+        when(serviceAutorisationAdmin.getSiteAdministreId()).thenReturn(1L);
+        when(siteRepository.findById(1L)).thenReturn(Optional.of(site1));
+        when(terrainRepository.findBySite_Id(1L)).thenReturn(List.of(terrain(10L, "Terrain A", site1)));
+        when(horaireSiteRepository.findBySiteIdOrderByAnneeAsc(1L))
+                .thenReturn(List.of(horaire(100L, site1, 2026, 8, 22)));
+
+        List<AdminSiteConsultationDto> result = service.getSitesConsultables();
+
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).getId());
+        assertEquals("Site 1", result.get(0).getNom());
+        assertEquals("Terrain A", result.get(0).getTerrains().get(0).getNom());
+        assertEquals(LocalTime.of(8, 0), result.get(0).getHoraires().get(0).getHeureOuverture());
+    }
+
+    private Site site(Long id, String nom, String ville, Set<DayOfWeek> joursFermeture) {
+        Site site = new Site(nom, ville);
+        ReflectionTestUtils.setField(site, "id", id);
+        site.setJoursFermeture(joursFermeture);
+        return site;
+    }
+
+    private Terrain terrain(Long id, String nom, Site site) {
+        Terrain terrain = new Terrain(nom, site);
+        ReflectionTestUtils.setField(terrain, "id", id);
+        return terrain;
+    }
+
+    private HoraireSite horaire(Long id, Site site, Integer annee, int ouverture, int fermeture) {
+        HoraireSite horaire = new HoraireSite(site, annee, LocalTime.of(ouverture, 0), LocalTime.of(fermeture, 0));
+        horaire.setId(id);
+        return horaire;
+    }
+}

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MatchPadelServiceTest.java
@@ -1260,6 +1260,11 @@ class MatchPadelServiceTest {
         assertFalse(response.getCreneaux().contains("20:30"));
         assertFalse(response.getCreneaux().contains("22:00"));
         assertNull(response.getMessage());
+        assertEquals(2026, response.getAnnee());
+        assertEquals(LocalTime.of(8, 0), response.getHeureOuverture());
+        assertEquals(LocalTime.of(22, 0), response.getHeureFermeture());
+        assertEquals(90L, response.getDureeMatchMinutes());
+        assertEquals(15L, response.getBufferMinutes());
     }
 
     @Test
@@ -1285,12 +1290,17 @@ class MatchPadelServiceTest {
         when(site.getId()).thenReturn(1L);
         when(terrainRepo.findById(1L)).thenReturn(Optional.of(terrain));
         when(horaireSiteService.getApplicable(1L, date.atStartOfDay()))
-                .thenThrow(new BusinessException("Aucun horaire configure"));
+                .thenThrow(new BusinessException("Aucun horaire configuré"));
 
         CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
 
         assertTrue(response.getCreneaux().isEmpty());
-        assertEquals("Aucun horaire n'est configure pour ce site et cette annee.", response.getMessage());
+        assertEquals("Aucun horaire n'est configuré pour ce site et cette année.", response.getMessage());
+        assertEquals(2026, response.getAnnee());
+        assertNull(response.getHeureOuverture());
+        assertNull(response.getHeureFermeture());
+        assertEquals(90L, response.getDureeMatchMinutes());
+        assertEquals(15L, response.getBufferMinutes());
         verify(matchRepo, never()).findByTerrainIdAndDateDebutBetween(anyLong(), any(), any());
     }
 
@@ -1303,7 +1313,9 @@ class MatchPadelServiceTest {
         CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
 
         assertTrue(response.getCreneaux().isEmpty());
-        assertEquals("Aucun creneau disponible : le site est ferme a cette date.", response.getMessage());
+        assertEquals("Le site est fermé à cette date. Aucun créneau n'est disponible.", response.getMessage());
+        assertNull(response.getHeureOuverture());
+        assertNull(response.getHeureFermeture());
         verify(matchRepo, never()).findByTerrainIdAndDateDebutBetween(anyLong(), any(), any());
     }
 
@@ -1316,7 +1328,9 @@ class MatchPadelServiceTest {
         CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
 
         assertTrue(response.getCreneaux().isEmpty());
-        assertEquals("Aucun creneau disponible : le site est ferme a cette date.", response.getMessage());
+        assertEquals("Le site est fermé à cette date. Aucun créneau n'est disponible.", response.getMessage());
+        assertNull(response.getHeureOuverture());
+        assertNull(response.getHeureFermeture());
         verify(matchRepo, never()).findByTerrainIdAndDateDebutBetween(anyLong(), any(), any());
     }
 
@@ -1329,7 +1343,9 @@ class MatchPadelServiceTest {
         CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
 
         assertTrue(response.getCreneaux().isEmpty());
-        assertEquals("Aucun creneau disponible : le site est ferme a cette date.", response.getMessage());
+        assertEquals("Le site est fermé à cette date. Aucun créneau n'est disponible.", response.getMessage());
+        assertNull(response.getHeureOuverture());
+        assertNull(response.getHeureFermeture());
         verify(matchRepo, never()).findByTerrainIdAndDateDebutBetween(anyLong(), any(), any());
     }
 
@@ -1352,6 +1368,83 @@ class MatchPadelServiceTest {
     }
 
     @Test
+    void getCreneauxDisponibles_terrain_totalement_occupe_retourne_message_dedie() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        stubTerrainPourCreneaux(1L, 1L, date, LocalTime.of(8, 0), LocalTime.of(9, 45));
+        MatchPadel existing = mock(MatchPadel.class);
+        when(existing.getDateDebut()).thenReturn(date.atTime(8, 0));
+        when(matchRepo.findByTerrainIdAndDateDebutBetween(eq(1L), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(List.of(existing));
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Tous les créneaux de cette date sont déjà occupés pour ce terrain.", response.getMessage());
+    }
+
+    @Test
+    void getCreneauxDisponibles_horaire_trop_court_retourne_message_dedie() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        stubTerrainPourCreneaux(1L, 1L, date, LocalTime.of(8, 0), LocalTime.of(9, 30));
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("L'horaire du site ne permet pas de placer un match complet à cette date.", response.getMessage());
+    }
+
+    @Test
+    void getCreneauxDisponibles_dette_retourne_message_dedie() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        stubTerrainPourCreneaux(1L, 1L, date);
+        stubCurrentJoueur("G0001", TypeJoueur.GLOBAL, BigDecimal.TEN);
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Vous ne pouvez pas réserver tant qu'un solde est dû.", response.getMessage());
+    }
+
+    @Test
+    void getCreneauxDisponibles_penalite_active_retourne_message_dedie() {
+        LocalDate date = LocalDate.of(2026, 3, 25);
+        stubTerrainPourCreneaux(1L, 1L, date);
+        Joueur joueur = stubCurrentJoueur("G0001", TypeJoueur.GLOBAL, BigDecimal.ZERO);
+        when(joueur.getPenaliteJusqua()).thenReturn(LocalDateTime.now(clock).plusDays(2));
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Vous ne pouvez pas réserver pendant votre période de pénalité.", response.getMessage());
+    }
+
+    @Test
+    void getCreneauxDisponibles_global_trop_loin_retourne_message_dedie() {
+        LocalDate date = LocalDate.of(2026, 4, 20);
+        stubTerrainPourCreneaux(1L, 1L, date);
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Vous pouvez réserver au maximum 3 semaines à l'avance.", response.getMessage());
+    }
+
+    @Test
+    void getCreneauxDisponibles_site_trop_loin_retourne_message_dedie() {
+        LocalDate date = LocalDate.of(2026, 4, 15);
+        stubTerrainPourCreneaux(1L, 1L, date);
+        Joueur joueur = stubCurrentJoueur("S0001", TypeJoueur.SITE, BigDecimal.ZERO);
+        Site siteJoueur = mock(Site.class);
+        when(siteJoueur.getId()).thenReturn(1L);
+        when(joueur.getSite()).thenReturn(siteJoueur);
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Vous pouvez réserver au maximum 2 semaines à l'avance.", response.getMessage());
+    }
+
+    @Test
     void getCreneauxDisponibles_libre_trop_loin_retourne_liste_vide() {
         LocalDate date = LocalDate.of(2026, 4, 15);
         stubTerrainPourCreneaux(1L, 1L, date);
@@ -1360,7 +1453,7 @@ class MatchPadelServiceTest {
         CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
 
         assertTrue(response.getCreneaux().isEmpty());
-        assertEquals("Aucun creneau disponible pour ce terrain et cette date.", response.getMessage());
+        assertEquals("Vous pouvez réserver au maximum 5 jours à l'avance.", response.getMessage());
     }
 
     @Test
@@ -1376,7 +1469,7 @@ class MatchPadelServiceTest {
         CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
 
         assertTrue(response.getCreneaux().isEmpty());
-        assertEquals("Aucun creneau disponible pour ce terrain et cette date.", response.getMessage());
+        assertEquals("Votre abonnement SITE permet de réserver uniquement sur votre site.", response.getMessage());
     }
 
     @Test
@@ -1389,6 +1482,17 @@ class MatchPadelServiceTest {
         assertFalse(response.getCreneaux().contains("08:00"));
         assertFalse(response.getCreneaux().contains("11:00"));
         assertTrue(response.getCreneaux().contains("11:15"));
+    }
+
+    @Test
+    void getCreneauxDisponibles_date_du_jour_sans_creneau_futur_retourne_message_dedie() {
+        LocalDate date = LocalDate.of(2026, 3, 24);
+        stubTerrainPourCreneaux(1L, 1L, date, LocalTime.of(8, 0), LocalTime.of(12, 45));
+
+        CreneauxMatchResponseDto response = service.getCreneauxDisponibles(1L, date);
+
+        assertTrue(response.getCreneaux().isEmpty());
+        assertEquals("Il n'y a plus de créneau disponible aujourd'hui pour ce terrain.", response.getMessage());
     }
 }
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MatchControllerTest.java
@@ -179,7 +179,15 @@ class MatchControllerTest {
     void getCreneaux_auth_200_et_json() throws Exception {
         LocalDate date = LocalDate.of(2030, 1, 1);
         when(matchPadelService.getCreneauxDisponibles(1L, date))
-                .thenReturn(new CreneauxMatchResponseDto(List.of("08:00", "08:15", "20:15"), null));
+                .thenReturn(new CreneauxMatchResponseDto(
+                        List.of("08:00", "08:15", "20:15"),
+                        null,
+                        2030,
+                        LocalTime.of(8, 0),
+                        LocalTime.of(22, 0),
+                        90L,
+                        15L
+                ));
 
         mvc.perform(get("/api/v1/matchs/creneaux")
                         .param("terrainId", "1")
@@ -188,7 +196,12 @@ class MatchControllerTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.creneaux[0]").value("08:00"))
                 .andExpect(jsonPath("$.creneaux[2]").value("20:15"))
-                .andExpect(jsonPath("$.message").value(nullValue()));
+                .andExpect(jsonPath("$.message").value(nullValue()))
+                .andExpect(jsonPath("$.annee").value(2030))
+                .andExpect(jsonPath("$.heureOuverture").value("08:00:00"))
+                .andExpect(jsonPath("$.heureFermeture").value("22:00:00"))
+                .andExpect(jsonPath("$.dureeMatchMinutes").value(90))
+                .andExpect(jsonPath("$.bufferMinutes").value(15));
 
         verify(matchPadelService).getCreneauxDisponibles(1L, date);
     }
@@ -199,7 +212,7 @@ class MatchControllerTest {
         when(matchPadelService.getCreneauxDisponibles(1L, date))
                 .thenReturn(new CreneauxMatchResponseDto(
                         List.of(),
-                        "Aucun horaire n'est configure pour ce site et cette annee."
+                        "Aucun horaire n'est configuré pour ce site et cette année."
                 ));
 
         mvc.perform(get("/api/v1/matchs/creneaux")
@@ -208,7 +221,9 @@ class MatchControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.creneaux").isArray())
                 .andExpect(jsonPath("$.creneaux").isEmpty())
-                .andExpect(jsonPath("$.message").value("Aucun horaire n'est configure pour ce site et cette annee."));
+                .andExpect(jsonPath("$.message").value("Aucun horaire n'est configuré pour ce site et cette année."))
+                .andExpect(jsonPath("$.heureOuverture").value(nullValue()))
+                .andExpect(jsonPath("$.heureFermeture").value(nullValue()));
     }
 
     @Test

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminSiteControllerSecurityTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminSiteControllerSecurityTest.java
@@ -2,6 +2,9 @@ package be.ephec.padel.backend.web.security;
 
 import be.ephec.padel.backend.config.SecurityConfig;
 import be.ephec.padel.backend.controller.AdminSiteController;
+import be.ephec.padel.backend.dto.response.AdminSiteConsultationDto;
+import be.ephec.padel.backend.dto.response.HoraireSiteDto;
+import be.ephec.padel.backend.dto.response.TerrainDto;
 import be.ephec.padel.backend.service.AdminSiteService;
 import be.ephec.padel.backend.service.AdminSiteStatsService;
 import org.junit.jupiter.api.Test;
@@ -13,7 +16,14 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = AdminSiteController.class)
@@ -42,6 +52,19 @@ class AdminSiteControllerSecurityTest {
     }
 
     @Test
+    void sitesSansAuth_401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/sites"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "joueur1", roles = {"JOUEUR"})
+    void sitesJoueurNonAdmin_403() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/sites"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void statsSansAuth_401() throws Exception {
         mockMvc.perform(get("/api/v1/admin/sites/1/stats/dettes"))
                 .andExpect(status().isUnauthorized());
@@ -59,5 +82,48 @@ class AdminSiteControllerSecurityTest {
     void adminGlobal_auth_200() throws Exception {
         mockMvc.perform(get("/api/v1/admin/sites/2/joueurs"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
+    void sitesAdminGlobal_auth_200_json_avec_terrains_et_horaires() throws Exception {
+        when(adminSiteService.getSitesConsultables()).thenReturn(List.of(
+                siteDto(1L, "Site 1", "Bruxelles"),
+                siteDto(2L, "Site 2", "Liege")
+        ));
+
+        mockMvc.perform(get("/api/v1/admin/sites"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].nom").value("Site 1"))
+                .andExpect(jsonPath("$[0].ville").value("Bruxelles"))
+                .andExpect(jsonPath("$[0].joursFermeture[0]").value("MONDAY"))
+                .andExpect(jsonPath("$[0].terrains[0].nom").value("Terrain A"))
+                .andExpect(jsonPath("$[0].horaires[0].annee").value(2026))
+                .andExpect(jsonPath("$[0].horaires[0].heureOuverture").value("08:00:00"))
+                .andExpect(jsonPath("$[1].id").value(2));
+    }
+
+    @Test
+    @WithMockUser(username = "adminSite1", roles = {"ADMIN_SITE"})
+    void sitesAdminSite_auth_200_uniquement_sites_retournes_par_service() throws Exception {
+        when(adminSiteService.getSitesConsultables()).thenReturn(List.of(siteDto(1L, "Site 1", "Bruxelles")));
+
+        mockMvc.perform(get("/api/v1/admin/sites"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].terrains[0].siteId").value(1))
+                .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    private AdminSiteConsultationDto siteDto(Long id, String nom, String ville) {
+        return new AdminSiteConsultationDto(
+                id,
+                nom,
+                ville,
+                Set.of(DayOfWeek.MONDAY),
+                List.of(new TerrainDto(id * 10, "Terrain A", id)),
+                List.of(new HoraireSiteDto(id * 100, id, 2026, LocalTime.of(8, 0), LocalTime.of(22, 0)))
+        );
     }
 }

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -38,6 +38,12 @@ export const routes: Routes = [
         canActivate: [authGuard]
       },
       {
+        path: 'admin/sites',
+        loadComponent: () => import('./features/admin/sites/admin-sites-page.component')
+          .then((m) => m.AdminSitesPageComponent),
+        canActivate: [authGuard]
+      },
+      {
         path: 'admin/statistiques',
         loadComponent: () => import('./features/admin/statistiques/admin-statistics-page.component')
           .then((m) => m.AdminStatisticsPageComponent),

--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -83,6 +83,21 @@ export interface AdminSiteScheduleResponse {
   heureFermeture: string;
 }
 
+export interface AdminSiteConsultationTerrain {
+  id: number;
+  nom: string;
+  siteId: number;
+}
+
+export interface AdminSiteConsultationResponse {
+  id: number;
+  nom: string;
+  ville: string;
+  joursFermeture: string[];
+  terrains: AdminSiteConsultationTerrain[];
+  horaires: AdminSiteScheduleResponse[];
+}
+
 export interface AdminCaStatsResponse {
   caTotal: number;
   from: string;

--- a/frontend/src/app/core/admin/admin.service.ts
+++ b/frontend/src/app/core/admin/admin.service.ts
@@ -9,6 +9,7 @@ import {
   AdminPlayerResponse,
   AdminSitePlayerResponse,
   AdminSiteClosureResponse,
+  AdminSiteConsultationResponse,
   AdminSiteScheduleResponse,
   AdminMatchsStatsResponse,
   AdminInfoResponse,
@@ -41,6 +42,10 @@ export class AdminService {
 
   getPlayersBySite(siteId: number): Observable<AdminSitePlayerResponse[]> {
     return this.http.get<AdminSitePlayerResponse[]>(`${environment.apiBaseUrl}/admin/sites/${siteId}/joueurs`);
+  }
+
+  getAdminSites(): Observable<AdminSiteConsultationResponse[]> {
+    return this.http.get<AdminSiteConsultationResponse[]>(`${environment.apiBaseUrl}/admin/sites`);
   }
 
   getGlobalClosures(): Observable<AdminGlobalClosureResponse[]> {

--- a/frontend/src/app/core/matches/create-match.models.ts
+++ b/frontend/src/app/core/matches/create-match.models.ts
@@ -24,4 +24,9 @@ export interface CreatedMatch {
 export interface MatchSlotsResponse {
   creneaux: string[];
   message: string | null;
+  annee: number | null;
+  heureOuverture: string | null;
+  heureFermeture: string | null;
+  dureeMatchMinutes: number | null;
+  bufferMinutes: number | null;
 }

--- a/frontend/src/app/features/admin/admin-page.component.ts
+++ b/frontend/src/app/features/admin/admin-page.component.ts
@@ -31,6 +31,9 @@ export class AdminPageComponent implements OnInit {
   protected readonly isLoadingRegistrations = signal(false);
   protected readonly registrationsError = signal(false);
   protected readonly canViewRegistrationRequests = computed(() => this.authService.hasRole('ROLE_ADMIN_GLOBAL'));
+  protected readonly isSiteScopedAdmin = computed(
+    () => this.adminInfo()?.adminType === 'SITE' || this.authService.hasRole('ROLE_ADMIN_SITE')
+  );
 
   protected readonly apiStatusMessage = computed(() => {
     const status = this.adminInfo()?.status;
@@ -99,6 +102,13 @@ export class AdminPageComponent implements OnInit {
 
     cards.push(
       { title: 'Joueurs', description: 'Consultez les joueurs enregistr\u00e9s dans votre p\u00e9rim\u00e8tre.', route: '/admin/joueurs' },
+      {
+        title: this.isSiteScopedAdmin() ? 'Site' : 'Sites',
+        description: this.isSiteScopedAdmin()
+          ? 'Consultez le site, ses terrains, ses jours de fermeture et ses horaires.'
+          : 'Consultez les sites, leurs terrains, leurs jours de fermeture et leurs horaires.',
+        route: '/admin/sites'
+      },
       { title: 'Fermetures', description: 'Consultez les fermetures globales et les fermetures de site.', route: '/admin/fermetures' },
       { title: 'Horaires', description: 'Consultez les horaires configur\u00e9s par site.', route: '/admin/horaires' },
       { title: 'Statistiques', description: "Consultez le chiffre d'affaires, les matchs et les dettes.", route: '/admin/statistiques' }

--- a/frontend/src/app/features/admin/sites/admin-sites-page.component.css
+++ b/frontend/src/app/features/admin/sites/admin-sites-page.component.css
@@ -1,0 +1,139 @@
+.admin-sites-page {
+  width: min(100%, 64rem);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  padding: 3rem 0;
+}
+
+.page-header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.page-eyebrow {
+  margin: 0;
+  color: #0f766e;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.back-link {
+  width: fit-content;
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  color: #10233f;
+}
+
+.page-intro,
+.site-section p,
+.site-heading p {
+  margin: 0;
+  color: #526277;
+}
+
+.page-state {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #2c3a4b;
+}
+
+.page-state.is-error {
+  border-color: #ef4444;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.sites-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.site-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.35rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.06);
+}
+
+.site-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid #e5edf6;
+  padding-bottom: 0.9rem;
+}
+
+.site-heading span,
+.schedule-card span {
+  color: #526277;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.site-heading h2,
+.site-section h3 {
+  margin: 0;
+  color: #10233f;
+}
+
+.site-section {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.compact-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.compact-list li {
+  padding: 0.35rem 0.65rem;
+  border: 1px solid #c3d0de;
+  border-radius: 999px;
+  background: #f8fbff;
+  color: #10233f;
+  font-weight: 700;
+}
+
+.schedules-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.75rem;
+}
+
+.schedule-card {
+  display: grid;
+  gap: 0.3rem;
+  padding: 0.85rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #f8fbff;
+}
+
+.schedule-card p {
+  margin: 0;
+  color: #10233f;
+  font-weight: 800;
+}

--- a/frontend/src/app/features/admin/sites/admin-sites-page.component.html
+++ b/frontend/src/app/features/admin/sites/admin-sites-page.component.html
@@ -1,0 +1,64 @@
+<section class="admin-sites-page">
+  <header class="page-header">
+    <p class="page-eyebrow">Administration</p>
+    <a routerLink="/admin" class="back-link">&larr; Retour &agrave; l&rsquo;administration</a>
+    <h1>{{ pageTitle() }}</h1>
+    <p class="page-intro">{{ pageIntro() }}</p>
+  </header>
+
+  @if (isLoading()) {
+    <p class="page-state">Chargement en cours...</p>
+  } @else if (errorMessage()) {
+    <p class="page-state is-error">{{ errorMessage() }}</p>
+  } @else if (hasNoSites()) {
+    <p class="page-state">Aucun site accessible.</p>
+  } @else {
+    <div class="sites-list">
+      @for (site of sites(); track trackSite(site)) {
+        <article class="site-card">
+          <div class="site-heading">
+            <div>
+              <span>Site</span>
+              <h2>{{ site.nom }}</h2>
+            </div>
+            <p>{{ site.ville }}</p>
+          </div>
+
+          <section class="site-section">
+            <h3>Jours de fermeture récurrents</h3>
+            <p>{{ getClosingDaysLabel(site) }}</p>
+          </section>
+
+          <section class="site-section">
+            <h3>Terrains</h3>
+            @if (site.terrains.length === 0) {
+              <p>Aucun terrain enregistré pour ce site.</p>
+            } @else {
+              <ul class="compact-list">
+                @for (terrain of site.terrains; track terrain.id) {
+                  <li>{{ terrain.nom }}</li>
+                }
+              </ul>
+            }
+          </section>
+
+          <section class="site-section">
+            <h3>Horaires configurés</h3>
+            @if (site.horaires.length === 0) {
+              <p>Aucun horaire configuré pour ce site.</p>
+            } @else {
+              <div class="schedules-grid">
+                @for (schedule of site.horaires; track trackSchedule(schedule)) {
+                  <article class="schedule-card">
+                    <span>Année {{ schedule.annee }}</span>
+                    <p>{{ formatTime(schedule.heureOuverture) }} → {{ formatTime(schedule.heureFermeture) }}</p>
+                  </article>
+                }
+              </div>
+            }
+          </section>
+        </article>
+      }
+    </div>
+  }
+</section>

--- a/frontend/src/app/features/admin/sites/admin-sites-page.component.ts
+++ b/frontend/src/app/features/admin/sites/admin-sites-page.component.ts
@@ -1,0 +1,109 @@
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { finalize } from 'rxjs';
+import { AdminSiteConsultationResponse, AdminSiteScheduleResponse } from '../../../core/admin/admin.models';
+import { AdminService } from '../../../core/admin/admin.service';
+
+@Component({
+  selector: 'app-admin-sites-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './admin-sites-page.component.html',
+  styleUrl: './admin-sites-page.component.css'
+})
+export class AdminSitesPageComponent implements OnInit {
+  private readonly adminService = inject(AdminService);
+
+  protected readonly sites = signal<AdminSiteConsultationResponse[]>([]);
+  protected readonly isLoading = signal(true);
+  protected readonly errorMessage = signal('');
+  protected readonly isSingleSiteView = computed(
+    () => !this.isLoading() && !this.errorMessage() && this.sites().length === 1
+  );
+  protected readonly pageTitle = computed(() => (this.isSingleSiteView() ? 'Site' : 'Sites'));
+  protected readonly pageIntro = computed(() =>
+    this.isSingleSiteView()
+      ? 'Consultez le site, ses terrains, ses jours de fermeture et ses horaires.'
+      : 'Consultez les sites, leurs terrains, leurs jours de fermeture et leurs horaires.'
+  );
+
+  private readonly dayLabels: Record<string, string> = {
+    MONDAY: 'Lundi',
+    TUESDAY: 'Mardi',
+    WEDNESDAY: 'Mercredi',
+    THURSDAY: 'Jeudi',
+    FRIDAY: 'Vendredi',
+    SATURDAY: 'Samedi',
+    SUNDAY: 'Dimanche'
+  };
+
+  ngOnInit(): void {
+    this.loadSites();
+  }
+
+  protected hasNoSites(): boolean {
+    return !this.isLoading() && !this.errorMessage() && this.sites().length === 0;
+  }
+
+  protected trackSite(site: AdminSiteConsultationResponse): number {
+    return site.id;
+  }
+
+  protected trackSchedule(schedule: AdminSiteScheduleResponse): number {
+    return schedule.id;
+  }
+
+  protected getClosingDaysLabel(site: AdminSiteConsultationResponse): string {
+    if (!site.joursFermeture || site.joursFermeture.length === 0) {
+      return 'Aucun jour de fermeture récurrent.';
+    }
+
+    return site.joursFermeture
+      .map((day) => this.dayLabels[day] ?? day)
+      .join(', ');
+  }
+
+  protected formatTime(value: string): string {
+    if (!value) {
+      return 'Non renseigné';
+    }
+
+    return value.length >= 5 ? value.slice(0, 5) : value;
+  }
+
+  private loadSites(): void {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+
+    this.adminService
+      .getAdminSites()
+      .pipe(finalize(() => this.isLoading.set(false)))
+      .subscribe({
+        next: (sites) => {
+          this.sites.set(sites);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.sites.set([]);
+          this.errorMessage.set(this.getErrorMessage(error));
+        }
+      });
+  }
+
+  private getErrorMessage(error: HttpErrorResponse): string {
+    if (error.status === 0) {
+      return 'Backend inaccessible.';
+    }
+
+    if (error.status === 401) {
+      return 'Authentification requise.';
+    }
+
+    if (error.status === 403) {
+      return 'Accès administrateur refusé.';
+    }
+
+    return 'Impossible de charger les sites.';
+  }
+}

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.css
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.css
@@ -150,6 +150,31 @@ h1 {
   font-size: 0.85rem;
 }
 
+.slot-info {
+  margin-top: 1.25rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid #bfdbfe;
+  border-radius: 0.85rem;
+  background: #eff6ff;
+}
+
+.slot-info-title {
+  margin: 0 0 0.85rem;
+  color: #10233f;
+  font-weight: 700;
+}
+
+.slot-info-text {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.slot-info-text p {
+  margin: 0;
+  color: #10233f;
+  line-height: 1.45;
+}
+
 .form-actions {
   margin-top: 1.4rem;
 }

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.html
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.html
@@ -107,7 +107,7 @@
             <select formControlName="heure">
               <option value="">Sélectionner une heure</option>
               @if (isLoadingSlots()) {
-                <option value="" disabled>Chargement des creneaux...</option>
+                <option value="" disabled>Chargement des créneaux...</option>
               }
               @for (slot of availableSlots(); track slot) {
                 <option [value]="slot">{{ slot }}</option>
@@ -138,6 +138,23 @@
             }
           </label>
         </div>
+
+        @if (slotScheduleInfo(); as info) {
+          <section class="slot-info" aria-live="polite">
+            <p class="slot-info-title">Créneaux disponibles</p>
+            <div class="slot-info-text">
+              <p>
+                Pour cette date, le site est ouvert de {{ formatSlotTime(info.heureOuverture) }}
+                à {{ formatSlotTime(info.heureFermeture) }}.
+              </p>
+              <p>Un match dure {{ formatDuration(info.dureeMatchMinutes) }}.</p>
+              <p>Un intervalle de {{ info.bufferMinutes }} minutes est prévu entre deux matchs.</p>
+              @if (lastAvailableSlot()) {
+                <p>Le dernier créneau possible est {{ lastAvailableSlot() }}.</p>
+              }
+            </div>
+          </section>
+        }
 
         <div class="form-actions">
           <button

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.ts
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
@@ -25,6 +25,14 @@ interface ApiErrorBody {
 interface FriendlyErrorDetail {
   key: string;
   message: string;
+}
+
+interface SlotScheduleInfo {
+  annee: number;
+  heureOuverture: string;
+  heureFermeture: string;
+  dureeMatchMinutes: number;
+  bufferMinutes: number;
 }
 
 @Component({
@@ -54,6 +62,11 @@ export class CreateMatchPageComponent implements OnInit {
   protected readonly backendFieldErrors = signal<Record<string, string>>({});
   protected readonly friendlyErrorDetails = signal<FriendlyErrorDetail[]>([]);
   protected readonly availableSlots = signal<string[]>([]);
+  protected readonly slotScheduleInfo = signal<SlotScheduleInfo | null>(null);
+  protected readonly lastAvailableSlot = computed(() => {
+    const slots = this.availableSlots();
+    return slots.length > 0 ? slots[slots.length - 1] : '';
+  });
 
   protected readonly form = this.fb.nonNullable.group({
     siteId: [null as number | null, Validators.required],
@@ -189,7 +202,7 @@ export class CreateMatchPageComponent implements OnInit {
     }
 
     if (this.isLoadingSlots()) {
-      hints.push('Chargement des creneaux en cours.');
+      hints.push('Chargement des créneaux en cours.');
     }
 
     if (this.isSubmitting()) {
@@ -218,11 +231,12 @@ export class CreateMatchPageComponent implements OnInit {
       this.form.controls.terrainId.value != null &&
       this.form.controls.date.value &&
       this.form.controls.heure.disabled &&
-      !this.isLoadingSlots()
+      !this.isLoadingSlots() &&
+      !this.slotsMessage()
     ) {
-      hints.push('Aucun creneau disponible.');
-    } else if (this.form.controls.heure.disabled) {
-      hints.push('Selectionnez un terrain et une date pour charger les creneaux.');
+      hints.push('Aucun créneau disponible.');
+    } else if (this.form.controls.heure.disabled && !this.slotsMessage()) {
+      hints.push('Sélectionnez un terrain et une date pour charger les créneaux.');
     }
 
     if (this.form.controls.heure.hasError('required')) {
@@ -238,6 +252,25 @@ export class CreateMatchPageComponent implements OnInit {
 
   protected dateDebutFieldError(): string {
     return this.backendFieldErrors()['dateDebut'] ?? '';
+  }
+
+  protected formatSlotTime(value: string): string {
+    return value.length >= 5 ? value.slice(0, 5) : value;
+  }
+
+  protected formatDuration(minutes: number): string {
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+
+    if (hours > 0 && remainingMinutes > 0) {
+      return `${hours}h${remainingMinutes}`;
+    }
+
+    if (hours > 0) {
+      return `${hours}h`;
+    }
+
+    return `${minutes} minutes`;
   }
 
   private loadSites(): void {
@@ -339,7 +372,7 @@ export class CreateMatchPageComponent implements OnInit {
           this.availableSlots.set([]);
           this.form.controls.heure.disable();
           this.slotsMessage.set(
-            error.status === 0 ? 'Backend inaccessible.' : 'Impossible de charger les creneaux.'
+            error.status === 0 ? 'Backend inaccessible.' : 'Impossible de charger les créneaux.'
           );
         }
       });
@@ -350,6 +383,7 @@ export class CreateMatchPageComponent implements OnInit {
 
     this.availableSlots.set(slots);
     this.slotsMessage.set(response.message ?? '');
+    this.slotScheduleInfo.set(this.toSlotScheduleInfo(response));
 
     if (slots.length > 0) {
       this.form.controls.heure.enable();
@@ -365,9 +399,30 @@ export class CreateMatchPageComponent implements OnInit {
   private resetSlots(): void {
     this.availableSlots.set([]);
     this.slotsMessage.set('');
+    this.slotScheduleInfo.set(null);
     this.isLoadingSlots.set(false);
     this.form.controls.heure.reset('');
     this.form.controls.heure.disable();
+  }
+
+  private toSlotScheduleInfo(response: MatchSlotsResponse): SlotScheduleInfo | null {
+    if (
+      response.annee == null ||
+      !response.heureOuverture ||
+      !response.heureFermeture ||
+      response.dureeMatchMinutes == null ||
+      response.bufferMinutes == null
+    ) {
+      return null;
+    }
+
+    return {
+      annee: response.annee,
+      heureOuverture: response.heureOuverture,
+      heureFermeture: response.heureFermeture,
+      dureeMatchMinutes: response.dureeMatchMinutes,
+      bufferMinutes: response.bufferMinutes
+    };
   }
 
   private handleSubmitError(error: HttpErrorResponse): void {
@@ -436,11 +491,11 @@ export class CreateMatchPageComponent implements OnInit {
 
   private normalizeForSearch(value: string): string {
     return value
-      .replace(/ÃƒÂ©|Ã©/g, 'e')
-      .replace(/ÃƒÂ¨|Ã¨/g, 'e')
-      .replace(/ÃƒÂª|Ãª/g, 'e')
-      .replace(/ÃƒÂ |Ã /g, 'a')
-      .replace(/ÃƒÂ§|Ã§/g, 'c')
+      .replace(/\u00c3\u0192\u00c2\u00a9|\u00c3\u00a9/g, 'e')
+      .replace(/\u00c3\u0192\u00c2\u00a8|\u00c3\u00a8/g, 'e')
+      .replace(/\u00c3\u0192\u00c2\u00aa|\u00c3\u00aa/g, 'e')
+      .replace(/\u00c3\u0192\u00c2\u00a0|\u00c3\u00a0/g, 'a')
+      .replace(/\u00c3\u0192\u00c2\u00a7|\u00c3\u00a7/g, 'c')
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '')
       .toLowerCase();


### PR DESCRIPTION
- Enrichissement de GET /api/v1/matchs/creneaux avec les informations horaires utiles au joueur.

- Affichage dans /matchs/creer d’un bloc explicatif sur les créneaux disponibles.

- Affichage dynamique de l’année, de l’horaire du site, de la durée du match, de l’intervalle et du dernier créneau possible.

- Amélioration des messages lorsqu’aucun créneau n’est pas disponible.

- Suppression du message générique lorsqu’un message backend précis existe déjà.

- Ajout de l’endpoint admin read-only GET /api/v1/admin/sites.

- Ajout d’une page /admin/sites pour consulter les sites, terrains, jours de fermeture et horaires configurés.

- Support ADMIN_GLOBAL : consultation de tous les sites.

- Support ADMIN_SITE : consultation limitée au site administré.

- Ajout de la carte Site/Sites dans le tableau de bord admin.


