### PR TITLE
Issue 187 - Ajout des tests unitaires frontend

### DIFF
--- a/frontend/src/app/core/admin/admin.service.spec.ts
+++ b/frontend/src/app/core/admin/admin.service.spec.ts
@@ -1,0 +1,113 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../../environments/environment';
+import {
+  AdminCaStatsResponse,
+  AdminInfoResponse,
+  AdminSiteMatchSummaryResponse,
+  AdminSiteScheduleResponse,
+  RegistrationDecisionResponse
+} from './admin.models';
+import { AdminService } from './admin.service';
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        AdminService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(AdminService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('loads admin info from the configured endpoint', () => {
+    const response = { status: 'OK', adminType: 'SITE', siteId: 2, siteNom: 'Padel Bruxelles' } as AdminInfoResponse;
+
+    service.getInfo().subscribe((info) => {
+      expect(info).toEqual(response);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/admin/info`);
+    expect(request.request.method).toBe('GET');
+    request.flush(response);
+  });
+
+  it('loads site matches with all supported filters', () => {
+    service.getSiteMatches(2, {
+      from: '2026-05-01',
+      to: '2026-05-31',
+      statut: 'PLANIFIE',
+      visibilite: 'PUBLIC',
+      scope: 'UPCOMING_PLANNED'
+    }).subscribe((matches) => {
+      expect(matches).toEqual([]);
+    });
+
+    const request = httpTesting.expectOne(
+      (req) => req.url === `${environment.apiBaseUrl}/admin/sites/2/matchs`
+    );
+    expect(request.request.method).toBe('GET');
+    expect(request.request.params.get('from')).toBe('2026-05-01');
+    expect(request.request.params.get('to')).toBe('2026-05-31');
+    expect(request.request.params.get('statut')).toBe('PLANIFIE');
+    expect(request.request.params.get('visibilite')).toBe('PUBLIC');
+    expect(request.request.params.get('scope')).toBe('UPCOMING_PLANNED');
+    request.flush([] as AdminSiteMatchSummaryResponse[]);
+  });
+
+  it('loads site revenue stats with date filters', () => {
+    const response = { caTotal: 1200, from: '2026-05-01', to: '2026-05-31' } as AdminCaStatsResponse;
+
+    service.getSiteCaStats(2, '2026-05-01', '2026-05-31').subscribe((stats) => {
+      expect(stats).toEqual(response);
+    });
+
+    const request = httpTesting.expectOne(
+      (req) => req.url === `${environment.apiBaseUrl}/admin/sites/2/stats/ca`
+    );
+    expect(request.request.method).toBe('GET');
+    expect(request.request.params.get('from')).toBe('2026-05-01');
+    expect(request.request.params.get('to')).toBe('2026-05-31');
+    request.flush(response);
+  });
+
+  it('creates a site schedule with the provided payload', () => {
+    const payload = { annee: 2026, heureOuverture: '08:00', heureFermeture: '22:00' };
+    const response = { id: 7, siteId: 2, ...payload } as AdminSiteScheduleResponse;
+
+    service.createSiteSchedule(2, payload).subscribe((schedule) => {
+      expect(schedule).toEqual(response);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/admin/sites/2/horaires`);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual(payload);
+    request.flush(response);
+  });
+
+  it('validates a registration request with the provided payload', () => {
+    const payload = { typeAbonnementFinal: 'SITE' as const, siteIdFinal: 2 };
+    const response = { userId: 5, status: 'VALIDATED' } as RegistrationDecisionResponse;
+
+    service.validateRegistration(5, payload).subscribe((decision) => {
+      expect(decision).toEqual(response);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/admin/inscriptions/5/validate`);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual(payload);
+    request.flush(response);
+  });
+});

--- a/frontend/src/app/core/auth/auth.guard.spec.ts
+++ b/frontend/src/app/core/auth/auth.guard.spec.ts
@@ -1,0 +1,45 @@
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree, provideRouter } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
+import { AuthService } from './auth.service';
+import { authGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  const authServiceMock = {
+    isAuthenticated: vi.fn()
+  };
+
+  function runGuard(url: string): boolean | UrlTree {
+    return TestBed.runInInjectionContext(() =>
+      authGuard({} as ActivatedRouteSnapshot, { url } as RouterStateSnapshot)
+    ) as boolean | UrlTree;
+  }
+
+  beforeEach(() => {
+    authServiceMock.isAuthenticated.mockReset();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authServiceMock }
+      ]
+    });
+  });
+
+  it('allows access when the user is authenticated', () => {
+    authServiceMock.isAuthenticated.mockReturnValue(true);
+
+    expect(runGuard('/matchs')).toBe(true);
+    expect(authServiceMock.isAuthenticated).toHaveBeenCalledOnce();
+  });
+
+  it('redirects to login with returnUrl when the user is not authenticated', () => {
+    authServiceMock.isAuthenticated.mockReturnValue(false);
+
+    const result = runGuard('/matchs/12');
+    const router = TestBed.inject(Router);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect((result as UrlTree).queryParams['returnUrl']).toBe('/matchs/12');
+    expect(router.serializeUrl(result as UrlTree).startsWith('/login')).toBe(true);
+  });
+});

--- a/frontend/src/app/core/auth/auth.service.spec.ts
+++ b/frontend/src/app/core/auth/auth.service.spec.ts
@@ -1,0 +1,150 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../../environments/environment';
+import { LoginResponse } from './auth.models';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpTesting: HttpTestingController;
+
+  const loginPayload = {
+    username: 'player@example.test',
+    password: 'secret'
+  };
+
+  const loginResponse: LoginResponse = {
+    token: 'jwt-token',
+    type: 'Bearer',
+    roles: ['ROLE_JOUEUR', 'ROLE_ADMIN_SITE'],
+    hasPlayerProfile: true
+  };
+
+  function configureTestingModule(): void {
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(AuthService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    httpTesting?.verify();
+    localStorage.clear();
+    TestBed.resetTestingModule();
+  });
+
+  it('starts unauthenticated when localStorage is empty', () => {
+    configureTestingModule();
+
+    expect(service.getToken()).toBeNull();
+    expect(service.isAuthenticated()).toBe(false);
+    expect(service.hasPlayerProfile()).toBe(false);
+    expect(service.isAdmin()).toBe(false);
+  });
+
+  it('calls the configured login endpoint and stores the session', () => {
+    configureTestingModule();
+
+    service.login(loginPayload).subscribe((response) => {
+      expect(response).toEqual(loginResponse);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/auth/login`);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual(loginPayload);
+
+    request.flush(loginResponse);
+
+    expect(localStorage.getItem('auth_token')).toBe('jwt-token');
+    expect(JSON.parse(localStorage.getItem('auth_context') ?? '{}')).toEqual({
+      roles: ['ROLE_JOUEUR', 'ROLE_ADMIN_SITE'],
+      hasPlayerProfile: true
+    });
+    expect(service.getToken()).toBe('jwt-token');
+    expect(service.isAuthenticated()).toBe(true);
+    expect(service.hasRole('ROLE_JOUEUR')).toBe(true);
+    expect(service.hasRole('ROLE_ADMIN_SITE')).toBe(true);
+    expect(service.hasRole('ROLE_ADMIN_GLOBAL')).toBe(false);
+    expect(service.hasPlayerProfile()).toBe(true);
+  });
+
+  it('filters unsupported roles from a login response before storing context', () => {
+    configureTestingModule();
+
+    service.login(loginPayload).subscribe();
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/auth/login`);
+    request.flush({
+      ...loginResponse,
+      roles: ['ROLE_JOUEUR', 'ROLE_INCONNU']
+    });
+
+    expect(JSON.parse(localStorage.getItem('auth_context') ?? '{}')).toEqual({
+      roles: ['ROLE_JOUEUR'],
+      hasPlayerProfile: true
+    });
+    expect(service.hasRole('ROLE_JOUEUR')).toBe(true);
+    expect(service.hasRole('ROLE_ADMIN_SITE')).toBe(false);
+  });
+
+  it('clears the stored session on logout', () => {
+    localStorage.setItem('auth_token', 'existing-token');
+    localStorage.setItem(
+      'auth_context',
+      JSON.stringify({ roles: ['ROLE_ADMIN_GLOBAL'], hasPlayerProfile: true })
+    );
+    configureTestingModule();
+
+    expect(service.isAuthenticated()).toBe(true);
+    expect(service.hasRole('ROLE_ADMIN_GLOBAL')).toBe(true);
+
+    service.logout();
+
+    expect(localStorage.getItem('auth_token')).toBeNull();
+    expect(localStorage.getItem('auth_context')).toBeNull();
+    expect(service.getToken()).toBeNull();
+    expect(service.isAuthenticated()).toBe(false);
+    expect(service.hasRole('ROLE_ADMIN_GLOBAL')).toBe(false);
+    expect(service.hasPlayerProfile()).toBe(false);
+  });
+
+  it('initializes authentication state from localStorage', () => {
+    localStorage.setItem('auth_token', 'stored-token');
+    localStorage.setItem(
+      'auth_context',
+      JSON.stringify({ roles: ['ROLE_ADMIN_GLOBAL'], hasPlayerProfile: false })
+    );
+
+    configureTestingModule();
+
+    expect(service.getToken()).toBe('stored-token');
+    expect(service.isAuthenticated()).toBe(true);
+    expect(service.hasRole('ROLE_ADMIN_GLOBAL')).toBe(true);
+    expect(service.isAdmin()).toBe(true);
+    expect(service.hasPlayerProfile()).toBe(false);
+  });
+
+  it('falls back to an empty auth context when localStorage context is invalid', () => {
+    localStorage.setItem('auth_token', 'stored-token');
+    localStorage.setItem('auth_context', '{invalid-json');
+
+    configureTestingModule();
+
+    expect(service.getToken()).toBe('stored-token');
+    expect(service.isAuthenticated()).toBe(true);
+    expect(service.hasRole('ROLE_JOUEUR')).toBe(false);
+    expect(service.isAdmin()).toBe(false);
+    expect(service.hasPlayerProfile()).toBe(false);
+  });
+});

--- a/frontend/src/app/core/auth/jwt.interceptor.spec.ts
+++ b/frontend/src/app/core/auth/jwt.interceptor.spec.ts
@@ -1,0 +1,53 @@
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { AuthService } from './auth.service';
+import { jwtInterceptor } from './jwt.interceptor';
+
+describe('jwtInterceptor', () => {
+  const authServiceMock = {
+    getToken: vi.fn()
+  };
+
+  let httpClient: HttpClient;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    authServiceMock.getToken.mockReset();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([jwtInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authServiceMock }
+      ]
+    });
+
+    httpClient = TestBed.inject(HttpClient);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('adds the Authorization header when a token is available', () => {
+    authServiceMock.getToken.mockReturnValue('jwt-token');
+
+    httpClient.get('/api/protected').subscribe();
+
+    const request = httpTesting.expectOne('/api/protected');
+    expect(request.request.headers.get('Authorization')).toBe('Bearer jwt-token');
+    request.flush({});
+  });
+
+  it('does not add the Authorization header when no token is available', () => {
+    authServiceMock.getToken.mockReturnValue(null);
+
+    httpClient.get('/api/public').subscribe();
+
+    const request = httpTesting.expectOne('/api/public');
+    expect(request.request.headers.has('Authorization')).toBe(false);
+    request.flush({});
+  });
+});

--- a/frontend/src/app/core/matches/match-creation.service.spec.ts
+++ b/frontend/src/app/core/matches/match-creation.service.spec.ts
@@ -1,0 +1,83 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../../environments/environment';
+import { CreateMatchPayload, CreatedMatch, MatchSlotsResponse } from './create-match.models';
+import { MatchCreationService } from './match-creation.service';
+
+describe('MatchCreationService', () => {
+  let service: MatchCreationService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MatchCreationService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(MatchCreationService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('posts the create match payload to the configured endpoint', () => {
+    const payload = {
+      terrainId: 12,
+      dateDebut: '2026-05-22T18:00:00',
+      visibilite: 'PUBLIC'
+    } satisfies CreateMatchPayload;
+    const response = {
+      id: 99,
+      terrainId: 12,
+      terrainNom: 'Terrain 1',
+      siteId: 2,
+      organisateurMatricule: 'J0001',
+      dateDebut: '2026-05-22T18:00:00',
+      visibilite: 'PUBLIC',
+      statut: 'PLANIFIE',
+      nbParticipants: 1,
+      montantTotal: 60,
+      montantPaye: 15,
+      resteAPayer: 45
+    } satisfies CreatedMatch;
+
+    service.createMatch(payload).subscribe((createdMatch) => {
+      expect(createdMatch).toEqual(response);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/matchs`);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual(payload);
+    request.flush(response);
+  });
+
+  it('loads available slots with terrain and date query parameters', () => {
+    const response = {
+      creneaux: [],
+      message: null,
+      annee: 2026,
+      heureOuverture: '08:00',
+      heureFermeture: '22:00',
+      dureeMatchMinutes: 90,
+      bufferMinutes: 15
+    } satisfies MatchSlotsResponse;
+
+    service.getCreneaux(12, '2026-05-22').subscribe((slots) => {
+      expect(slots).toEqual(response);
+    });
+
+    const request = httpTesting.expectOne(
+      (req) => req.url === `${environment.apiBaseUrl}/matchs/creneaux`
+    );
+    expect(request.request.method).toBe('GET');
+    expect(request.request.params.get('terrainId')).toBe('12');
+    expect(request.request.params.get('date')).toBe('2026-05-22');
+    request.flush(response);
+  });
+});

--- a/frontend/src/app/core/matches/match-detail.service.spec.ts
+++ b/frontend/src/app/core/matches/match-detail.service.spec.ts
@@ -1,0 +1,51 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../../environments/environment';
+import { MatchDetail } from './match-detail.models';
+import { MatchDetailService } from './match-detail.service';
+
+describe('MatchDetailService', () => {
+  let service: MatchDetailService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MatchDetailService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(MatchDetailService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('loads a match detail by id', () => {
+    const response = { id: 42 } as MatchDetail;
+
+    service.getMatchDetail(42).subscribe((match) => {
+      expect(match).toEqual(response);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/matchs/42`);
+    expect(request.request.method).toBe('GET');
+    request.flush(response);
+  });
+
+  it('posts match cancellation with a null body', () => {
+    service.cancelMatch(42).subscribe((response) => {
+      expect(response).toBeNull();
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/matchs/42/annulation`);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toBeNull();
+    request.flush(null);
+  });
+});

--- a/frontend/src/app/core/matches/organized-matches.service.spec.ts
+++ b/frontend/src/app/core/matches/organized-matches.service.spec.ts
@@ -1,0 +1,37 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../../environments/environment';
+import { OrganizedMatchesService } from './organized-matches.service';
+
+describe('OrganizedMatchesService', () => {
+  let service: OrganizedMatchesService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OrganizedMatchesService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(OrganizedMatchesService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('loads matches organized by the current player', () => {
+    service.getMyOrganizedMatches().subscribe((matches) => {
+      expect(matches).toEqual([]);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/me/matchs/organises`);
+    expect(request.request.method).toBe('GET');
+    request.flush([]);
+  });
+});

--- a/frontend/src/app/core/matches/player-matches.service.spec.ts
+++ b/frontend/src/app/core/matches/player-matches.service.spec.ts
@@ -1,0 +1,37 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../../environments/environment';
+import { PlayerMatchesService } from './player-matches.service';
+
+describe('PlayerMatchesService', () => {
+  let service: PlayerMatchesService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PlayerMatchesService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(PlayerMatchesService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('loads matches linked to the current player', () => {
+    service.getMyMatches().subscribe((matches) => {
+      expect(matches).toEqual([]);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/me/matchs`);
+    expect(request.request.method).toBe('GET');
+    request.flush([]);
+  });
+});

--- a/frontend/src/app/core/matches/public-matches.service.spec.ts
+++ b/frontend/src/app/core/matches/public-matches.service.spec.ts
@@ -1,0 +1,51 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../../environments/environment';
+import { PublicMatchesService } from './public-matches.service';
+
+describe('PublicMatchesService', () => {
+  let service: PublicMatchesService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PublicMatchesService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(PublicMatchesService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('loads public matches from the configured endpoint without filters', () => {
+    service.getPublicMatches().subscribe((matches) => {
+      expect(matches).toEqual([]);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/matchs/public`);
+    expect(request.request.method).toBe('GET');
+    expect(request.request.params.keys()).toEqual([]);
+    request.flush([]);
+  });
+
+  it('sends date and site filters as query parameters', () => {
+    service.getPublicMatches({ from: '2026-05-01', to: '2026-05-31', siteId: 3 }).subscribe();
+
+    const request = httpTesting.expectOne(
+      (req) => req.url === `${environment.apiBaseUrl}/matchs/public`
+    );
+    expect(request.request.method).toBe('GET');
+    expect(request.request.params.get('from')).toBe('2026-05-01');
+    expect(request.request.params.get('to')).toBe('2026-05-31');
+    expect(request.request.params.get('siteId')).toBe('3');
+    request.flush([]);
+  });
+});

--- a/frontend/src/app/shared/date/belgian-date-formats.spec.ts
+++ b/frontend/src/app/shared/date/belgian-date-formats.spec.ts
@@ -1,0 +1,64 @@
+import {
+  BELGIAN_DATE_FORMATS,
+  formatDateForApi,
+  parseApiDateForPicker
+} from './belgian-date-formats';
+
+describe('belgian-date-formats', () => {
+  it('exposes Belgian parse and display date formats', () => {
+    expect(BELGIAN_DATE_FORMATS.parse.dateInput).toEqual({
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    });
+    expect(BELGIAN_DATE_FORMATS.display.dateInput).toEqual({
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    });
+    expect(BELGIAN_DATE_FORMATS.display.monthYearLabel).toEqual({
+      month: 'long',
+      year: 'numeric'
+    });
+    expect(BELGIAN_DATE_FORMATS.display.dateA11yLabel).toEqual({
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric'
+    });
+    expect(BELGIAN_DATE_FORMATS.display.monthYearA11yLabel).toEqual({
+      month: 'long',
+      year: 'numeric'
+    });
+  });
+
+  describe('formatDateForApi', () => {
+    it('returns an empty string for empty values', () => {
+      expect(formatDateForApi(null)).toBe('');
+      expect(formatDateForApi(undefined)).toBe('');
+    });
+
+    it('keeps an already formatted string unchanged', () => {
+      expect(formatDateForApi('2026-05-09')).toBe('2026-05-09');
+    });
+
+    it('formats a Date as yyyy-MM-dd', () => {
+      expect(formatDateForApi(new Date(2026, 4, 9))).toBe('2026-05-09');
+    });
+  });
+
+  describe('parseApiDateForPicker', () => {
+    it('returns null for empty or invalid values', () => {
+      expect(parseApiDateForPicker('')).toBeNull();
+      expect(parseApiDateForPicker('date-invalide')).toBeNull();
+    });
+
+    it('parses an API date as a local Date', () => {
+      const result = parseApiDateForPicker('2026-05-09');
+
+      expect(result).toBeInstanceOf(Date);
+      expect(result?.getFullYear()).toBe(2026);
+      expect(result?.getMonth()).toBe(4);
+      expect(result?.getDate()).toBe(9);
+    });
+  });
+});

--- a/frontend/src/app/shared/matches/match-status.utils.spec.ts
+++ b/frontend/src/app/shared/matches/match-status.utils.spec.ts
@@ -1,0 +1,141 @@
+import {
+  getAvailabilityClassName,
+  getAvailabilityLabel,
+  getMatchStatusClassMap,
+  getSecondaryMatchBadge,
+  getTemporalStatusClassName,
+  getTemporalStatusLabel,
+  getUserMatchRoleClassName,
+  getUserMatchRoleLabel,
+  isTerminalMatchStatus
+} from './match-status.utils';
+
+describe('match-status.utils', () => {
+  describe('getTemporalStatusLabel', () => {
+    it('returns the cancelled label first', () => {
+      expect(getTemporalStatusLabel({ statut: 'ANNULE', statutTemporel: 'FUTUR' })).toBe('Annulé');
+    });
+
+    it('returns the past label from the temporal status', () => {
+      expect(getTemporalStatusLabel({ statut: 'PLANIFIE', statutTemporel: 'PASSE' })).toBe('Déjà joué');
+    });
+
+    it('returns the today label from the temporal status', () => {
+      expect(getTemporalStatusLabel({ statut: 'PLANIFIE', statutTemporel: 'AUJOURD_HUI' })).toBe('Aujourd’hui');
+    });
+
+    it('returns the future label from the temporal status', () => {
+      expect(getTemporalStatusLabel({ statut: 'PLANIFIE', statutTemporel: 'FUTUR' })).toBe('À venir');
+    });
+
+    it('falls back to the future label when no supported status is available', () => {
+      expect(getTemporalStatusLabel({ statut: 'INCONNU' })).toBe('À venir');
+    });
+  });
+
+  describe('status classes', () => {
+    it('returns the cancelled class', () => {
+      expect(getTemporalStatusClassName({ statut: 'ANNULE' })).toBe('is-cancelled');
+    });
+
+    it('returns the past class', () => {
+      expect(getTemporalStatusClassName({ statutTemporel: 'PASSE' })).toBe('temporal-passe');
+    });
+
+    it('returns the today class', () => {
+      expect(getTemporalStatusClassName({ statutTemporel: 'AUJOURD_HUI' })).toBe('temporal-aujourd_hui');
+    });
+
+    it('returns the future class', () => {
+      expect(getTemporalStatusClassName({ statutTemporel: 'FUTUR' })).toBe('temporal-futur');
+    });
+
+    it('builds an exclusive class map', () => {
+      expect(getMatchStatusClassMap({ statutTemporel: 'AUJOURD_HUI' })).toEqual({
+        'is-cancelled': false,
+        'temporal-passe': false,
+        'temporal-aujourd_hui': true,
+        'temporal-futur': false
+      });
+    });
+  });
+
+  describe('user role labels and classes', () => {
+    it('maps organizer role display', () => {
+      expect(getUserMatchRoleLabel('ORGANISATEUR')).toBe('Organisateur');
+      expect(getUserMatchRoleClassName('ORGANISATEUR')).toBe('is-organizer');
+    });
+
+    it('maps participant role display', () => {
+      expect(getUserMatchRoleLabel('PARTICIPANT')).toBe('Déjà inscrit');
+      expect(getUserMatchRoleClassName('PARTICIPANT')).toBe('is-registered');
+    });
+
+    it('returns empty display for missing role', () => {
+      expect(getUserMatchRoleLabel(null)).toBe('');
+      expect(getUserMatchRoleClassName(undefined)).toBe('');
+    });
+  });
+
+  describe('availability display', () => {
+    it('maps a full match', () => {
+      expect(getAvailabilityLabel({ complet: true })).toBe('Complet');
+      expect(getAvailabilityClassName({ complet: true })).toBe('is-full');
+    });
+
+    it('maps an open match', () => {
+      expect(getAvailabilityLabel({ complet: false })).toBe('Places disponibles');
+      expect(getAvailabilityClassName({ complet: false })).toBe('is-open');
+    });
+  });
+
+  describe('getSecondaryMatchBadge', () => {
+    it('prioritizes the organizer badge on an active match', () => {
+      expect(getSecondaryMatchBadge({ statutTemporel: 'FUTUR', complet: false }, 'ORGANISATEUR')).toEqual({
+        label: 'Organisateur',
+        className: 'is-organizer'
+      });
+    });
+
+    it('prioritizes the participant badge on an active match', () => {
+      expect(getSecondaryMatchBadge({ statutTemporel: 'AUJOURD_HUI', complet: false }, 'PARTICIPANT')).toEqual({
+        label: 'Déjà inscrit',
+        className: 'is-registered'
+      });
+    });
+
+    it('uses availability when there is no user role', () => {
+      expect(getSecondaryMatchBadge({ statutTemporel: 'FUTUR', complet: false }, null)).toEqual({
+        label: 'Places disponibles',
+        className: 'is-open'
+      });
+      expect(getSecondaryMatchBadge({ statutTemporel: 'FUTUR', complet: true }, undefined)).toEqual({
+        label: 'Complet',
+        className: 'is-full'
+      });
+    });
+
+    it('does not return a secondary badge for cancelled or past matches', () => {
+      expect(getSecondaryMatchBadge({ statut: 'ANNULE', complet: false }, 'PARTICIPANT')).toEqual({
+        label: '',
+        className: ''
+      });
+      expect(getSecondaryMatchBadge({ statutTemporel: 'PASSE', complet: false }, 'ORGANISATEUR')).toEqual({
+        label: '',
+        className: ''
+      });
+    });
+  });
+
+  describe('isTerminalMatchStatus', () => {
+    it('detects cancelled and past matches as terminal', () => {
+      expect(isTerminalMatchStatus({ statut: 'ANNULE' })).toBe(true);
+      expect(isTerminalMatchStatus({ statutTemporel: 'PASSE' })).toBe(true);
+    });
+
+    it('does not treat future or today matches as terminal', () => {
+      expect(isTerminalMatchStatus({ statutTemporel: 'FUTUR' })).toBe(false);
+      expect(isTerminalMatchStatus({ statutTemporel: 'AUJOURD_HUI' })).toBe(false);
+    });
+  });
+});

--- a/frontend/src/app/shared/ui/page-header/page-header.component.spec.ts
+++ b/frontend/src/app/shared/ui/page-header/page-header.component.spec.ts
@@ -1,0 +1,55 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { PageHeaderComponent } from './page-header.component';
+
+describe('PageHeaderComponent', () => {
+  let fixture: ComponentFixture<PageHeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PageHeaderComponent],
+      providers: [provideRouter([])]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PageHeaderComponent);
+    fixture.componentRef.setInput('eyebrow', 'Matchs');
+    fixture.componentRef.setInput('title', 'Détail du match');
+  });
+
+  it('renders the eyebrow, title and optional description', () => {
+    fixture.componentRef.setInput('description', 'Consultez les informations du match.');
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelector('.eyebrow')?.textContent?.trim()).toBe('Matchs');
+    expect(element.querySelector('h1')?.textContent?.trim()).toBe('Détail du match');
+    expect(element.querySelector('.page-intro')?.textContent?.trim()).toBe('Consultez les informations du match.');
+  });
+
+  it('renders a router back link when backLink is provided', () => {
+    fixture.componentRef.setInput('backLink', '/matchs');
+    fixture.componentRef.setInput('backLabel', 'Retour aux matchs');
+    fixture.detectChanges();
+
+    const backLink = fixture.nativeElement.querySelector('.back-link') as HTMLAnchorElement | null;
+
+    expect(backLink?.tagName).toBe('A');
+    expect(backLink?.getAttribute('href')).toBe('/matchs');
+    expect(backLink?.textContent?.trim()).toContain('Retour aux matchs');
+  });
+
+  it('emits backClick when configured as a button', () => {
+    const emitSpy = vi.fn();
+    fixture.componentRef.setInput('backButton', true);
+    fixture.componentRef.setInput('backLabel', 'Retour');
+    fixture.componentInstance.backClick.subscribe(emitSpy);
+    fixture.detectChanges();
+
+    const backButton = fixture.nativeElement.querySelector('.back-link') as HTMLButtonElement | null;
+    backButton?.click();
+
+    expect(backButton?.tagName).toBe('BUTTON');
+    expect(emitSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/app/shared/ui/page-state/page-state.component.spec.ts
+++ b/frontend/src/app/shared/ui/page-state/page-state.component.spec.ts
@@ -1,0 +1,44 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PageStateComponent } from './page-state.component';
+
+describe('PageStateComponent', () => {
+  let fixture: ComponentFixture<PageStateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PageStateComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PageStateComponent);
+  });
+
+  it('renders the provided message', () => {
+    fixture.componentRef.setInput('message', 'Aucun match à afficher.');
+    fixture.componentRef.setInput('type', 'empty');
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Aucun match à afficher.');
+  });
+
+  it('sets alert role for error states', () => {
+    fixture.componentRef.setInput('message', 'Impossible de charger les données.');
+    fixture.componentRef.setInput('type', 'error');
+    fixture.detectChanges();
+
+    const state = fixture.nativeElement.querySelector('.page-state') as HTMLElement | null;
+
+    expect(state?.getAttribute('role')).toBe('alert');
+    expect(state?.classList.contains('is-error')).toBe(true);
+  });
+
+  it('renders a spinner and message for loading states', () => {
+    fixture.componentRef.setInput('message', 'Chargement...');
+    fixture.componentRef.setInput('type', 'loading');
+    fixture.detectChanges();
+
+    const spinner = fixture.nativeElement.querySelector('mat-spinner');
+
+    expect(spinner).not.toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('Chargement...');
+  });
+});

--- a/frontend/src/app/shared/ui/ui-feedback.service.spec.ts
+++ b/frontend/src/app/shared/ui/ui-feedback.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { UiFeedbackService } from './ui-feedback.service';
+
+describe('UiFeedbackService', () => {
+  const snackBarMock = {
+    open: vi.fn()
+  };
+
+  let service: UiFeedbackService;
+
+  beforeEach(() => {
+    snackBarMock.open.mockClear();
+
+    TestBed.configureTestingModule({
+      providers: [
+        UiFeedbackService,
+        { provide: MatSnackBar, useValue: snackBarMock }
+      ]
+    });
+
+    service = TestBed.inject(UiFeedbackService);
+  });
+
+  it('shows a success message through MatSnackBar', () => {
+    service.showSuccess('Match créé.');
+
+    expect(snackBarMock.open).toHaveBeenCalledWith('Match créé.', 'OK', { duration: 3500 });
+  });
+
+  it('shows an error message through MatSnackBar', () => {
+    service.showError('Impossible de charger les données.');
+
+    expect(snackBarMock.open).toHaveBeenCalledWith('Impossible de charger les données.', 'OK', {
+      duration: 3500
+    });
+  });
+
+  it('shows an info message through MatSnackBar', () => {
+    service.showInfo('Chargement en cours.');
+
+    expect(snackBarMock.open).toHaveBeenCalledWith('Chargement en cours.', 'OK', {
+      duration: 3500
+    });
+  });
+});


### PR DESCRIPTION
Éléments testés :
- helpers d’affichage des statuts de matchs ;
- formats de date belges ;
- service de feedback utilisateur ;
- AuthService, AuthGuard et jwtInterceptor ;
- services API admin et matchs ;
- composants partagés PageHeaderComponent et PageStateComponent.

Validation :
- 15 fichiers de tests passent ;
- 60 tests passent ;
- build Angular OK ;
