### PR TITLE
Issue 188 - Ajout des tests d'intégration frontend

### DIFF
--- a/frontend/src/app/features/admin/site-matches/admin-site-matches-page.component.spec.ts
+++ b/frontend/src/app/features/admin/site-matches/admin-site-matches-page.component.spec.ts
@@ -1,0 +1,134 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AdminSiteMatchSummaryResponse } from '../../../core/admin/admin.models';
+import { AdminService } from '../../../core/admin/admin.service';
+import { AdminSiteMatchesPageComponent } from './admin-site-matches-page.component';
+
+describe('AdminSiteMatchesPageComponent integration', () => {
+  let fixture: ComponentFixture<AdminSiteMatchesPageComponent>;
+  let adminService: { getSiteMatches: ReturnType<typeof vi.fn> };
+  let router: { navigateByUrl: ReturnType<typeof vi.fn> };
+  let routeSiteId = '7';
+
+  const siteMatch: AdminSiteMatchSummaryResponse = {
+    id: 31,
+    dateDebut: '2099-07-15',
+    heureDebut: '20:00:00',
+    siteId: 7,
+    siteNom: 'Padel Namur',
+    terrainId: 30,
+    terrainNom: 'Terrain Admin',
+    organisateurMatricule: 'J0099',
+    organisateurNom: 'Admin Joueur',
+    visibilite: 'PUBLIC',
+    statut: 'PLANIFIE',
+    nbParticipants: 3,
+    placesRestantes: 1,
+    peutAnnuler: true,
+    passe: false
+  };
+
+  beforeEach(async () => {
+    adminService = { getSiteMatches: vi.fn() };
+    router = { navigateByUrl: vi.fn() };
+    routeSiteId = '7';
+
+    await TestBed.configureTestingModule({
+      imports: [AdminSiteMatchesPageComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useFactory: () => ({
+            snapshot: {
+              paramMap: convertToParamMap({ siteId: routeSiteId })
+            }
+          })
+        },
+        { provide: AdminService, useValue: adminService },
+        { provide: Router, useValue: router }
+      ]
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads matches for the site id from the route and renders the list', () => {
+    adminService.getSiteMatches.mockReturnValue(of([siteMatch]));
+
+    createPage();
+
+    expect(adminService.getSiteMatches).toHaveBeenCalledWith(7, {
+      scope: 'ALL',
+      from: '',
+      to: '',
+      statut: '',
+      visibilite: ''
+    });
+    expect(pageText()).toContain('Padel Namur');
+    expect(pageText()).toContain('Terrain Admin');
+    expect(pageText()).toContain('Admin Joueur');
+    expect(pageText()).toContain('Voir détail');
+  });
+
+  it('renders the empty state when no site match matches the filters', () => {
+    adminService.getSiteMatches.mockReturnValue(of([]));
+
+    createPage();
+
+    expect(pageText()).toContain('Aucun match ne correspond aux filtres sélectionnés.');
+  });
+
+  it('renders an error and does not call the service when the route site id is invalid', () => {
+    routeSiteId = 'invalid';
+    adminService.getSiteMatches.mockReturnValue(of([siteMatch]));
+
+    createPage();
+
+    expect(adminService.getSiteMatches).not.toHaveBeenCalled();
+    expect(pageText()).toContain('Identifiant de site invalide.');
+  });
+
+  it('reloads matches with the selected filters', () => {
+    adminService.getSiteMatches.mockReturnValue(of([siteMatch]));
+    createPage();
+    adminService.getSiteMatches.mockClear();
+
+    const dateInputs = fixture.nativeElement.querySelectorAll('input[type="date"]') as NodeListOf<HTMLInputElement>;
+    dateInputs[0].value = '2099-07-01';
+    dateInputs[0].dispatchEvent(new Event('change', { bubbles: true }));
+    dateInputs[1].value = '2099-07-31';
+    dateInputs[1].dispatchEvent(new Event('change', { bubbles: true }));
+
+    const selects = fixture.nativeElement.querySelectorAll('select') as NodeListOf<HTMLSelectElement>;
+    selects[0].value = 'UPCOMING';
+    selects[0].dispatchEvent(new Event('change', { bubbles: true }));
+    selects[1].value = 'PUBLIC';
+    selects[1].dispatchEvent(new Event('change', { bubbles: true }));
+
+    const applyButton = fixture.nativeElement.querySelector('.filter-button.is-primary') as HTMLButtonElement;
+    applyButton.click();
+    fixture.detectChanges();
+
+    expect(adminService.getSiteMatches).toHaveBeenCalledWith(7, {
+      scope: 'UPCOMING_PLANNED',
+      from: '2099-07-01',
+      to: '2099-07-31',
+      statut: '',
+      visibilite: 'PUBLIC'
+    });
+  });
+
+  function createPage(): void {
+    fixture = TestBed.createComponent(AdminSiteMatchesPageComponent);
+    fixture.detectChanges();
+  }
+
+  function pageText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+});

--- a/frontend/src/app/features/admin/statistiques/admin-statistics-page.component.spec.ts
+++ b/frontend/src/app/features/admin/statistiques/admin-statistics-page.component.spec.ts
@@ -1,0 +1,167 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import {
+  AdminCaStatsResponse,
+  AdminDettesStatsResponse,
+  AdminInfoResponse,
+  AdminMatchsStatsResponse
+} from '../../../core/admin/admin.models';
+import { AdminService } from '../../../core/admin/admin.service';
+import { SiteOption } from '../../../core/sites/site.models';
+import { SitesService } from '../../../core/sites/sites.service';
+import { AdminStatisticsPageComponent } from './admin-statistics-page.component';
+
+describe('AdminStatisticsPageComponent integration', () => {
+  let fixture: ComponentFixture<AdminStatisticsPageComponent>;
+  let adminService: {
+    getInfo: ReturnType<typeof vi.fn>;
+    getGlobalCaStats: ReturnType<typeof vi.fn>;
+    getGlobalMatchsStats: ReturnType<typeof vi.fn>;
+    getGlobalDettesStats: ReturnType<typeof vi.fn>;
+    getSiteCaStats: ReturnType<typeof vi.fn>;
+    getSiteMatchsStats: ReturnType<typeof vi.fn>;
+    getSiteDettesStats: ReturnType<typeof vi.fn>;
+  };
+  let sitesService: { getSites: ReturnType<typeof vi.fn> };
+
+  const globalInfo: AdminInfoResponse = {
+    status: 'ok',
+    adminType: 'GLOBAL',
+    siteId: null,
+    siteNom: null
+  };
+  const siteInfo: AdminInfoResponse = {
+    status: 'ok',
+    adminType: 'SITE',
+    siteId: 2,
+    siteNom: 'Padel Liège'
+  };
+  const sites: SiteOption[] = [
+    { id: 2, nom: 'Padel Liège', ville: 'Liège', joursFermeture: [] }
+  ];
+  const caStats: AdminCaStatsResponse = { caTotal: 1200, from: '2099-05-01', to: '2099-05-31' };
+  const matchsStats: AdminMatchsStatsResponse = { nbMatchs: 8, from: '2099-05-01', to: '2099-05-31' };
+  const dettesStats: AdminDettesStatsResponse = { detteTotale: 45, nbJoueursEnDette: 2 };
+
+  beforeEach(async () => {
+    adminService = {
+      getInfo: vi.fn(),
+      getGlobalCaStats: vi.fn(),
+      getGlobalMatchsStats: vi.fn(),
+      getGlobalDettesStats: vi.fn(),
+      getSiteCaStats: vi.fn(),
+      getSiteMatchsStats: vi.fn(),
+      getSiteDettesStats: vi.fn()
+    };
+    sitesService = { getSites: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [AdminStatisticsPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AdminService, useValue: adminService },
+        { provide: SitesService, useValue: sitesService }
+      ]
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads and renders global statistics for a global admin', () => {
+    arrangeGlobalAdmin();
+
+    createPage();
+
+    expect(sitesService.getSites).toHaveBeenCalled();
+    expect(adminService.getGlobalCaStats).toHaveBeenCalled();
+    expect(adminService.getGlobalMatchsStats).toHaveBeenCalled();
+    expect(adminService.getGlobalDettesStats).toHaveBeenCalled();
+    expect(pageText()).toContain('Tous les sites');
+    expect(pageText()).toContain('1');
+    expect(pageText()).toContain('200');
+    expect(pageText()).toContain('8');
+  });
+
+  it('loads and renders site statistics for a site admin', () => {
+    adminService.getInfo.mockReturnValue(of(siteInfo));
+    arrangeSiteStats();
+
+    createPage();
+
+    expect(sitesService.getSites).not.toHaveBeenCalled();
+    expect(adminService.getSiteCaStats).toHaveBeenCalledWith(2, expect.any(String), expect.any(String));
+    expect(adminService.getSiteMatchsStats).toHaveBeenCalledWith(2, expect.any(String), expect.any(String));
+    expect(adminService.getSiteDettesStats).toHaveBeenCalledWith(2);
+    expect(pageText()).toContain('Padel Liège');
+    expect(pageText()).toContain('Joueurs en dette');
+  });
+
+  it('shows a validation error and does not reload stats when the period is invalid', () => {
+    arrangeGlobalAdmin();
+    createPage();
+    vi.clearAllMocks();
+
+    const form = getComponentForm();
+    form.controls.from.setValue('2099-06-01');
+    form.controls.to.setValue('2099-05-01');
+    submitForm();
+
+    expect(pageText()).toContain('La date de');
+    expect(adminService.getGlobalCaStats).not.toHaveBeenCalled();
+    expect(adminService.getSiteCaStats).not.toHaveBeenCalled();
+  });
+
+  it('renders an error state when statistics loading fails', () => {
+    adminService.getInfo.mockReturnValue(of(globalInfo));
+    sitesService.getSites.mockReturnValue(of(sites));
+    adminService.getGlobalCaStats.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 }))
+    );
+    adminService.getGlobalMatchsStats.mockReturnValue(of(matchsStats));
+    adminService.getGlobalDettesStats.mockReturnValue(of(dettesStats));
+
+    createPage();
+
+    expect(pageText()).toContain('Impossible de charger les statistiques.');
+  });
+
+  function arrangeGlobalAdmin(): void {
+    adminService.getInfo.mockReturnValue(of(globalInfo));
+    sitesService.getSites.mockReturnValue(of(sites));
+    adminService.getGlobalCaStats.mockReturnValue(of(caStats));
+    adminService.getGlobalMatchsStats.mockReturnValue(of(matchsStats));
+    adminService.getGlobalDettesStats.mockReturnValue(of(dettesStats));
+    arrangeSiteStats();
+  }
+
+  function arrangeSiteStats(): void {
+    adminService.getSiteCaStats.mockReturnValue(of(caStats));
+    adminService.getSiteMatchsStats.mockReturnValue(of(matchsStats));
+    adminService.getSiteDettesStats.mockReturnValue(of(dettesStats));
+  }
+
+  function createPage(): void {
+    fixture = TestBed.createComponent(AdminStatisticsPageComponent);
+    fixture.detectChanges();
+  }
+
+  function getComponentForm() {
+    return (fixture.componentInstance as unknown as {
+      periodForm: AdminStatisticsPageComponent['periodForm'];
+    }).periodForm;
+  }
+
+  function submitForm(): void {
+    const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    fixture.detectChanges();
+  }
+
+  function pageText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+});

--- a/frontend/src/app/features/auth/login/login-page.component.spec.ts
+++ b/frontend/src/app/features/auth/login/login-page.component.spec.ts
@@ -1,0 +1,110 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AuthService } from '../../../core/auth/auth.service';
+import { LoginPageComponent } from './login-page.component';
+
+describe('LoginPageComponent integration', () => {
+  let fixture: ComponentFixture<LoginPageComponent>;
+  let authService: {
+    login: ReturnType<typeof vi.fn>;
+    isAdmin: ReturnType<typeof vi.fn>;
+    hasPlayerProfile: ReturnType<typeof vi.fn>;
+  };
+  let router: {
+    navigateByUrl: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    authService = {
+      login: vi.fn(),
+      isAdmin: vi.fn(),
+      hasPlayerProfile: vi.fn()
+    };
+    router = {
+      navigateByUrl: vi.fn()
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [LoginPageComponent],
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: Router, useValue: router }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPageComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not call login when the form is invalid', () => {
+    const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    fixture.detectChanges();
+
+    expect(authService.login).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain("L'identifiant est obligatoire.");
+    expect(fixture.nativeElement.textContent).toContain('Le mot de passe est obligatoire.');
+  });
+
+  it('calls AuthService and navigates to the player area after a player login', () => {
+    authService.login.mockReturnValue(of({ token: 'jwt', type: 'Bearer', roles: ['ROLE_JOUEUR'], hasPlayerProfile: true }));
+    authService.isAdmin.mockReturnValue(false);
+    authService.hasPlayerProfile.mockReturnValue(true);
+    setFormValue({ username: 'joueur@example.test', password: 'secret' });
+
+    submitForm();
+
+    expect(authService.login).toHaveBeenCalledWith({
+      username: 'joueur@example.test',
+      password: 'secret'
+    });
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/espace-prive');
+  });
+
+  it('navigates to the admin area after an admin login', () => {
+    authService.login.mockReturnValue(of({ token: 'jwt', type: 'Bearer', roles: ['ROLE_ADMIN_GLOBAL'], hasPlayerProfile: false }));
+    authService.isAdmin.mockReturnValue(true);
+    authService.hasPlayerProfile.mockReturnValue(false);
+    setFormValue({ username: 'admin@example.test', password: 'secret' });
+
+    submitForm();
+
+    expect(authService.login).toHaveBeenCalledWith({
+      username: 'admin@example.test',
+      password: 'secret'
+    });
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/admin');
+  });
+
+  it('shows the authentication error message when login fails', () => {
+    authService.login.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 401, error: { message: 'Unauthorized' } }))
+    );
+    setFormValue({ username: 'joueur@example.test', password: 'wrong' });
+
+    submitForm();
+
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('Identifiant ou mot de passe invalide.');
+  });
+
+  function setFormValue(value: { username: string; password: string }): void {
+    (fixture.componentInstance as unknown as {
+      form: { setValue: (formValue: { username: string; password: string }) => void };
+    }).form.setValue(value);
+    fixture.detectChanges();
+  }
+
+  function submitForm(): void {
+    const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    fixture.detectChanges();
+  }
+});

--- a/frontend/src/app/features/matches/create-match/create-match-page.component.spec.ts
+++ b/frontend/src/app/features/matches/create-match/create-match-page.component.spec.ts
@@ -1,0 +1,188 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { CreatedMatch, MatchSlotsResponse } from '../../../core/matches/create-match.models';
+import { MatchCreationService } from '../../../core/matches/match-creation.service';
+import { MeProfile } from '../../../core/me/me.models';
+import { MeService } from '../../../core/me/me.service';
+import { SiteOption } from '../../../core/sites/site.models';
+import { SitesService } from '../../../core/sites/sites.service';
+import { TerrainOption } from '../../../core/terrains/terrain.models';
+import { TerrainsService } from '../../../core/terrains/terrains.service';
+import { UiFeedbackService } from '../../../shared/ui/ui-feedback.service';
+import { CreateMatchPageComponent } from './create-match-page.component';
+
+describe('CreateMatchPageComponent integration', () => {
+  let fixture: ComponentFixture<CreateMatchPageComponent>;
+  let matchCreationService: {
+    getCreneaux: ReturnType<typeof vi.fn>;
+    createMatch: ReturnType<typeof vi.fn>;
+  };
+  let meService: { getMe: ReturnType<typeof vi.fn> };
+  let sitesService: { getSites: ReturnType<typeof vi.fn> };
+  let terrainsService: { getTerrains: ReturnType<typeof vi.fn> };
+  let feedbackService: { showSuccess: ReturnType<typeof vi.fn> };
+
+  const globalProfile: MeProfile = {
+    matricule: 'J0002',
+    nom: 'Joueur Global',
+    type: 'GLOBAL',
+    siteId: null,
+    solde: 0
+  };
+  const siteProfile: MeProfile = {
+    matricule: 'J0003',
+    nom: 'Joueur Site',
+    type: 'SITE',
+    siteId: 1,
+    solde: 0
+  };
+  const sites: SiteOption[] = [
+    { id: 1, nom: 'Padel Bruxelles', ville: 'Bruxelles', joursFermeture: [] }
+  ];
+  const terrains: TerrainOption[] = [
+    { id: 10, nom: 'Terrain 1', siteId: 1 }
+  ];
+  const slotsResponse: MatchSlotsResponse = {
+    creneaux: ['18:00', '19:45'],
+    message: null,
+    annee: 2099,
+    heureOuverture: '08:00',
+    heureFermeture: '22:00',
+    dureeMatchMinutes: 90,
+    bufferMinutes: 15
+  };
+  const createdMatch: CreatedMatch = {
+    id: 99,
+    terrainId: 10,
+    terrainNom: 'Terrain 1',
+    siteId: 1,
+    organisateurMatricule: 'J0002',
+    dateDebut: '2099-05-22T18:00:00',
+    visibilite: 'PUBLIC',
+    statut: 'PLANIFIE',
+    nbParticipants: 1,
+    montantTotal: 60,
+    montantPaye: 15,
+    resteAPayer: 45
+  };
+
+  beforeEach(async () => {
+    matchCreationService = {
+      getCreneaux: vi.fn(),
+      createMatch: vi.fn()
+    };
+    meService = { getMe: vi.fn() };
+    sitesService = { getSites: vi.fn() };
+    terrainsService = { getTerrains: vi.fn() };
+    feedbackService = { showSuccess: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [CreateMatchPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: MatchCreationService, useValue: matchCreationService },
+        { provide: MeService, useValue: meService },
+        { provide: SitesService, useValue: sitesService },
+        { provide: TerrainsService, useValue: terrainsService },
+        { provide: UiFeedbackService, useValue: feedbackService }
+      ]
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads profile and sites before rendering the creation form', () => {
+    arrangeInitialData(globalProfile);
+
+    createPage();
+
+    expect(meService.getMe).toHaveBeenCalled();
+    expect(sitesService.getSites).toHaveBeenCalled();
+    expect(pageText()).toContain('Créer un match');
+    expect(pageText()).toContain('Choisissez un site');
+    expect(pageText()).toContain('Créer le match');
+  });
+
+  it('shows the locked site information for a SITE player profile', () => {
+    arrangeInitialData(siteProfile);
+
+    createPage();
+
+    const lockedSiteInput = fixture.nativeElement.querySelector('input[readonly]') as HTMLInputElement | null;
+
+    expect(lockedSiteInput?.value).toBe('Padel Bruxelles - Bruxelles');
+    expect(pageText()).toContain('Votre abonnement SITE permet de');
+  });
+
+  it('loads and displays available slots after site, terrain and date are selected', () => {
+    arrangeInitialData(globalProfile);
+    createPage();
+
+    const form = getComponentForm();
+    form.controls.siteId.setValue(1);
+    fixture.detectChanges();
+    form.controls.terrainId.setValue(10);
+    form.controls.date.setValue(new Date(2099, 4, 22));
+    fixture.detectChanges();
+
+    expect(terrainsService.getTerrains).toHaveBeenCalledWith(1);
+    expect(matchCreationService.getCreneaux).toHaveBeenCalledWith(10, '2099-05-22');
+    expect(pageText()).toContain('Créneaux disponibles');
+    expect(pageText()).toContain('19:45');
+  });
+
+  it('creates a match with the payload produced by the form and renders the success summary', () => {
+    arrangeInitialData(globalProfile);
+    matchCreationService.createMatch.mockReturnValue(of(createdMatch));
+    createPage();
+
+    const form = getComponentForm();
+    form.controls.siteId.setValue(1);
+    form.controls.terrainId.setValue(10);
+    form.controls.date.setValue(new Date(2099, 4, 22));
+    form.controls.heure.setValue('18:00');
+    form.controls.heure.enable();
+    form.controls.visibilite.setValue('PUBLIC');
+    fixture.detectChanges();
+    submitForm();
+
+    expect(matchCreationService.createMatch).toHaveBeenCalledWith({
+      terrainId: 10,
+      dateDebut: '2099-05-22T18:00:00',
+      visibilite: 'PUBLIC'
+    });
+    expect(feedbackService.showSuccess).toHaveBeenCalled();
+    expect(pageText()).toContain('Terrain 1');
+    expect(pageText()).toContain('Voir mes matchs');
+  });
+
+  function arrangeInitialData(profile: MeProfile): void {
+    meService.getMe.mockReturnValue(of(profile));
+    sitesService.getSites.mockReturnValue(of(sites));
+    terrainsService.getTerrains.mockReturnValue(of(terrains));
+    matchCreationService.getCreneaux.mockReturnValue(of(slotsResponse));
+    matchCreationService.createMatch.mockReturnValue(of(createdMatch));
+  }
+
+  function createPage(): void {
+    fixture = TestBed.createComponent(CreateMatchPageComponent);
+    fixture.detectChanges();
+  }
+
+  function getComponentForm() {
+    return (fixture.componentInstance as unknown as { form: CreateMatchPageComponent['form'] }).form;
+  }
+
+  function submitForm(): void {
+    const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    fixture.detectChanges();
+  }
+
+  function pageText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+});

--- a/frontend/src/app/features/matches/match-detail/match-detail-page.component.spec.ts
+++ b/frontend/src/app/features/matches/match-detail/match-detail-page.component.spec.ts
@@ -1,0 +1,183 @@
+import { Location } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AuthService } from '../../../core/auth/auth.service';
+import { MatchDetail } from '../../../core/matches/match-detail.models';
+import { MatchDetailService } from '../../../core/matches/match-detail.service';
+import { MatchParticipationService } from '../../../core/matches/match-participation.service';
+import { MeProfile } from '../../../core/me/me.models';
+import { MeService } from '../../../core/me/me.service';
+import { MatchDetailPageComponent } from './match-detail-page.component';
+
+describe('MatchDetailPageComponent integration', () => {
+  let fixture: ComponentFixture<MatchDetailPageComponent>;
+  let authService: {
+    isAdmin: ReturnType<typeof vi.fn>;
+    hasPlayerProfile: ReturnType<typeof vi.fn>;
+  };
+  let matchDetailService: {
+    getMatchDetail: ReturnType<typeof vi.fn>;
+    cancelMatch: ReturnType<typeof vi.fn>;
+  };
+  let matchParticipationService: {
+    rejoindreMatchPublic: ReturnType<typeof vi.fn>;
+    ajouterJoueurPrive: ReturnType<typeof vi.fn>;
+  };
+  let meService: { getMe: ReturnType<typeof vi.fn> };
+  let router: { navigateByUrl: ReturnType<typeof vi.fn> };
+  let location: { back: ReturnType<typeof vi.fn> };
+  let routeId = '42';
+
+  const baseMatch: MatchDetail = {
+    id: 42,
+    dateDebut: '2099-05-22',
+    heureDebut: '18:00:00',
+    siteId: 1,
+    siteNom: 'Padel Bruxelles',
+    terrainId: 10,
+    terrainNom: 'Terrain 1',
+    organisateurMatricule: 'J0001',
+    organisateurNom: 'Organisateur',
+    visibilite: 'PUBLIC',
+    statut: 'PLANIFIE',
+    nbParticipants: 1,
+    placesRestantes: 3,
+    complet: false,
+    peutAjouterJoueurPrive: false,
+    peutAnnuler: false,
+    montantTotal: 60,
+    montantPaye: 15,
+    resteAPayer: 45,
+    montantRembourse: 0,
+    participants: [{ matricule: 'J0001', nom: 'Organisateur' }]
+  };
+
+  const currentProfile: MeProfile = {
+    matricule: 'J0002',
+    nom: 'Participant potentiel',
+    type: 'GLOBAL',
+    siteId: null,
+    solde: 0
+  };
+
+  beforeEach(async () => {
+    authService = {
+      isAdmin: vi.fn(),
+      hasPlayerProfile: vi.fn()
+    };
+    matchDetailService = {
+      getMatchDetail: vi.fn(),
+      cancelMatch: vi.fn()
+    };
+    matchParticipationService = {
+      rejoindreMatchPublic: vi.fn(),
+      ajouterJoueurPrive: vi.fn()
+    };
+    meService = { getMe: vi.fn() };
+    router = { navigateByUrl: vi.fn() };
+    location = { back: vi.fn() };
+    routeId = '42';
+
+    await TestBed.configureTestingModule({
+      imports: [MatchDetailPageComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useFactory: () => ({
+            snapshot: {
+              paramMap: convertToParamMap({ id: routeId })
+            }
+          })
+        },
+        { provide: AuthService, useValue: authService },
+        { provide: MatchDetailService, useValue: matchDetailService },
+        { provide: MatchParticipationService, useValue: matchParticipationService },
+        { provide: MeService, useValue: meService },
+        { provide: Router, useValue: router },
+        { provide: Location, useValue: location }
+      ]
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an error and does not call the service when the route id is invalid', () => {
+    routeId = 'invalid';
+
+    createPage();
+
+    expect(matchDetailService.getMatchDetail).not.toHaveBeenCalled();
+    expect(pageText()).toContain('Identifiant de match invalide.');
+  });
+
+  it('loads the match from the route id and renders the main information', () => {
+    arrangePlayerDetail(baseMatch, currentProfile);
+
+    createPage();
+
+    expect(matchDetailService.getMatchDetail).toHaveBeenCalledWith(42);
+    expect(meService.getMe).toHaveBeenCalled();
+    expect(pageText()).toContain('Padel Bruxelles');
+    expect(pageText()).toContain('Terrain 1');
+    expect(pageText()).toContain('Organisateur');
+  });
+
+  it('shows the join action for an open public match when the player is not already participating', () => {
+    arrangePlayerDetail(baseMatch, currentProfile);
+
+    createPage();
+
+    expect(pageText()).toContain('Rejoindre et payer');
+  });
+
+  it('does not show the join action when the current player already participates', () => {
+    arrangePlayerDetail(
+      {
+        ...baseMatch,
+        participants: [
+          ...baseMatch.participants,
+          { matricule: currentProfile.matricule, nom: currentProfile.nom }
+        ]
+      },
+      currentProfile
+    );
+
+    createPage();
+
+    expect(pageText()).not.toContain('Rejoindre et payer');
+  });
+
+  it('renders a load error when the match cannot be found', () => {
+    authService.isAdmin.mockReturnValue(false);
+    authService.hasPlayerProfile.mockReturnValue(true);
+    matchDetailService.getMatchDetail.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 404 }))
+    );
+    meService.getMe.mockReturnValue(of(currentProfile));
+
+    createPage();
+
+    expect(pageText()).toContain('Match introuvable.');
+  });
+
+  function arrangePlayerDetail(match: MatchDetail, profile: MeProfile): void {
+    authService.isAdmin.mockReturnValue(false);
+    authService.hasPlayerProfile.mockReturnValue(true);
+    matchDetailService.getMatchDetail.mockReturnValue(of(match));
+    meService.getMe.mockReturnValue(of(profile));
+  }
+
+  function createPage(): void {
+    fixture = TestBed.createComponent(MatchDetailPageComponent);
+    fixture.detectChanges();
+  }
+
+  function pageText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+});

--- a/frontend/src/app/features/matches/my-matches/my-matches-page.component.spec.ts
+++ b/frontend/src/app/features/matches/my-matches/my-matches-page.component.spec.ts
@@ -1,0 +1,85 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { PlayerMatchSummary } from '../../../core/matches/player-match-summary.models';
+import { PlayerMatchesService } from '../../../core/matches/player-matches.service';
+import { MyMatchesPageComponent } from './my-matches-page.component';
+
+describe('MyMatchesPageComponent integration', () => {
+  let fixture: ComponentFixture<MyMatchesPageComponent>;
+  let playerMatchesService: { getMyMatches: ReturnType<typeof vi.fn> };
+
+  const playerMatch: PlayerMatchSummary = {
+    id: 11,
+    dateDebut: '2099-05-22T18:00:00',
+    siteId: 1,
+    siteNom: 'Padel Bruxelles',
+    terrainId: 10,
+    terrainNom: 'Terrain 1',
+    visibilite: 'PUBLIC',
+    statut: 'PLANIFIE',
+    roleJoueur: 'PARTICIPANT',
+    statutTemporel: 'FUTUR',
+    joursAvantMatch: 4,
+    paiementJoueurEffectue: true,
+    participationId: 100,
+    montantPayeJoueur: 15,
+    montantRestantJoueur: 0,
+    peutPayerParticipation: false
+  };
+
+  beforeEach(async () => {
+    playerMatchesService = { getMyMatches: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [MyMatchesPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: PlayerMatchesService, useValue: playerMatchesService }
+      ]
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the player matches returned by the service', () => {
+    playerMatchesService.getMyMatches.mockReturnValue(of([playerMatch]));
+
+    createPage();
+
+    expect(playerMatchesService.getMyMatches).toHaveBeenCalled();
+    expect(pageText()).toContain('Padel Bruxelles');
+    expect(pageText()).toContain('Terrain 1');
+    expect(pageText()).toContain('Voir le détail');
+  });
+
+  it('renders the empty state when the player has no matches', () => {
+    playerMatchesService.getMyMatches.mockReturnValue(of([]));
+
+    createPage();
+
+    expect(pageText()).toContain("Vous n'avez aucun match pour le moment.");
+  });
+
+  it('renders the error state when loading player matches fails', () => {
+    playerMatchesService.getMyMatches.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 }))
+    );
+
+    createPage();
+
+    expect(pageText()).toContain('Impossible de charger vos matchs.');
+  });
+
+  function createPage(): void {
+    fixture = TestBed.createComponent(MyMatchesPageComponent);
+    fixture.detectChanges();
+  }
+
+  function pageText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+});

--- a/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.spec.ts
+++ b/frontend/src/app/features/matches/organized-matches/organized-matches-page.component.spec.ts
@@ -1,0 +1,84 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { OrganizedMatchSummary } from '../../../core/matches/organized-match-summary.models';
+import { OrganizedMatchesService } from '../../../core/matches/organized-matches.service';
+import { OrganizedMatchesPageComponent } from './organized-matches-page.component';
+
+describe('OrganizedMatchesPageComponent integration', () => {
+  let fixture: ComponentFixture<OrganizedMatchesPageComponent>;
+  let organizedMatchesService: { getMyOrganizedMatches: ReturnType<typeof vi.fn> };
+
+  const organizedMatch: OrganizedMatchSummary = {
+    id: 21,
+    dateDebut: '2099-06-10T19:00:00',
+    siteId: 2,
+    siteNom: 'Padel Liège',
+    terrainId: 20,
+    terrainNom: 'Terrain Central',
+    visibilite: 'PRIVE',
+    statut: 'PLANIFIE',
+    nbParticipants: 2,
+    placesRestantes: 2,
+    complet: false,
+    statutTemporel: 'FUTUR',
+    joursAvantMatch: 6,
+    risquePenaliteJ1: true
+  };
+
+  beforeEach(async () => {
+    organizedMatchesService = { getMyOrganizedMatches: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [OrganizedMatchesPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: OrganizedMatchesService, useValue: organizedMatchesService }
+      ]
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders organized matches returned by the service', () => {
+    organizedMatchesService.getMyOrganizedMatches.mockReturnValue(of([organizedMatch]));
+
+    createPage();
+
+    expect(organizedMatchesService.getMyOrganizedMatches).toHaveBeenCalled();
+    expect(pageText()).toContain('Padel Liège');
+    expect(pageText()).toContain('Terrain Central');
+    expect(pageText()).toContain('Participants');
+    expect(pageText()).toContain('Voir le détail');
+  });
+
+  it('renders the empty state when no organized match exists', () => {
+    organizedMatchesService.getMyOrganizedMatches.mockReturnValue(of([]));
+
+    createPage();
+
+    expect(pageText()).toContain("Vous n'avez aucun match organisé pour le moment.");
+  });
+
+  it('renders the error state when loading organized matches fails', () => {
+    organizedMatchesService.getMyOrganizedMatches.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 }))
+    );
+
+    createPage();
+
+    expect(pageText()).toContain('Impossible de charger vos matchs organisés.');
+  });
+
+  function createPage(): void {
+    fixture = TestBed.createComponent(OrganizedMatchesPageComponent);
+    fixture.detectChanges();
+  }
+
+  function pageText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+});

--- a/frontend/src/app/features/matches/public-matches/public-matches-page.component.spec.ts
+++ b/frontend/src/app/features/matches/public-matches/public-matches-page.component.spec.ts
@@ -1,0 +1,112 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AuthService } from '../../../core/auth/auth.service';
+import { PlayerMatchSummary } from '../../../core/matches/player-match-summary.models';
+import { PlayerMatchesService } from '../../../core/matches/player-matches.service';
+import { PublicMatch } from '../../../core/matches/public-match.models';
+import { PublicMatchesService } from '../../../core/matches/public-matches.service';
+import { PublicMatchesPageComponent } from './public-matches-page.component';
+
+describe('PublicMatchesPageComponent integration', () => {
+  let fixture: ComponentFixture<PublicMatchesPageComponent>;
+  let authService: { hasPlayerProfile: ReturnType<typeof vi.fn> };
+  let publicMatchesService: { getPublicMatches: ReturnType<typeof vi.fn> };
+  let playerMatchesService: { getMyMatches: ReturnType<typeof vi.fn> };
+
+  const publicMatch: PublicMatch = {
+    id: 42,
+    dateDebut: '2099-05-22',
+    heureDebut: '18:00:00',
+    statut: 'PLANIFIE',
+    statutTemporel: 'FUTUR',
+    siteId: 1,
+    siteNom: 'Padel Bruxelles',
+    terrainId: 10,
+    terrainNom: 'Terrain 1',
+    organisateurMatricule: 'J0001',
+    nbParticipants: 2,
+    placesRestantes: 2,
+    complet: false,
+    montantParJoueur: 15
+  };
+
+  beforeEach(async () => {
+    authService = { hasPlayerProfile: vi.fn() };
+    publicMatchesService = { getPublicMatches: vi.fn() };
+    playerMatchesService = { getMyMatches: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [PublicMatchesPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authService },
+        { provide: PublicMatchesService, useValue: publicMatchesService },
+        { provide: PlayerMatchesService, useValue: playerMatchesService }
+      ]
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders public matches returned by the service', () => {
+    renderPage({ matches: [publicMatch], hasPlayerProfile: false });
+
+    expect(publicMatchesService.getPublicMatches).toHaveBeenCalled();
+    expect(pageText()).toContain('Padel Bruxelles');
+    expect(pageText()).toContain('Terrain 1');
+    expect(pageText()).toContain('Voir le');
+  });
+
+  it('renders the empty state when the service returns no matches', () => {
+    renderPage({ matches: [], hasPlayerProfile: false });
+
+    expect(pageText()).toContain('Aucun match public disponible');
+  });
+
+  it('renders the error state when loading public matches fails', () => {
+    authService.hasPlayerProfile.mockReturnValue(false);
+    publicMatchesService.getPublicMatches.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 }))
+    );
+
+    fixture = TestBed.createComponent(PublicMatchesPageComponent);
+    fixture.detectChanges();
+
+    expect(pageText()).toContain('Impossible de charger les matchs publics.');
+  });
+
+  it('uses the detail-only CTA when the current player already participates', () => {
+    const playerMatch = {
+      id: 42,
+      roleJoueur: 'PARTICIPANT'
+    } as PlayerMatchSummary;
+
+    renderPage({ matches: [publicMatch], hasPlayerProfile: true, playerMatches: [playerMatch] });
+
+    const detailLink = fixture.nativeElement.querySelector('a[href="/matchs/42"]') as HTMLAnchorElement | null;
+
+    expect(pageText()).toContain('Padel Bruxelles');
+    expect(detailLink?.textContent?.trim()).toBe('Voir le détail');
+  });
+
+  function renderPage(options: {
+    matches: PublicMatch[];
+    hasPlayerProfile: boolean;
+    playerMatches?: PlayerMatchSummary[];
+  }): void {
+    authService.hasPlayerProfile.mockReturnValue(options.hasPlayerProfile);
+    publicMatchesService.getPublicMatches.mockReturnValue(of(options.matches));
+    playerMatchesService.getMyMatches.mockReturnValue(of(options.playerMatches ?? []));
+
+    fixture = TestBed.createComponent(PublicMatchesPageComponent);
+    fixture.detectChanges();
+  }
+
+  function pageText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+});


### PR DESCRIPTION
On test : 
- Connexion utilisateur
- Liste des matchs publics
- Détail d’un match
- Création d’un match
- Mes matchs
- Matchs organisés
- Statistiques administrateur
- Historique admin des matchs par site

Comportements testés :

- validation du formulaire de connexion ;
- redirection joueur / administrateur après authentification ;
- affichage des listes, états vides et messages d’erreur ;
- chargement d’un détail depuis un paramètre de route ;
- affichage conditionnel de l’action « Rejoindre et payer » ;
- chargement des créneaux et création d’un match ;
- affichage des statistiques selon le type d’administrateur ;
- validation d’une période de statistiques ;
- affichage des matchs du joueur et des matchs organisés ;
- chargement et filtrage de l’historique des matchs d’un site.

Validation

- 31 tests d’intégration Angular ajoutés ;
- 23 fichiers de tests frontend passent ;
- 91 tests frontend passent ;
- build Angular OK ;
- aucun warning affiché pendant le build.

