### PR TITLE
Issue 183 - Historique admin des matchs avec accès au détail

### DIFF
--- a/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminSiteController.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/controller/AdminSiteController.java
@@ -6,7 +6,9 @@ import be.ephec.padel.backend.dto.response.AdminMatchsStatsDto;
 import be.ephec.padel.backend.dto.response.AdminSiteConsultationDto;
 import be.ephec.padel.backend.dto.response.AdminSiteMatchSummaryDto;
 import be.ephec.padel.backend.dto.response.JoueurAdminDto;
+import be.ephec.padel.backend.model.enums.AdminMatchScope;
 import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.service.AdminSiteService;
 import be.ephec.padel.backend.service.AdminSiteStatsService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -50,8 +52,10 @@ public class AdminSiteController {
                                                     @RequestParam(required = false)
                                                     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
                                                     LocalDate to,
-                                                    @RequestParam(required = false) MatchStatut statut) {
-        return adminSiteService.getMatchsBySite(siteId, from, to, statut);
+                                                    @RequestParam(required = false) MatchStatut statut,
+                                                    @RequestParam(required = false) MatchVisibilite visibilite,
+                                                    @RequestParam(required = false) AdminMatchScope scope) {
+        return adminSiteService.getMatchsBySite(siteId, from, to, statut, visibilite, scope);
     }
 
     @GetMapping("/{siteId}/stats/ca")

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminSiteMatchSummaryDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/AdminSiteMatchSummaryDto.java
@@ -22,6 +22,7 @@ public class AdminSiteMatchSummaryDto {
     private final int nbParticipants;
     private final int placesRestantes;
     private final boolean peutAnnuler;
+    private final boolean passe;
 
     public AdminSiteMatchSummaryDto(Long id,
                                     LocalDate dateDebut,
@@ -36,7 +37,8 @@ public class AdminSiteMatchSummaryDto {
                                     MatchStatut statut,
                                     int nbParticipants,
                                     int placesRestantes,
-                                    boolean peutAnnuler) {
+                                    boolean peutAnnuler,
+                                    boolean passe) {
         this.id = id;
         this.dateDebut = dateDebut;
         this.heureDebut = heureDebut;
@@ -51,6 +53,7 @@ public class AdminSiteMatchSummaryDto {
         this.nbParticipants = nbParticipants;
         this.placesRestantes = placesRestantes;
         this.peutAnnuler = peutAnnuler;
+        this.passe = passe;
     }
 
     public Long getId() { return id; }
@@ -67,4 +70,5 @@ public class AdminSiteMatchSummaryDto {
     public int getNbParticipants() { return nbParticipants; }
     public int getPlacesRestantes() { return placesRestantes; }
     public boolean isPeutAnnuler() { return peutAnnuler; }
+    public boolean isPasse() { return passe; }
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/MatchPadelRepository.java
@@ -155,17 +155,21 @@ public interface MatchPadelRepository extends JpaRepository<MatchPadel, Long> {
         left join fetch m.participations p
         where s.id = :siteId
           and (:statut is null or m.statut = :statut)
+          and (:visibilite is null or m.visibilite = :visibilite)
           and (:from is null or m.dateDebut >= :from)
           and (:to is null or m.dateDebut < :to)
-          and (:futureOnly = false or m.dateDebut > :now)
+          and (:futureOnly = false or (m.statut = be.ephec.padel.backend.model.enums.MatchStatut.PLANIFIE and m.dateDebut > :now))
+          and (:historyOnly = false or (m.dateDebut < :now or m.statut = be.ephec.padel.backend.model.enums.MatchStatut.ANNULE))
         order by m.dateDebut asc
     """)
     List<MatchPadel> findAdminSiteMatches(
             @Param("siteId") Long siteId,
             @Param("statut") MatchStatut statut,
+            @Param("visibilite") MatchVisibilite visibilite,
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to,
             @Param("futureOnly") boolean futureOnly,
+            @Param("historyOnly") boolean historyOnly,
             @Param("now") LocalDateTime now
     );
 

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminSiteService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/AdminSiteService.java
@@ -9,7 +9,9 @@ import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.exception.NotFoundException;
 import be.ephec.padel.backend.model.entities.HoraireSite;
 import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.enums.AdminMatchScope;
 import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.repository.JoueurRepository;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
 import be.ephec.padel.backend.model.entities.Site;
@@ -24,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -86,7 +89,9 @@ public class AdminSiteService {
     public List<AdminSiteMatchSummaryDto> getMatchsBySite(Long siteId,
                                                           LocalDate from,
                                                           LocalDate to,
-                                                          MatchStatut statut) {
+                                                          MatchStatut statut,
+                                                          MatchVisibilite visibilite,
+                                                          AdminMatchScope scope) {
         serviceAutorisationAdmin.verifierAccesAuSite(siteId);
 
         if (!siteRepository.existsById(siteId)) {
@@ -94,22 +99,35 @@ public class AdminSiteService {
         }
 
         LocalDateTime now = LocalDateTime.now(clock);
-        boolean defaultFilter = from == null && to == null && statut == null;
-        MatchStatut effectiveStatut = statut != null ? statut : MatchStatut.PLANIFIE;
-        LocalDateTime fromDateTime = defaultFilter ? now : toStartOfDay(from);
+        AdminMatchScope effectiveScope = scope == null ? AdminMatchScope.UPCOMING_PLANNED : scope;
+        boolean upcomingPlannedOnly = effectiveScope == AdminMatchScope.UPCOMING_PLANNED;
+        boolean historyOnly = effectiveScope == AdminMatchScope.HISTORY;
+        MatchStatut effectiveStatut = upcomingPlannedOnly ? MatchStatut.PLANIFIE : statut;
+        LocalDateTime fromDateTime = toStartOfDay(from);
         LocalDateTime toDateTime = to == null ? null : to.plusDays(1).atStartOfDay();
 
         return matchPadelRepository.findAdminSiteMatches(
                         siteId,
                         effectiveStatut,
+                        visibilite,
                         fromDateTime,
                         toDateTime,
-                        defaultFilter,
+                        upcomingPlannedOnly,
+                        historyOnly,
                         now
                 )
                 .stream()
+                .sorted(getAdminMatchComparator(effectiveScope))
                 .map((match) -> toAdminSiteMatchSummaryDto(match, now))
                 .toList();
+    }
+
+    private Comparator<MatchPadel> getAdminMatchComparator(AdminMatchScope scope) {
+        Comparator<MatchPadel> comparator = Comparator.comparing(MatchPadel::getDateDebut);
+        if (scope == AdminMatchScope.UPCOMING_PLANNED) {
+            return comparator;
+        }
+        return comparator.reversed();
     }
 
     private JoueurAdminDto toJoueurAdminDto(Joueur joueur) {
@@ -147,6 +165,7 @@ public class AdminSiteService {
         boolean peutAnnuler = match.getStatut() == MatchStatut.PLANIFIE
                 && match.getDateDebut().isAfter(now)
                 && serviceAutorisationAdmin.peutAdministrerSite(match.getTerrain().getSite().getId());
+        boolean passe = match.getDateDebut().isBefore(now);
 
         return new AdminSiteMatchSummaryDto(
                 match.getId(),
@@ -162,7 +181,8 @@ public class AdminSiteService {
                 match.getStatut(),
                 nbParticipants,
                 placesRestantes,
-                peutAnnuler
+                peutAnnuler,
+                passe
         );
     }
 

--- a/backend/backend/src/test/java/be/ephec/padel/backend/repository/MatchPadelRepositoryTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/repository/MatchPadelRepositoryTest.java
@@ -481,6 +481,161 @@ class MatchPadelRepositoryTest extends SqlServerTestContainerConfig {
     }
 
     @Test
+    void findAdminSiteMatches_scopeAll_sans_filtres_retourne_tous_les_matchs_du_site() {
+        Site siteA = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Site siteB = siteRepository.save(new Site("Site B", "Namur"));
+        Terrain terrainA = terrainRepository.save(new Terrain("T1", siteA));
+        Terrain terrainB = terrainRepository.save(new Terrain("T2", siteB));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        LocalDateTime now = LocalDateTime.of(2030, 1, 10, 9, 0);
+        MatchPadel plannedFuture = matchPadelRepository.save(new MatchPadel(
+                terrainA, orga, LocalDateTime.of(2030, 1, 11, 10, 0), MatchVisibilite.PUBLIC
+        ));
+        MatchPadel plannedPast = matchPadelRepository.save(new MatchPadel(
+                terrainA, orga, LocalDateTime.of(2030, 1, 9, 10, 0), MatchVisibilite.PUBLIC
+        ));
+        MatchPadel cancelledFuture = new MatchPadel(
+                terrainA, orga, LocalDateTime.of(2030, 1, 12, 10, 0), MatchVisibilite.PRIVE
+        );
+        cancelledFuture.setStatut(MatchStatut.ANNULE);
+        cancelledFuture = matchPadelRepository.save(cancelledFuture);
+        matchPadelRepository.save(new MatchPadel(
+                terrainB, orga, LocalDateTime.of(2030, 1, 13, 10, 0), MatchVisibilite.PUBLIC
+        ));
+
+        em.flush();
+        em.clear();
+
+        List<MatchPadel> rows = matchPadelRepository.findAdminSiteMatches(
+                siteA.getId(),
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                now
+        );
+
+        assertThat(rows)
+                .extracting(MatchPadel::getId)
+                .containsExactlyInAnyOrder(plannedFuture.getId(), plannedPast.getId(), cancelledFuture.getId());
+    }
+
+    @Test
+    void findAdminSiteMatches_futureOnly_retourne_uniquement_les_futurs_planifies() {
+        Site site = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain terrain = terrainRepository.save(new Terrain("T1", site));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        LocalDateTime now = LocalDateTime.of(2030, 1, 10, 9, 0);
+        MatchPadel plannedFuture = matchPadelRepository.save(new MatchPadel(
+                terrain, orga, LocalDateTime.of(2030, 1, 11, 10, 0), MatchVisibilite.PUBLIC
+        ));
+        matchPadelRepository.save(new MatchPadel(
+                terrain, orga, LocalDateTime.of(2030, 1, 9, 10, 0), MatchVisibilite.PUBLIC
+        ));
+        MatchPadel cancelledFuture = new MatchPadel(
+                terrain, orga, LocalDateTime.of(2030, 1, 12, 10, 0), MatchVisibilite.PUBLIC
+        );
+        cancelledFuture.setStatut(MatchStatut.ANNULE);
+        matchPadelRepository.save(cancelledFuture);
+
+        em.flush();
+        em.clear();
+
+        List<MatchPadel> rows = matchPadelRepository.findAdminSiteMatches(
+                site.getId(),
+                MatchStatut.PLANIFIE,
+                null,
+                null,
+                null,
+                true,
+                false,
+                now
+        );
+
+        assertThat(rows).extracting(MatchPadel::getId).containsExactly(plannedFuture.getId());
+    }
+
+    @Test
+    void findAdminSiteMatches_history_retourne_matchs_passes_et_annules_futurs() {
+        Site site = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain terrain = terrainRepository.save(new Terrain("T1", site));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        LocalDateTime now = LocalDateTime.of(2030, 1, 10, 9, 0);
+        MatchPadel plannedPast = matchPadelRepository.save(new MatchPadel(
+                terrain, orga, LocalDateTime.of(2030, 1, 9, 10, 0), MatchVisibilite.PUBLIC
+        ));
+        matchPadelRepository.save(new MatchPadel(
+                terrain, orga, LocalDateTime.of(2030, 1, 11, 10, 0), MatchVisibilite.PUBLIC
+        ));
+        MatchPadel cancelledFuture = new MatchPadel(
+                terrain, orga, LocalDateTime.of(2030, 1, 12, 10, 0), MatchVisibilite.PUBLIC
+        );
+        cancelledFuture.setStatut(MatchStatut.ANNULE);
+        cancelledFuture = matchPadelRepository.save(cancelledFuture);
+
+        em.flush();
+        em.clear();
+
+        List<MatchPadel> rows = matchPadelRepository.findAdminSiteMatches(
+                site.getId(),
+                null,
+                null,
+                null,
+                null,
+                false,
+                true,
+                now
+        );
+
+        assertThat(rows)
+                .extracting(MatchPadel::getId)
+                .containsExactlyInAnyOrder(plannedPast.getId(), cancelledFuture.getId());
+    }
+
+    @Test
+    void findAdminSiteMatches_filtre_par_statut_et_visibilite() {
+        Site site = siteRepository.save(new Site("Site A", "Bruxelles"));
+        Terrain terrain = terrainRepository.save(new Terrain("T1", site));
+        Joueur orga = joueurRepository.save(new Joueur("ORG1", "Orga", TypeJoueur.GLOBAL));
+
+        LocalDateTime now = LocalDateTime.of(2030, 1, 10, 9, 0);
+        MatchPadel cancelledPublic = new MatchPadel(
+                terrain, orga, LocalDateTime.of(2030, 1, 11, 10, 0), MatchVisibilite.PUBLIC
+        );
+        cancelledPublic.setStatut(MatchStatut.ANNULE);
+        cancelledPublic = matchPadelRepository.save(cancelledPublic);
+        MatchPadel cancelledPrivate = new MatchPadel(
+                terrain, orga, LocalDateTime.of(2030, 1, 12, 10, 0), MatchVisibilite.PRIVE
+        );
+        cancelledPrivate.setStatut(MatchStatut.ANNULE);
+        matchPadelRepository.save(cancelledPrivate);
+        matchPadelRepository.save(new MatchPadel(
+                terrain, orga, LocalDateTime.of(2030, 1, 13, 10, 0), MatchVisibilite.PUBLIC
+        ));
+
+        em.flush();
+        em.clear();
+
+        List<MatchPadel> rows = matchPadelRepository.findAdminSiteMatches(
+                site.getId(),
+                MatchStatut.ANNULE,
+                MatchVisibilite.PUBLIC,
+                null,
+                null,
+                false,
+                false,
+                now
+        );
+
+        assertThat(rows).extracting(MatchPadel::getId).containsExactly(cancelledPublic.getId());
+    }
+
+    @Test
     void countByOrganisateurMatricule_compte_les_matchs_organises() {
         Site s = siteRepository.save(new Site("Site A", "Bruxelles"));
         Terrain t = terrainRepository.save(new Terrain("T1", s));

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminSiteServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/AdminSiteServiceTest.java
@@ -2,12 +2,14 @@ package be.ephec.padel.backend.unit.service;
 
 import be.ephec.padel.backend.dto.response.AdminSiteConsultationDto;
 import be.ephec.padel.backend.dto.response.AdminSiteMatchSummaryDto;
+import be.ephec.padel.backend.exception.ForbiddenException;
 import be.ephec.padel.backend.model.entities.HoraireSite;
 import be.ephec.padel.backend.model.entities.Joueur;
 import be.ephec.padel.backend.model.entities.MatchPadel;
 import be.ephec.padel.backend.model.entities.Participation;
 import be.ephec.padel.backend.model.entities.Site;
 import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.AdminMatchScope;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypeJoueur;
@@ -34,8 +36,12 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AdminSiteServiceTest {
@@ -132,14 +138,16 @@ class AdminSiteServiceTest {
         when(matchPadelRepository.findAdminSiteMatches(
                 1L,
                 MatchStatut.PLANIFIE,
-                LocalDateTime.of(2026, 5, 14, 10, 0),
+                null,
+                null,
                 null,
                 true,
+                false,
                 LocalDateTime.of(2026, 5, 14, 10, 0)
         )).thenReturn(List.of(match));
         when(serviceAutorisationAdmin.peutAdministrerSite(1L)).thenReturn(true);
 
-        List<AdminSiteMatchSummaryDto> result = service.getMatchsBySite(1L, null, null, null);
+        List<AdminSiteMatchSummaryDto> result = service.getMatchsBySite(1L, null, null, null, null, null);
 
         assertEquals(1, result.size());
         AdminSiteMatchSummaryDto dto = result.getFirst();
@@ -153,16 +161,136 @@ class AdminSiteServiceTest {
         assertEquals(2, dto.getNbParticipants());
         assertEquals(2, dto.getPlacesRestantes());
         assertTrue(dto.isPeutAnnuler());
+        assertFalse(dto.isPasse());
     }
 
     @Test
-    void getMatchsBySite_verifie_acces_site_avant_recherche() {
+    void getMatchsBySite_history_retourne_matchs_passes_et_annules_futurs() {
+        Site site = site(1L, "Site 1", "Bruxelles", Set.of());
+        Terrain terrain = terrain(10L, "Terrain A", site);
+        Joueur organisateur = new Joueur("ORG001", "Organisateur", TypeJoueur.GLOBAL);
+
+        MatchPadel passe = new MatchPadel(
+                terrain,
+                organisateur,
+                LocalDateTime.of(2026, 5, 1, 9, 0),
+                MatchVisibilite.PUBLIC
+        );
+        ReflectionTestUtils.setField(passe, "id", 101L);
+
+        MatchPadel annuleFutur = new MatchPadel(
+                terrain,
+                organisateur,
+                LocalDateTime.of(2026, 5, 20, 9, 0),
+                MatchVisibilite.PRIVE
+        );
+        ReflectionTestUtils.setField(annuleFutur, "id", 102L);
+        annuleFutur.setStatut(MatchStatut.ANNULE);
+
+        when(siteRepository.existsById(1L)).thenReturn(true);
+        when(matchPadelRepository.findAdminSiteMatches(
+                1L,
+                null,
+                null,
+                null,
+                null,
+                false,
+                true,
+                LocalDateTime.of(2026, 5, 14, 10, 0)
+        )).thenReturn(List.of(passe, annuleFutur));
+        when(serviceAutorisationAdmin.peutAdministrerSite(1L)).thenReturn(true);
+
+        List<AdminSiteMatchSummaryDto> result = service.getMatchsBySite(
+                1L,
+                null,
+                null,
+                null,
+                null,
+                AdminMatchScope.HISTORY
+        );
+
+        assertEquals(2, result.size());
+        assertEquals(102L, result.get(0).getId());
+        assertFalse(result.get(0).isPasse());
+        assertEquals(MatchStatut.ANNULE, result.get(0).getStatut());
+        assertEquals(101L, result.get(1).getId());
+        assertTrue(result.get(1).isPasse());
+        assertEquals(MatchStatut.PLANIFIE, result.get(1).getStatut());
+    }
+
+    @Test
+    void getMatchsBySite_scopeAll_sans_filtres_retourne_tous_les_matchs_et_calcule_passe() {
+        Site site = site(1L, "Site 1", "Bruxelles", Set.of());
+        Terrain terrain = terrain(10L, "Terrain A", site);
+        Joueur organisateur = new Joueur("ORG001", "Organisateur", TypeJoueur.GLOBAL);
+
+        MatchPadel passe = new MatchPadel(
+                terrain,
+                organisateur,
+                LocalDateTime.of(2026, 5, 3, 9, 0),
+                MatchVisibilite.PUBLIC
+        );
+        ReflectionTestUtils.setField(passe, "id", 201L);
+
+        MatchPadel futur = new MatchPadel(
+                terrain,
+                organisateur,
+                LocalDateTime.of(2026, 5, 20, 9, 0),
+                MatchVisibilite.PUBLIC
+        );
+        ReflectionTestUtils.setField(futur, "id", 202L);
+
+        MatchPadel annule = new MatchPadel(
+                terrain,
+                organisateur,
+                LocalDateTime.of(2026, 5, 10, 9, 0),
+                MatchVisibilite.PRIVE
+        );
+        ReflectionTestUtils.setField(annule, "id", 203L);
+        annule.setStatut(MatchStatut.ANNULE);
+
+        when(siteRepository.existsById(1L)).thenReturn(true);
+        when(matchPadelRepository.findAdminSiteMatches(
+                1L,
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                LocalDateTime.of(2026, 5, 14, 10, 0)
+        )).thenReturn(List.of(passe, futur, annule));
+        when(serviceAutorisationAdmin.peutAdministrerSite(1L)).thenReturn(true);
+
+        List<AdminSiteMatchSummaryDto> result = service.getMatchsBySite(
+                1L,
+                null,
+                null,
+                null,
+                null,
+                AdminMatchScope.ALL
+        );
+
+        assertEquals(3, result.size());
+        assertEquals(202L, result.get(0).getId());
+        assertFalse(result.get(0).isPasse());
+        assertEquals(203L, result.get(1).getId());
+        assertTrue(result.get(1).isPasse());
+        assertEquals(MatchStatut.ANNULE, result.get(1).getStatut());
+        assertEquals(201L, result.get(2).getId());
+        assertTrue(result.get(2).isPasse());
+    }
+
+    @Test
+    void getMatchsBySite_transmet_filtres_periode_statut_visibilite_et_scope_all() {
         when(siteRepository.existsById(2L)).thenReturn(true);
         when(matchPadelRepository.findAdminSiteMatches(
                 2L,
                 MatchStatut.ANNULE,
+                MatchVisibilite.PRIVE,
                 LocalDateTime.of(2026, 5, 1, 0, 0),
                 LocalDateTime.of(2026, 6, 1, 0, 0),
+                false,
                 false,
                 LocalDateTime.of(2026, 5, 14, 10, 0)
         )).thenReturn(List.of());
@@ -171,11 +299,27 @@ class AdminSiteServiceTest {
                 2L,
                 LocalDate.of(2026, 5, 1),
                 LocalDate.of(2026, 5, 31),
-                MatchStatut.ANNULE
+                MatchStatut.ANNULE,
+                MatchVisibilite.PRIVE,
+                AdminMatchScope.ALL
         );
 
         assertTrue(result.isEmpty());
-        org.mockito.Mockito.verify(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+        verify(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+    }
+
+    @Test
+    void getMatchsBySite_adminSite_hors_perimetre_est_refuse() {
+        doThrow(new ForbiddenException("Acces interdit")).when(serviceAutorisationAdmin).verifierAccesAuSite(2L);
+
+        assertThrows(ForbiddenException.class, () -> service.getMatchsBySite(
+                2L,
+                null,
+                null,
+                null,
+                null,
+                AdminMatchScope.HISTORY
+        ));
     }
 
     private Site site(Long id, String nom, String ville, Set<DayOfWeek> joursFermeture) {

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminSiteControllerSecurityTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/security/AdminSiteControllerSecurityTest.java
@@ -6,6 +6,7 @@ import be.ephec.padel.backend.dto.response.AdminSiteConsultationDto;
 import be.ephec.padel.backend.dto.response.AdminSiteMatchSummaryDto;
 import be.ephec.padel.backend.dto.response.HoraireSiteDto;
 import be.ephec.padel.backend.dto.response.TerrainDto;
+import be.ephec.padel.backend.model.enums.AdminMatchScope;
 import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.service.AdminSiteService;
@@ -97,7 +98,7 @@ class AdminSiteControllerSecurityTest {
     @Test
     @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
     void matchsAdmin_auth_200_json() throws Exception {
-        when(adminSiteService.getMatchsBySite(1L, null, null, null)).thenReturn(List.of(
+        when(adminSiteService.getMatchsBySite(1L, null, null, null, null, null)).thenReturn(List.of(
                 new AdminSiteMatchSummaryDto(
                         100L,
                         LocalDate.of(2026, 5, 15),
@@ -112,7 +113,8 @@ class AdminSiteControllerSecurityTest {
                         MatchStatut.PLANIFIE,
                         2,
                         2,
-                        true
+                        true,
+                        false
                 )
         ));
 
@@ -123,7 +125,29 @@ class AdminSiteControllerSecurityTest {
                 .andExpect(jsonPath("$[0].terrainNom").value("Terrain A"))
                 .andExpect(jsonPath("$[0].organisateurMatricule").value("ORG001"))
                 .andExpect(jsonPath("$[0].statut").value("PLANIFIE"))
-                .andExpect(jsonPath("$[0].peutAnnuler").value(true));
+                .andExpect(jsonPath("$[0].peutAnnuler").value(true))
+                .andExpect(jsonPath("$[0].passe").value(false));
+    }
+
+    @Test
+    @WithMockUser(username = "adminGlobal", roles = {"ADMIN_GLOBAL"})
+    void matchsAdmin_auth_200_avec_filtres_historique() throws Exception {
+        when(adminSiteService.getMatchsBySite(
+                1L,
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 5, 31),
+                MatchStatut.ANNULE,
+                MatchVisibilite.PRIVE,
+                AdminMatchScope.HISTORY
+        )).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/admin/sites/1/matchs")
+                        .param("from", "2026-05-01")
+                        .param("to", "2026-05-31")
+                        .param("statut", "ANNULE")
+                        .param("visibilite", "PRIVE")
+                        .param("scope", "HISTORY"))
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/frontend/src/app/core/admin/admin.models.ts
+++ b/frontend/src/app/core/admin/admin.models.ts
@@ -98,6 +98,11 @@ export interface AdminSiteConsultationResponse {
   horaires: AdminSiteScheduleResponse[];
 }
 
+export type AdminMatchScope = 'UPCOMING_PLANNED' | 'HISTORY' | 'ALL';
+export type AdminMatchStateFilter = 'ALL' | 'UPCOMING' | 'PLAYED' | 'CANCELLED';
+export type AdminMatchStatusFilter = 'PLANIFIE' | 'ANNULE';
+export type AdminMatchVisibilityFilter = 'PUBLIC' | 'PRIVE';
+
 export interface AdminSiteMatchSummaryResponse {
   id: number;
   dateDebut: string;
@@ -113,6 +118,7 @@ export interface AdminSiteMatchSummaryResponse {
   nbParticipants: number;
   placesRestantes: number;
   peutAnnuler: boolean;
+  passe: boolean;
 }
 
 export interface AdminCaStatsResponse {

--- a/frontend/src/app/core/admin/admin.service.ts
+++ b/frontend/src/app/core/admin/admin.service.ts
@@ -10,6 +10,7 @@ import {
   AdminSitePlayerResponse,
   AdminSiteClosureResponse,
   AdminSiteConsultationResponse,
+  AdminMatchScope,
   AdminSiteMatchSummaryResponse,
   AdminSiteScheduleResponse,
   AdminMatchsStatsResponse,
@@ -49,9 +50,33 @@ export class AdminService {
     return this.http.get<AdminSiteConsultationResponse[]>(`${environment.apiBaseUrl}/admin/sites`);
   }
 
-  getSiteMatches(siteId: number): Observable<AdminSiteMatchSummaryResponse[]> {
+  getSiteMatches(siteId: number, filters?: {
+    from?: string;
+    to?: string;
+    statut?: string;
+    visibilite?: string;
+    scope?: AdminMatchScope;
+  }): Observable<AdminSiteMatchSummaryResponse[]> {
+    const params: Record<string, string> = {};
+    if (filters?.from) {
+      params['from'] = filters.from;
+    }
+    if (filters?.to) {
+      params['to'] = filters.to;
+    }
+    if (filters?.statut) {
+      params['statut'] = filters.statut;
+    }
+    if (filters?.visibilite) {
+      params['visibilite'] = filters.visibilite;
+    }
+    if (filters?.scope) {
+      params['scope'] = filters.scope;
+    }
+
     return this.http.get<AdminSiteMatchSummaryResponse[]>(
-      `${environment.apiBaseUrl}/admin/sites/${siteId}/matchs`
+      `${environment.apiBaseUrl}/admin/sites/${siteId}/matchs`,
+      { params }
     );
   }
 

--- a/frontend/src/app/features/admin/site-matches/admin-site-matches-page.component.css
+++ b/frontend/src/app/features/admin/site-matches/admin-site-matches-page.component.css
@@ -61,6 +61,76 @@
   color: #b91c1c;
 }
 
+.filters-panel {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
+  align-items: end;
+  padding: 1rem;
+  border: 1px solid #d7e0eb;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.06);
+}
+
+.filters-panel label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.filters-panel span {
+  color: #526277;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.filters-panel select,
+.filters-panel input {
+  min-height: 2.55rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid #c3d0de;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #10233f;
+  font: inherit;
+}
+
+.filters-panel select:disabled {
+  background: #f1f5f9;
+  color: #94a3b8;
+}
+
+.filter-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.6rem;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.filter-button {
+  min-height: 2.25rem;
+  padding: 0.42rem 0.8rem;
+  border: 1px solid #0f766e;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #0f766e;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  width: auto;
+}
+
+.filter-button.is-primary {
+  background: #0f766e;
+  color: #ffffff;
+}
+
+.filter-button:hover {
+  filter: brightness(0.97);
+}
+
 .matches-list {
   display: grid;
   gap: 1rem;
@@ -85,7 +155,7 @@
 }
 
 .match-date,
-.status-badge,
+.state-badge,
 .cancel-indicator {
   color: #526277;
   font-size: 0.86rem;
@@ -105,12 +175,37 @@
   color: #526277;
 }
 
-.status-badge {
+.match-badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.state-badge {
   padding: 0.3rem 0.55rem;
   border: 1px solid #c3d0de;
   border-radius: 999px;
   background: #f8fbff;
   color: #10233f;
+}
+
+.state-badge.is-cancelled {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.state-badge.is-upcoming {
+  border-color: #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.state-badge.is-played {
+  border-color: #e5e7eb;
+  background: #f3f4f6;
+  color: #374151;
 }
 
 .match-meta {
@@ -156,4 +251,34 @@
 
 .detail-link:hover {
   background: #ecfdf5;
+}
+
+@media (max-width: 900px) {
+  .filters-panel {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .filters-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .match-main,
+  .match-actions {
+    display: grid;
+  }
+
+  .match-badges {
+    justify-content: flex-start;
+  }
+
+  .filter-actions {
+    display: grid;
+  }
+
+  .filter-button,
+  .detail-link {
+    width: 100%;
+  }
 }

--- a/frontend/src/app/features/admin/site-matches/admin-site-matches-page.component.html
+++ b/frontend/src/app/features/admin/site-matches/admin-site-matches-page.component.html
@@ -3,15 +3,57 @@
     <p class="page-eyebrow">Administration</p>
     <button type="button" class="back-link" (click)="goBackToSites()">← Retour au détail du site</button>
     <h1>{{ pageTitle() }}</h1>
-    <p class="page-intro">Liste des matchs à venir encore planifiés pour ce site.</p>
+    <p class="page-intro">Consultez les matchs du site selon la période, l’état et la visibilité.</p>
   </header>
+
+  <section class="filters-panel" aria-label="Filtres des matchs">
+    <label>
+      <span>Du</span>
+      <input
+        type="date"
+        [value]="from()"
+        (change)="onFromChange($any($event.target).value)" />
+    </label>
+
+    <label>
+      <span>Au</span>
+      <input
+        type="date"
+        [value]="to()"
+        (change)="onToChange($any($event.target).value)" />
+    </label>
+
+    <label>
+      <span>État</span>
+      <select [value]="etat()" (change)="onStateChange($any($event.target).value)">
+        <option value="ALL">Tous</option>
+        <option value="UPCOMING">À venir</option>
+        <option value="PLAYED">Déjà joué</option>
+        <option value="CANCELLED">Annulé</option>
+      </select>
+    </label>
+
+    <label>
+      <span>Visibilité</span>
+      <select [value]="visibilite()" (change)="onVisibilityChange($any($event.target).value)">
+        <option value="">Toutes</option>
+        <option value="PUBLIC">Public</option>
+        <option value="PRIVE">Privé</option>
+      </select>
+    </label>
+
+    <div class="filter-actions">
+      <button type="button" class="filter-button is-primary" (click)="applyFilters()">Appliquer</button>
+      <button type="button" class="filter-button" (click)="resetFilters()">Réinitialiser</button>
+    </div>
+  </section>
 
   @if (isLoading()) {
     <p class="page-state">Chargement en cours...</p>
   } @else if (errorMessage()) {
     <p class="page-state is-error">{{ errorMessage() }}</p>
   } @else if (hasNoMatches()) {
-    <p class="page-state">Aucun match à venir planifié pour ce site.</p>
+    <p class="page-state">Aucun match ne correspond aux filtres sélectionnés.</p>
   } @else {
     <div class="matches-list">
       @for (match of matches(); track trackMatch(match)) {
@@ -22,7 +64,15 @@
               <h2>{{ match.terrainNom }}</h2>
               <p>{{ match.siteNom }}</p>
             </div>
-            <span class="status-badge">{{ getStatusLabel(match.statut) }}</span>
+            <div class="match-badges">
+              <span
+                class="state-badge"
+                [class.is-cancelled]="isCancelled(match)"
+                [class.is-played]="isPlayed(match)"
+                [class.is-upcoming]="isUpcoming(match)">
+                {{ getMatchStateLabel(match) }}
+              </span>
+            </div>
           </div>
 
           <dl class="match-meta">

--- a/frontend/src/app/features/admin/site-matches/admin-site-matches-page.component.ts
+++ b/frontend/src/app/features/admin/site-matches/admin-site-matches-page.component.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { finalize } from 'rxjs';
-import { AdminSiteMatchSummaryResponse } from '../../../core/admin/admin.models';
+import { AdminMatchScope, AdminMatchStateFilter, AdminSiteMatchSummaryResponse } from '../../../core/admin/admin.models';
 import { AdminService } from '../../../core/admin/admin.service';
 
 @Component({
@@ -22,7 +22,11 @@ export class AdminSiteMatchesPageComponent implements OnInit {
   protected readonly matches = signal<AdminSiteMatchSummaryResponse[]>([]);
   protected readonly isLoading = signal(true);
   protected readonly errorMessage = signal('');
-  protected readonly pageTitle = computed(() => 'Matchs planifiés du site');
+  protected readonly from = signal('');
+  protected readonly to = signal('');
+  protected readonly etat = signal<AdminMatchStateFilter>('ALL');
+  protected readonly visibilite = signal('');
+  protected readonly pageTitle = computed(() => 'Matchs du site');
 
   ngOnInit(): void {
     const idParam = this.route.snapshot.paramMap.get('siteId');
@@ -46,24 +50,45 @@ export class AdminSiteMatchesPageComponent implements OnInit {
     return match.id;
   }
 
+  protected onFromChange(value: string): void {
+    this.from.set(value);
+  }
+
+  protected onToChange(value: string): void {
+    this.to.set(value);
+  }
+
+  protected onStateChange(value: string): void {
+    this.etat.set(this.toStateFilter(value));
+  }
+
+  protected onVisibilityChange(value: string): void {
+    this.visibilite.set(value);
+  }
+
+  protected applyFilters(): void {
+    const siteId = this.siteId();
+    if (siteId == null) {
+      return;
+    }
+
+    this.loadMatches(siteId);
+  }
+
+  protected resetFilters(): void {
+    this.from.set('');
+    this.to.set('');
+    this.etat.set('ALL');
+    this.visibilite.set('');
+    this.applyFilters();
+  }
+
   protected formatTime(value: string): string {
     if (!value) {
       return 'Non renseigné';
     }
 
     return value.length >= 5 ? value.slice(0, 5) : value;
-  }
-
-  protected getStatusLabel(statut: string): string {
-    if (statut === 'PLANIFIE') {
-      return 'Planifié';
-    }
-
-    if (statut === 'ANNULE') {
-      return 'Annulé';
-    }
-
-    return statut;
   }
 
   protected getVisibilityLabel(visibilite: string): string {
@@ -78,6 +103,30 @@ export class AdminSiteMatchesPageComponent implements OnInit {
     return visibilite;
   }
 
+  protected getMatchStateLabel(match: AdminSiteMatchSummaryResponse): string {
+    if (match.statut === 'ANNULE') {
+      return 'Annulé';
+    }
+
+    if (this.isPastMatch(match)) {
+      return 'Déjà joué';
+    }
+
+    return 'À venir';
+  }
+
+  protected isCancelled(match: AdminSiteMatchSummaryResponse): boolean {
+    return match.statut === 'ANNULE';
+  }
+
+  protected isPlayed(match: AdminSiteMatchSummaryResponse): boolean {
+    return !this.isCancelled(match) && this.isPastMatch(match);
+  }
+
+  protected isUpcoming(match: AdminSiteMatchSummaryResponse): boolean {
+    return !this.isCancelled(match) && !this.isPastMatch(match);
+  }
+
   protected goBackToSites(): void {
     this.router.navigateByUrl('/admin/sites');
   }
@@ -85,9 +134,16 @@ export class AdminSiteMatchesPageComponent implements OnInit {
   private loadMatches(siteId: number): void {
     this.isLoading.set(true);
     this.errorMessage.set('');
+    const matchFilters = this.toBackendMatchFilters();
 
     this.adminService
-      .getSiteMatches(siteId)
+      .getSiteMatches(siteId, {
+        scope: matchFilters.scope,
+        from: this.from(),
+        to: this.to(),
+        statut: matchFilters.statut,
+        visibilite: this.visibilite()
+      })
       .pipe(finalize(() => this.isLoading.set(false)))
       .subscribe({
         next: (matches) => {
@@ -118,5 +174,48 @@ export class AdminSiteMatchesPageComponent implements OnInit {
     }
 
     return 'Impossible de charger les matchs du site.';
+  }
+
+  private toStateFilter(value: string): AdminMatchStateFilter {
+    if (value === 'UPCOMING' || value === 'PLAYED' || value === 'CANCELLED') {
+      return value;
+    }
+
+    return 'ALL';
+  }
+
+  private toBackendMatchFilters(): { scope: AdminMatchScope; statut: string } {
+    switch (this.etat()) {
+      case 'UPCOMING':
+        return { scope: 'UPCOMING_PLANNED', statut: '' };
+      case 'PLAYED':
+        return { scope: 'HISTORY', statut: 'PLANIFIE' };
+      case 'CANCELLED':
+        return { scope: 'ALL', statut: 'ANNULE' };
+      default:
+        return { scope: 'ALL', statut: '' };
+    }
+  }
+
+  private isPastMatch(match: AdminSiteMatchSummaryResponse): boolean {
+    const matchDate = this.toLocalMatchDate(match);
+    if (matchDate == null) {
+      return match.passe;
+    }
+
+    return matchDate.getTime() < Date.now();
+  }
+
+  private toLocalMatchDate(match: AdminSiteMatchSummaryResponse): Date | null {
+    const dateParts = match.dateDebut.split('-').map(Number);
+    const timeParts = (match.heureDebut || '00:00:00').split(':').map(Number);
+
+    if (dateParts.length < 3 || dateParts.some(Number.isNaN)) {
+      return null;
+    }
+
+    const [year, month, day] = dateParts;
+    const [hour = 0, minute = 0, second = 0] = timeParts;
+    return new Date(year, month - 1, day, hour, minute, second);
   }
 }

--- a/frontend/src/app/features/admin/sites/admin-sites-page.component.html
+++ b/frontend/src/app/features/admin/sites/admin-sites-page.component.html
@@ -24,7 +24,7 @@
             <div class="site-actions">
               <p>{{ site.ville }}</p>
               <a class="site-action-link" [routerLink]="['/admin/sites', site.id, 'matchs']">
-                Voir les matchs planifiés
+                Consulter les matchs
               </a>
             </div>
           </div>

--- a/frontend/src/app/features/admin/sites/admin-sites-page.component.ts
+++ b/frontend/src/app/features/admin/sites/admin-sites-page.component.ts
@@ -25,8 +25,8 @@ export class AdminSitesPageComponent implements OnInit {
   protected readonly pageTitle = computed(() => (this.isSingleSiteView() ? 'Détail du site' : 'Détail des sites'));
   protected readonly pageIntro = computed(() =>
     this.isSingleSiteView()
-      ? 'Consultez les informations du site : terrains, jours de fermeture, horaires et matchs planifiés.'
-      : 'Consultez les sites, leurs terrains, leurs jours de fermeture, leurs horaires et leurs matchs planifiés.'
+      ? 'Consultez les informations du site : terrains, jours de fermeture, horaires et matchs.'
+      : 'Consultez les informations des sites : terrains, jours de fermeture, horaires et matchs.'
   );
 
   private readonly dayLabels: Record<string, string> = {


### PR DESCRIPTION
- extension de la consultation admin des matchs d’un site ;
- support des filtres par période ;
- support du filtre par état logique : À venir, Déjà joué, Annulé ou Tous ;
- support du filtre par visibilité : Public, Privé ou Toutes ;
- maintien des règles d’autorisation :
  - ADMIN_GLOBAL peut consulter tous les sites ;
  - ADMIN_SITE peut consulter uniquement son site ;
- accès au détail d’un match via l’endpoint existant ;
- aucun nouveau statut métier ajouté.

Frontend :
- amélioration de la page /admin/sites/{siteId}/matchs ;
- simplification des filtres :
  - Du ;
  - Au ;
  - État ;
  - Visibilité ;
- affichage clair des états :
  - À venir ;
  - Déjà joué ;
  - Annulé ;
- accès au détail via le bouton “Voir détail” ;
- correction des libellés et messages utilisateur ;
- maintien d’une interface simple, sans refonte globale.

