### PR TITLE
Issue 196 - Ajouté et fiabilisé les statistiques personnelles joueur

### DIFF
--- a/DOCUMENT_EXPLOITATION.md
+++ b/DOCUMENT_EXPLOITATION.md
@@ -228,7 +228,7 @@ cd backend\backend
 Résultat validé :
 
 ```text
-539 tests backend réussis
+541 tests backend réussis
 Package backend réussi
 ```
 
@@ -243,7 +243,7 @@ npm.cmd run build
 Résultat validé :
 
 ```text
-91 tests Angular réussis
+96 tests Angular réussis
 Build Angular réussi
 ```
 

--- a/DOSSIER_ARCHITECTURE.md
+++ b/DOSSIER_ARCHITECTURE.md
@@ -123,9 +123,9 @@ Le projet contient plusieurs niveaux de tests :
 Résultats validés avant remise :
 
 ```text
-539 tests backend réussis
+541 tests backend réussis
 Package backend réussi
-91 tests Angular réussis
+96 tests Angular réussis
 Build Angular réussi
 6 tests Cypress E2E réussis
 ```

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MeMatchRoleStatsDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MeMatchRoleStatsDto.java
@@ -1,0 +1,8 @@
+package be.ephec.padel.backend.dto.response;
+
+public record MeMatchRoleStatsDto(
+        long joues,
+        long aVenir,
+        long annules
+) {
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MeNextMatchDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MeNextMatchDto.java
@@ -1,0 +1,14 @@
+package be.ephec.padel.backend.dto.response;
+
+import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+
+import java.time.LocalDateTime;
+
+public record MeNextMatchDto(
+        Long id,
+        LocalDateTime dateDebut,
+        String siteNom,
+        String terrainNom,
+        PlayerMatchRoleDto roleJoueur
+) {
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MePaymentStatsDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MePaymentStatsDto.java
@@ -1,0 +1,11 @@
+package be.ephec.padel.backend.dto.response;
+
+import java.math.BigDecimal;
+
+public record MePaymentStatsDto(
+        long participationsPayees,
+        long participationsAPayer,
+        BigDecimal montantNetPaye,
+        BigDecimal montantRembourse
+) {
+}

--- a/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MeStatsDto.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/dto/response/MeStatsDto.java
@@ -1,58 +1,9 @@
 package be.ephec.padel.backend.dto.response;
 
-import java.math.BigDecimal;
-
-public class MeStatsDto {
-
-    private final long nbMatchsParticipes;
-    private final long nbMatchsOrganises;
-    private final long nbMatchsPasses;
-    private final long nbMatchsFuturs;
-    private final long nbMatchsAnnules;
-    private final BigDecimal montantTotalPaye;
-    private final BigDecimal detteActuelle;
-
-    public MeStatsDto(long nbMatchsParticipes,
-                      long nbMatchsOrganises,
-                      long nbMatchsPasses,
-                      long nbMatchsFuturs,
-                      long nbMatchsAnnules,
-                      BigDecimal montantTotalPaye,
-                      BigDecimal detteActuelle) {
-        this.nbMatchsParticipes = nbMatchsParticipes;
-        this.nbMatchsOrganises = nbMatchsOrganises;
-        this.nbMatchsPasses = nbMatchsPasses;
-        this.nbMatchsFuturs = nbMatchsFuturs;
-        this.nbMatchsAnnules = nbMatchsAnnules;
-        this.montantTotalPaye = montantTotalPaye;
-        this.detteActuelle = detteActuelle;
-    }
-
-    public long getNbMatchsParticipes() {
-        return nbMatchsParticipes;
-    }
-
-    public long getNbMatchsOrganises() {
-        return nbMatchsOrganises;
-    }
-
-    public long getNbMatchsPasses() {
-        return nbMatchsPasses;
-    }
-
-    public long getNbMatchsFuturs() {
-        return nbMatchsFuturs;
-    }
-
-    public long getNbMatchsAnnules() {
-        return nbMatchsAnnules;
-    }
-
-    public BigDecimal getMontantTotalPaye() {
-        return montantTotalPaye;
-    }
-
-    public BigDecimal getDetteActuelle() {
-        return detteActuelle;
-    }
+public record MeStatsDto(
+        MeNextMatchDto prochainMatch,
+        MeMatchRoleStatsDto matchsCommeOrganisateur,
+        MeMatchRoleStatsDto matchsCommeParticipant,
+        MePaymentStatsDto paiements
+) {
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/repository/ParticipationRepository.java
@@ -40,5 +40,19 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             """)
     Optional<Participation> findByIdWithDetails(@Param("id") Long id);
 
+    @Query("""
+            select distinct p
+            from Participation p
+            join fetch p.joueur
+            join fetch p.match m
+            join fetch m.organisateur
+            join fetch m.terrain t
+            join fetch t.site
+            left join fetch p.paiements
+            where p.joueur.matricule = :matricule
+            order by m.dateDebut asc, m.id asc
+            """)
+    List<Participation> findByJoueurMatriculeWithStatsDetails(@Param("matricule") String matricule);
+
     int countByMatch_Id(Long matchId);
 }

--- a/backend/backend/src/main/java/be/ephec/padel/backend/service/MeStatsService.java
+++ b/backend/backend/src/main/java/be/ephec/padel/backend/service/MeStatsService.java
@@ -1,38 +1,51 @@
 package be.ephec.padel.backend.service;
 
+import be.ephec.padel.backend.common.Tarifs;
+import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
+import be.ephec.padel.backend.dto.response.MeMatchRoleStatsDto;
+import be.ephec.padel.backend.dto.response.MeNextMatchDto;
+import be.ephec.padel.backend.dto.response.MePaymentStatsDto;
 import be.ephec.padel.backend.dto.response.MeStatsDto;
 import be.ephec.padel.backend.model.entities.Joueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Paiement;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.enums.MatchStatut;
 import be.ephec.padel.backend.model.enums.TypePaiement;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
-import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.security.CurrentUserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 @Service
 @Transactional(readOnly = true)
 public class MeStatsService {
 
+    private static final BigDecimal PART_JOUEUR = Tarifs.PART_PAR_JOUEUR;
+
     private final CurrentUserFacade currentUserFacade;
     private final ParticipationRepository participationRepository;
     private final MatchPadelRepository matchPadelRepository;
-    private final PaiementRepository paiementRepository;
     private final Clock clock;
 
     public MeStatsService(CurrentUserFacade currentUserFacade,
                           ParticipationRepository participationRepository,
                           MatchPadelRepository matchPadelRepository,
-                          PaiementRepository paiementRepository,
                           Clock clock) {
         this.currentUserFacade = currentUserFacade;
         this.participationRepository = participationRepository;
         this.matchPadelRepository = matchPadelRepository;
-        this.paiementRepository = paiementRepository;
         this.clock = clock;
     }
 
@@ -41,25 +54,166 @@ public class MeStatsService {
         String matricule = joueur.getMatricule();
         LocalDateTime now = LocalDateTime.now(clock);
 
-        long nbMatchsParticipes = participationRepository.countByJoueur_Matricule(matricule);
-        long nbMatchsOrganises = matchPadelRepository.countByOrganisateur_Matricule(matricule);
-        long nbMatchsPasses = matchPadelRepository.countDistinctLinkedPastMatchesByMatricule(matricule, now);
-        long nbMatchsFuturs = matchPadelRepository.countDistinctLinkedFutureMatchesByMatricule(matricule, now);
-        long nbMatchsAnnules = matchPadelRepository.countDistinctLinkedCancelledMatchesByMatricule(matricule);
-        BigDecimal montantTotalPaye = paiementRepository.sumMontantByParticipationJoueurMatriculeAndType(
-                matricule,
-                TypePaiement.ENCAISSEMENT
-        );
-        BigDecimal detteActuelle = joueur.getSolde() == null ? BigDecimal.ZERO : joueur.getSolde();
+        List<Participation> participations =
+                participationRepository.findByJoueurMatriculeWithStatsDetails(matricule);
+        List<MatchPadel> matchsOrganises =
+                matchPadelRepository.findOrganizedMatchesWithDetailsByMatricule(matricule);
 
         return new MeStatsDto(
-                nbMatchsParticipes,
-                nbMatchsOrganises,
-                nbMatchsPasses,
-                nbMatchsFuturs,
-                nbMatchsAnnules,
-                montantTotalPaye,
-                detteActuelle
+                getProchainMatch(matricule, matchsOrganises, participations, now).orElse(null),
+                getStatsMatchsOrganisateur(matchsOrganises, now),
+                getStatsMatchsParticipant(matricule, participations, now),
+                getStatsPaiements(participations)
         );
+    }
+
+    private Optional<MeNextMatchDto> getProchainMatch(String matricule,
+                                                     List<MatchPadel> matchsOrganises,
+                                                     List<Participation> participations,
+                                                     LocalDateTime now) {
+        return Stream.concat(
+                        nullSafe(matchsOrganises).stream(),
+                        nullSafe(participations).stream()
+                                .map(Participation::getMatch)
+                )
+                .filter(Objects::nonNull)
+                .filter(match -> match.getDateDebut() != null)
+                .filter(match -> match.getStatut() != MatchStatut.ANNULE)
+                .filter(match -> match.getDateDebut().isAfter(now))
+                .filter(match -> joueurConcerne(matricule, match))
+                .distinct()
+                .min(Comparator
+                        .comparing(MatchPadel::getDateDebut)
+                        .thenComparing(MatchPadel::getId, Comparator.nullsLast(Long::compareTo)))
+                .map(match -> toNextMatchDto(matricule, match));
+    }
+
+    private MeMatchRoleStatsDto getStatsMatchsOrganisateur(List<MatchPadel> matchsOrganises,
+                                                           LocalDateTime now) {
+        return new MeMatchRoleStatsDto(
+                countJoues(nullSafe(matchsOrganises), now),
+                countAVenir(nullSafe(matchsOrganises), now),
+                countAnnules(nullSafe(matchsOrganises))
+        );
+    }
+
+    private MeMatchRoleStatsDto getStatsMatchsParticipant(String matricule,
+                                                          List<Participation> participations,
+                                                          LocalDateTime now) {
+        List<MatchPadel> matchsCommeParticipant = nullSafe(participations).stream()
+                .map(Participation::getMatch)
+                .filter(Objects::nonNull)
+                .filter(match -> !isOrganisateur(matricule, match))
+                .distinct()
+                .toList();
+
+        return new MeMatchRoleStatsDto(
+                countJoues(matchsCommeParticipant, now),
+                countAVenir(matchsCommeParticipant, now),
+                countAnnules(matchsCommeParticipant)
+        );
+    }
+
+    private MePaymentStatsDto getStatsPaiements(List<Participation> participations) {
+        long participationsPayees = 0;
+        long participationsAPayer = 0;
+        BigDecimal montantNetPaye = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        BigDecimal montantRembourse = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+
+        for (Participation participation : nullSafe(participations)) {
+            MatchPadel match = participation.getMatch();
+
+            montantRembourse = montantRembourse
+                    .add(sumPaiementsParticipationByType(participation, TypePaiement.REMBOURSEMENT).abs())
+                    .setScale(2, RoundingMode.HALF_UP);
+
+            if (match == null || match.getStatut() == MatchStatut.ANNULE) {
+                continue;
+            }
+
+            BigDecimal montantPaye = sumPaiementsParticipation(participation);
+            if (montantPaye.compareTo(PART_JOUEUR) >= 0) {
+                participationsPayees++;
+            } else {
+                participationsAPayer++;
+            }
+
+            montantNetPaye = montantNetPaye
+                    .add(montantPaye.max(BigDecimal.ZERO).min(PART_JOUEUR))
+                    .setScale(2, RoundingMode.HALF_UP);
+        }
+
+        return new MePaymentStatsDto(
+                participationsPayees,
+                participationsAPayer,
+                montantNetPaye,
+                montantRembourse
+        );
+    }
+
+    private long countJoues(List<MatchPadel> matchs, LocalDateTime now) {
+        return matchs.stream()
+                .filter(match -> match.getStatut() != MatchStatut.ANNULE)
+                .filter(match -> match.getDateDebut() != null && match.getDateDebut().isBefore(now))
+                .count();
+    }
+
+    private long countAVenir(List<MatchPadel> matchs, LocalDateTime now) {
+        return matchs.stream()
+                .filter(match -> match.getStatut() != MatchStatut.ANNULE)
+                .filter(match -> match.getDateDebut() != null && match.getDateDebut().isAfter(now))
+                .count();
+    }
+
+    private long countAnnules(List<MatchPadel> matchs) {
+        return matchs.stream()
+                .filter(match -> match.getStatut() == MatchStatut.ANNULE)
+                .count();
+    }
+
+    private boolean joueurConcerne(String matricule, MatchPadel match) {
+        return isOrganisateur(matricule, match)
+                || nullSafe(match.getParticipations()).stream()
+                .map(Participation::getJoueur)
+                .filter(Objects::nonNull)
+                .anyMatch(joueur -> matricule.equals(joueur.getMatricule()));
+    }
+
+    private boolean isOrganisateur(String matricule, MatchPadel match) {
+        return match.getOrganisateur() != null
+                && matricule.equals(match.getOrganisateur().getMatricule());
+    }
+
+    private MeNextMatchDto toNextMatchDto(String matricule, MatchPadel match) {
+        return new MeNextMatchDto(
+                match.getId(),
+                match.getDateDebut(),
+                match.getTerrain().getSite().getNom(),
+                match.getTerrain().getNom(),
+                isOrganisateur(matricule, match)
+                        ? PlayerMatchRoleDto.ORGANISATEUR
+                        : PlayerMatchRoleDto.PARTICIPANT
+        );
+    }
+
+    private BigDecimal sumPaiementsParticipation(Participation participation) {
+        return nullSafe(participation.getPaiements()).stream()
+                .map(Paiement::getMontant)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal sumPaiementsParticipationByType(Participation participation, TypePaiement type) {
+        return nullSafe(participation.getPaiements()).stream()
+                .filter(paiement -> paiement.getType() == type)
+                .map(Paiement::getMontant)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private <T> List<T> nullSafe(List<T> items) {
+        return items == null ? List.of() : items;
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MeStatsServiceTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/unit/service/MeStatsServiceTest.java
@@ -1,12 +1,19 @@
 package be.ephec.padel.backend.unit.service;
 
+import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
 import be.ephec.padel.backend.dto.response.MeStatsDto;
 import be.ephec.padel.backend.exception.ForbiddenException;
 import be.ephec.padel.backend.model.entities.Joueur;
-import be.ephec.padel.backend.model.enums.TypeJoueur;
+import be.ephec.padel.backend.model.entities.MatchPadel;
+import be.ephec.padel.backend.model.entities.Paiement;
+import be.ephec.padel.backend.model.entities.Participation;
+import be.ephec.padel.backend.model.entities.Site;
+import be.ephec.padel.backend.model.entities.Terrain;
+import be.ephec.padel.backend.model.enums.MatchStatut;
+import be.ephec.padel.backend.model.enums.MatchVisibilite;
 import be.ephec.padel.backend.model.enums.TypePaiement;
+import be.ephec.padel.backend.model.enums.TypeJoueur;
 import be.ephec.padel.backend.repository.MatchPadelRepository;
-import be.ephec.padel.backend.repository.PaiementRepository;
 import be.ephec.padel.backend.repository.ParticipationRepository;
 import be.ephec.padel.backend.security.CurrentUserFacade;
 import be.ephec.padel.backend.service.MeStatsService;
@@ -21,10 +28,10 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,8 +44,6 @@ class MeStatsServiceTest {
     ParticipationRepository participationRepository;
     @Mock
     MatchPadelRepository matchPadelRepository;
-    @Mock
-    PaiementRepository paiementRepository;
 
     private MeStatsService service;
     private Clock fixedClock;
@@ -50,81 +55,120 @@ class MeStatsServiceTest {
                 currentUserFacade,
                 participationRepository,
                 matchPadelRepository,
-                paiementRepository,
                 fixedClock
         );
     }
 
     @Test
-    void getCurrentUserStats_calcule_le_snapshot_nominal() {
+    void getCurrentUserStats_calcule_les_statistiques_personnelles() {
         Joueur joueur = new Joueur("G0001", "Alice", TypeJoueur.GLOBAL);
-        joueur.setSolde(new BigDecimal("12.50"));
-
+        Joueur autreJoueur = new Joueur("G0002", "Bob", TypeJoueur.GLOBAL);
         LocalDateTime now = LocalDateTime.now(fixedClock);
 
+        MatchPadel organisePasse = match(joueur, now.minusDays(2), MatchStatut.PLANIFIE);
+        MatchPadel organiseFutur = match(joueur, now.plusDays(1), MatchStatut.PLANIFIE);
+        MatchPadel organiseAnnule = match(joueur, now.plusDays(3), MatchStatut.ANNULE);
+
+        MatchPadel participantPasse = match(autreJoueur, now.minusDays(3), MatchStatut.PLANIFIE);
+        MatchPadel participantFutur = match(autreJoueur, now.plusHours(4), MatchStatut.PLANIFIE);
+        MatchPadel participantAnnule = match(autreJoueur, now.plusDays(4), MatchStatut.ANNULE);
+
+        Participation participationOrganisateur = participation(organiseFutur, joueur, new BigDecimal("15.00"));
+        Participation participationPayee = participation(participantPasse, joueur, new BigDecimal("15.00"));
+        Participation participationAPayer = participation(participantFutur, joueur, new BigDecimal("5.00"));
+        Participation participationAnnulee = participation(participantAnnule, joueur, new BigDecimal("15.00"), new BigDecimal("-15.00"));
+
         when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
-        when(participationRepository.countByJoueur_Matricule("G0001")).thenReturn(5L);
-        when(matchPadelRepository.countByOrganisateur_Matricule("G0001")).thenReturn(3L);
-        when(matchPadelRepository.countDistinctLinkedPastMatchesByMatricule("G0001", now)).thenReturn(2L);
-        when(matchPadelRepository.countDistinctLinkedFutureMatchesByMatricule("G0001", now)).thenReturn(4L);
-        when(matchPadelRepository.countDistinctLinkedCancelledMatchesByMatricule("G0001")).thenReturn(1L);
-        when(paiementRepository.sumMontantByParticipationJoueurMatriculeAndType("G0001", TypePaiement.ENCAISSEMENT))
-                .thenReturn(new BigDecimal("42.00"));
+        when(participationRepository.findByJoueurMatriculeWithStatsDetails("G0001"))
+                .thenReturn(List.of(
+                        participationOrganisateur,
+                        participationPayee,
+                        participationAPayer,
+                        participationAnnulee
+                ));
+        when(matchPadelRepository.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of(organisePasse, organiseFutur, organiseAnnule));
 
         MeStatsDto dto = service.getCurrentUserStats();
 
-        assertThat(dto.getNbMatchsParticipes()).isEqualTo(5L);
-        assertThat(dto.getNbMatchsOrganises()).isEqualTo(3L);
-        assertThat(dto.getNbMatchsPasses()).isEqualTo(2L);
-        assertThat(dto.getNbMatchsFuturs()).isEqualTo(4L);
-        assertThat(dto.getNbMatchsAnnules()).isEqualTo(1L);
-        assertThat(dto.getMontantTotalPaye()).isEqualByComparingTo("42.00");
-        assertThat(dto.getDetteActuelle()).isEqualByComparingTo("12.50");
+        assertThat(dto.prochainMatch()).isNotNull();
+        assertThat(dto.prochainMatch().dateDebut()).isEqualTo(now.plusHours(4));
+        assertThat(dto.prochainMatch().roleJoueur()).isEqualTo(PlayerMatchRoleDto.PARTICIPANT);
 
-        verify(matchPadelRepository).countDistinctLinkedPastMatchesByMatricule("G0001", now);
-        verify(matchPadelRepository).countDistinctLinkedFutureMatchesByMatricule("G0001", now);
-        verify(paiementRepository).sumMontantByParticipationJoueurMatriculeAndType("G0001", TypePaiement.ENCAISSEMENT);
+        assertThat(dto.matchsCommeOrganisateur().joues()).isEqualTo(1L);
+        assertThat(dto.matchsCommeOrganisateur().aVenir()).isEqualTo(1L);
+        assertThat(dto.matchsCommeOrganisateur().annules()).isEqualTo(1L);
+
+        assertThat(dto.matchsCommeParticipant().joues()).isEqualTo(1L);
+        assertThat(dto.matchsCommeParticipant().aVenir()).isEqualTo(1L);
+        assertThat(dto.matchsCommeParticipant().annules()).isEqualTo(1L);
+
+        assertThat(dto.paiements().participationsPayees()).isEqualTo(2L);
+        assertThat(dto.paiements().participationsAPayer()).isEqualTo(1L);
+        assertThat(dto.paiements().montantNetPaye()).isEqualByComparingTo("35.00");
+        assertThat(dto.paiements().montantRembourse()).isEqualByComparingTo("15.00");
+
+        verify(participationRepository).findByJoueurMatriculeWithStatsDetails("G0001");
+        verify(matchPadelRepository).findOrganizedMatchesWithDetailsByMatricule("G0001");
     }
 
     @Test
-    void getCurrentUserStats_utilise_le_solde_courant_du_joueur() {
-        Joueur joueur = new Joueur("G0001", "Alice", TypeJoueur.GLOBAL);
-        joueur.setSolde(new BigDecimal("7.25"));
-
-        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
-        when(participationRepository.countByJoueur_Matricule("G0001")).thenReturn(0L);
-        when(matchPadelRepository.countByOrganisateur_Matricule("G0001")).thenReturn(0L);
-        when(matchPadelRepository.countDistinctLinkedPastMatchesByMatricule(eq("G0001"), eq(LocalDateTime.now(fixedClock))))
-                .thenReturn(0L);
-        when(matchPadelRepository.countDistinctLinkedFutureMatchesByMatricule(eq("G0001"), eq(LocalDateTime.now(fixedClock))))
-                .thenReturn(0L);
-        when(matchPadelRepository.countDistinctLinkedCancelledMatchesByMatricule("G0001")).thenReturn(0L);
-        when(paiementRepository.sumMontantByParticipationJoueurMatriculeAndType("G0001", TypePaiement.ENCAISSEMENT))
-                .thenReturn(BigDecimal.ZERO);
-
-        MeStatsDto dto = service.getCurrentUserStats();
-
-        assertThat(dto.getDetteActuelle()).isEqualByComparingTo("7.25");
-    }
-
-    @Test
-    void getCurrentUserStats_passe_et_futur_sont_bases_sur_clock() {
+    void getCurrentUserStats_retourne_null_si_aucun_prochain_match() {
         Joueur joueur = new Joueur("G0001", "Alice", TypeJoueur.GLOBAL);
         LocalDateTime now = LocalDateTime.now(fixedClock);
 
         when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
-        when(participationRepository.countByJoueur_Matricule("G0001")).thenReturn(0L);
-        when(matchPadelRepository.countByOrganisateur_Matricule("G0001")).thenReturn(0L);
-        when(matchPadelRepository.countDistinctLinkedPastMatchesByMatricule("G0001", now)).thenReturn(1L);
-        when(matchPadelRepository.countDistinctLinkedFutureMatchesByMatricule("G0001", now)).thenReturn(2L);
-        when(matchPadelRepository.countDistinctLinkedCancelledMatchesByMatricule("G0001")).thenReturn(0L);
-        when(paiementRepository.sumMontantByParticipationJoueurMatriculeAndType("G0001", TypePaiement.ENCAISSEMENT))
-                .thenReturn(BigDecimal.ZERO);
+        when(participationRepository.findByJoueurMatriculeWithStatsDetails("G0001"))
+                .thenReturn(List.of(participation(match(new Joueur("G0002", "Bob", TypeJoueur.GLOBAL), now.minusDays(1), MatchStatut.PLANIFIE), joueur)));
+        when(matchPadelRepository.findOrganizedMatchesWithDetailsByMatricule("G0001")).thenReturn(List.of());
 
         MeStatsDto dto = service.getCurrentUserStats();
 
-        assertThat(dto.getNbMatchsPasses()).isEqualTo(1L);
-        assertThat(dto.getNbMatchsFuturs()).isEqualTo(2L);
+        assertThat(dto.prochainMatch()).isNull();
+    }
+
+    @Test
+    void getCurrentUserStats_ne_compte_pas_l_organisateur_comme_participant() {
+        Joueur joueur = new Joueur("G0001", "Alice", TypeJoueur.GLOBAL);
+        LocalDateTime now = LocalDateTime.now(fixedClock);
+        MatchPadel matchOrganise = match(joueur, now.minusDays(1), MatchStatut.PLANIFIE);
+
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
+        when(participationRepository.findByJoueurMatriculeWithStatsDetails("G0001"))
+                .thenReturn(List.of(participation(matchOrganise, joueur)));
+        when(matchPadelRepository.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of(matchOrganise));
+
+        MeStatsDto dto = service.getCurrentUserStats();
+
+        assertThat(dto.matchsCommeOrganisateur().joues()).isEqualTo(1L);
+        assertThat(dto.matchsCommeParticipant().joues()).isZero();
+    }
+
+    @Test
+    void getCurrentUserStats_plafonne_le_montant_net_aux_participations_non_annulees() {
+        Joueur joueur = new Joueur("G0001", "Alice", TypeJoueur.GLOBAL);
+        Joueur autreJoueur = new Joueur("G0002", "Bob", TypeJoueur.GLOBAL);
+        LocalDateTime now = LocalDateTime.now(fixedClock);
+
+        MatchPadel participationNonAnnulee = match(autreJoueur, now.minusDays(1), MatchStatut.PLANIFIE);
+        MatchPadel participationAnnulee = match(autreJoueur, now.plusDays(1), MatchStatut.ANNULE);
+
+        when(currentUserFacade.getCurrentJoueur()).thenReturn(joueur);
+        when(participationRepository.findByJoueurMatriculeWithStatsDetails("G0001"))
+                .thenReturn(List.of(
+                        participation(participationNonAnnulee, joueur, new BigDecimal("45.00")),
+                        participation(participationAnnulee, joueur, new BigDecimal("15.00"), new BigDecimal("-15.00"))
+                ));
+        when(matchPadelRepository.findOrganizedMatchesWithDetailsByMatricule("G0001"))
+                .thenReturn(List.of());
+
+        MeStatsDto dto = service.getCurrentUserStats();
+
+        assertThat(dto.paiements().participationsPayees()).isEqualTo(1L);
+        assertThat(dto.paiements().participationsAPayer()).isZero();
+        assertThat(dto.paiements().montantNetPaye()).isEqualByComparingTo("15.00");
+        assertThat(dto.paiements().montantRembourse()).isEqualByComparingTo("15.00");
     }
 
     @Test
@@ -135,5 +179,23 @@ class MeStatsServiceTest {
         assertThatThrownBy(() -> service.getCurrentUserStats())
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("Aucun joueur lié à l'utilisateur authentifié.");
+    }
+
+    private MatchPadel match(Joueur organisateur, LocalDateTime dateDebut, MatchStatut statut) {
+        Site site = new Site("Site Delta", "Bruxelles");
+        Terrain terrain = new Terrain("Terrain 1", site);
+        MatchPadel match = new MatchPadel(terrain, organisateur, dateDebut, MatchVisibilite.PUBLIC);
+        match.setStatut(statut);
+        return match;
+    }
+
+    private Participation participation(MatchPadel match, Joueur joueur, BigDecimal... montants) {
+        Participation participation = new Participation(match, joueur);
+        match.addParticipation(participation);
+        for (BigDecimal montant : montants) {
+            TypePaiement type = montant.signum() < 0 ? TypePaiement.REMBOURSEMENT : TypePaiement.ENCAISSEMENT;
+            participation.addPaiement(new Paiement(participation, montant, type, match.getDateDebut()));
+        }
+        return participation;
     }
 }

--- a/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MeControllerTest.java
+++ b/backend/backend/src/test/java/be/ephec/padel/backend/web/controller/MeControllerTest.java
@@ -3,6 +3,9 @@ package be.ephec.padel.backend.web.controller;
 import be.ephec.padel.backend.config.SecurityConfig;
 import be.ephec.padel.backend.controller.MeController;
 import be.ephec.padel.backend.dto.enums.MatchTemporalStatusDto;
+import be.ephec.padel.backend.dto.response.MeMatchRoleStatsDto;
+import be.ephec.padel.backend.dto.response.MeNextMatchDto;
+import be.ephec.padel.backend.dto.response.MePaymentStatsDto;
 import be.ephec.padel.backend.dto.response.MeStatsDto;
 import be.ephec.padel.backend.dto.enums.PlayerMatchRoleDto;
 import be.ephec.padel.backend.dto.response.OrganizerMatchSummaryDto;
@@ -255,25 +258,54 @@ class MeControllerTest {
     @Test
     void getMyStats_ok_200() throws Exception {
         when(meStatsService.getCurrentUserStats()).thenReturn(new MeStatsDto(
-                5L,
-                2L,
-                3L,
-                1L,
-                1L,
-                new BigDecimal("42.00"),
-                new BigDecimal("7.50")
+                new MeNextMatchDto(
+                        12L,
+                        LocalDateTime.of(2030, 1, 10, 10, 0),
+                        "Site Delta",
+                        "Terrain 1",
+                        PlayerMatchRoleDto.ORGANISATEUR
+                ),
+                new MeMatchRoleStatsDto(2L, 1L, 1L),
+                new MeMatchRoleStatsDto(6L, 3L, 0L),
+                new MePaymentStatsDto(7L, 2L, new BigDecimal("105.00"), new BigDecimal("15.00"))
         ));
 
         mvc.perform(get("/api/v1/me/stats"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.nbMatchsParticipes").value(5))
-                .andExpect(jsonPath("$.nbMatchsOrganises").value(2))
-                .andExpect(jsonPath("$.nbMatchsPasses").value(3))
-                .andExpect(jsonPath("$.nbMatchsFuturs").value(1))
-                .andExpect(jsonPath("$.nbMatchsAnnules").value(1))
-                .andExpect(jsonPath("$.montantTotalPaye").value(42.00))
-                .andExpect(jsonPath("$.detteActuelle").value(7.50));
+                .andExpect(jsonPath("$.prochainMatch.id").value(12))
+                .andExpect(jsonPath("$.prochainMatch.dateDebut").value("2030-01-10T10:00:00"))
+                .andExpect(jsonPath("$.prochainMatch.siteNom").value("Site Delta"))
+                .andExpect(jsonPath("$.prochainMatch.terrainNom").value("Terrain 1"))
+                .andExpect(jsonPath("$.prochainMatch.roleJoueur").value("ORGANISATEUR"))
+                .andExpect(jsonPath("$.matchsCommeOrganisateur.joues").value(2))
+                .andExpect(jsonPath("$.matchsCommeOrganisateur.aVenir").value(1))
+                .andExpect(jsonPath("$.matchsCommeOrganisateur.annules").value(1))
+                .andExpect(jsonPath("$.matchsCommeParticipant.joues").value(6))
+                .andExpect(jsonPath("$.matchsCommeParticipant.aVenir").value(3))
+                .andExpect(jsonPath("$.matchsCommeParticipant.annules").value(0))
+                .andExpect(jsonPath("$.paiements.participationsPayees").value(7))
+                .andExpect(jsonPath("$.paiements.participationsAPayer").value(2))
+                .andExpect(jsonPath("$.paiements.montantNetPaye").value(105.00))
+                .andExpect(jsonPath("$.paiements.montantRembourse").value(15.00));
+    }
+
+    @Test
+    void getMyStats_accepte_prochain_match_null() throws Exception {
+        when(meStatsService.getCurrentUserStats()).thenReturn(new MeStatsDto(
+                null,
+                new MeMatchRoleStatsDto(0L, 0L, 0L),
+                new MeMatchRoleStatsDto(0L, 0L, 0L),
+                new MePaymentStatsDto(0L, 0L, BigDecimal.ZERO, BigDecimal.ZERO)
+        ));
+
+        mvc.perform(get("/api/v1/me/stats"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.prochainMatch").value(nullValue()))
+                .andExpect(jsonPath("$.matchsCommeOrganisateur.joues").value(0))
+                .andExpect(jsonPath("$.matchsCommeParticipant.joues").value(0))
+                .andExpect(jsonPath("$.paiements.montantNetPaye").value(0));
     }
 
     @Test

--- a/frontend/src/app/core/me/me.models.ts
+++ b/frontend/src/app/core/me/me.models.ts
@@ -8,3 +8,31 @@ export interface MeProfile {
   solde: number;
   penaliteJusqua?: string | null;
 }
+
+export interface MeStats {
+  prochainMatch: MeNextMatch | null;
+  matchsCommeOrganisateur: MeMatchRoleStats;
+  matchsCommeParticipant: MeMatchRoleStats;
+  paiements: MePaymentStats;
+}
+
+export interface MeNextMatch {
+  id: number;
+  dateDebut: string;
+  siteNom: string;
+  terrainNom: string;
+  roleJoueur: 'ORGANISATEUR' | 'PARTICIPANT';
+}
+
+export interface MeMatchRoleStats {
+  joues: number;
+  aVenir: number;
+  annules: number;
+}
+
+export interface MePaymentStats {
+  participationsPayees: number;
+  participationsAPayer: number;
+  montantNetPaye: number;
+  montantRembourse: number;
+}

--- a/frontend/src/app/core/me/me.service.spec.ts
+++ b/frontend/src/app/core/me/me.service.spec.ts
@@ -1,0 +1,83 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../../environments/environment';
+import { MeProfile, MeStats } from './me.models';
+import { MeService } from './me.service';
+
+describe('MeService', () => {
+  let service: MeService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MeService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(MeService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('loads the current player profile', () => {
+    const response: MeProfile = {
+      matricule: 'joueur.site.dev',
+      nom: 'Joueur Site',
+      type: 'SITE',
+      siteId: 1,
+      solde: 0,
+      penaliteJusqua: null
+    };
+
+    service.getMe().subscribe((profile) => {
+      expect(profile).toEqual(response);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/me`);
+    expect(request.request.method).toBe('GET');
+    request.flush(response);
+  });
+
+  it('loads the current player statistics', () => {
+    const response: MeStats = {
+      prochainMatch: {
+        id: 12,
+        dateDebut: '2030-01-10T10:00:00',
+        siteNom: 'Site Nord',
+        terrainNom: 'Terrain 1',
+        roleJoueur: 'ORGANISATEUR'
+      },
+      matchsCommeOrganisateur: {
+        joues: 2,
+        aVenir: 1,
+        annules: 1
+      },
+      matchsCommeParticipant: {
+        joues: 6,
+        aVenir: 3,
+        annules: 0
+      },
+      paiements: {
+        participationsPayees: 7,
+        participationsAPayer: 2,
+        montantNetPaye: 105,
+        montantRembourse: 15
+      }
+    };
+
+    service.getMyStats().subscribe((stats) => {
+      expect(stats).toEqual(response);
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/me/stats`);
+    expect(request.request.method).toBe('GET');
+    request.flush(response);
+  });
+});

--- a/frontend/src/app/core/me/me.service.ts
+++ b/frontend/src/app/core/me/me.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { MeProfile } from './me.models';
+import { MeProfile, MeStats } from './me.models';
 
 @Injectable({ providedIn: 'root' })
 export class MeService {
@@ -10,5 +10,9 @@ export class MeService {
 
   getMe(): Observable<MeProfile> {
     return this.http.get<MeProfile>(`${environment.apiBaseUrl}/me`);
+  }
+
+  getMyStats(): Observable<MeStats> {
+    return this.http.get<MeStats>(`${environment.apiBaseUrl}/me/stats`);
   }
 }

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.css
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.css
@@ -96,6 +96,48 @@
   margin-top: 0.5rem;
 }
 
+.player-stats-layout {
+  display: grid;
+  gap: 1rem;
+}
+
+.stats-group {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.stats-group h3 {
+  color: var(--app-text);
+  font-weight: 800;
+}
+
+.stats-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.stats-metrics div {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.85rem;
+  border: 1px solid var(--app-border);
+  border-radius: var(--app-radius);
+  background: var(--app-surface-muted);
+}
+
+.stats-metrics dt {
+  color: var(--app-muted);
+  font-weight: 800;
+}
+
+.stats-metrics dd {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 800;
+}
+
 .traceable-total {
   display: flex;
   align-items: baseline;

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.html
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.html
@@ -169,6 +169,98 @@
         }
       </section>
 
+      <section class="info-section">
+        <h2>Mes statistiques</h2>
+
+        @if (isLoadingStats()) {
+          <p class="page-state">Chargement des statistiques...</p>
+        } @else if (statsErrorMessage()) {
+          <p class="page-state is-error">{{ statsErrorMessage() }}</p>
+        } @else if (stats(); as stats) {
+          <div class="player-stats-layout">
+            <article class="regularization-card">
+              @if (stats.prochainMatch; as prochainMatch) {
+                <div class="regularization-main">
+                  <div class="regularization-summary">
+                    <p class="regularization-site">Prochain match</p>
+                    <h3>{{ prochainMatch.siteNom }}</h3>
+                    <p class="regularization-datetime">
+                      {{ prochainMatch.dateDebut | date:'dd/MM/yyyy' }} à
+                      {{ prochainMatch.dateDebut | date:'HH:mm' }}
+                    </p>
+                    <p class="regularization-datetime">{{ prochainMatch.terrainNom }}</p>
+                  </div>
+
+                  <div class="regularization-badges">
+                    <span class="meta-badge">{{ getRoleLabel(prochainMatch.roleJoueur) }}</span>
+                  </div>
+                </div>
+              } @else {
+                <p class="page-state">Aucun match à venir pour le moment.</p>
+              }
+            </article>
+
+            <article class="stats-group">
+              <h3>Matchs comme organisateur</h3>
+              <dl class="stats-metrics">
+                <div>
+                  <dt>Joués</dt>
+                  <dd>{{ formatNumber(stats.matchsCommeOrganisateur.joues) }}</dd>
+                </div>
+                <div>
+                  <dt>À venir</dt>
+                  <dd>{{ formatNumber(stats.matchsCommeOrganisateur.aVenir) }}</dd>
+                </div>
+                <div>
+                  <dt>Annulés</dt>
+                  <dd>{{ formatNumber(stats.matchsCommeOrganisateur.annules) }}</dd>
+                </div>
+              </dl>
+            </article>
+
+            <article class="stats-group">
+              <h3>Matchs comme participant</h3>
+              <dl class="stats-metrics">
+                <div>
+                  <dt>Joués</dt>
+                  <dd>{{ formatNumber(stats.matchsCommeParticipant.joues) }}</dd>
+                </div>
+                <div>
+                  <dt>À venir</dt>
+                  <dd>{{ formatNumber(stats.matchsCommeParticipant.aVenir) }}</dd>
+                </div>
+                <div>
+                  <dt>Annulés</dt>
+                  <dd>{{ formatNumber(stats.matchsCommeParticipant.annules) }}</dd>
+                </div>
+              </dl>
+            </article>
+
+            <article class="stats-group">
+              <h3>Paiements</h3>
+              <dl class="stats-metrics is-payment">
+                <div>
+                  <dt>Participations payées</dt>
+                  <dd>{{ formatNumber(stats.paiements.participationsPayees) }}</dd>
+                </div>
+                <div>
+                  <dt>Participations non payées</dt>
+                  <dd>{{ formatNumber(stats.paiements.participationsAPayer) }}</dd>
+                </div>
+                <div>
+                  <dt>Montant net payé</dt>
+                  <dd>{{ formatAmount(stats.paiements.montantNetPaye) }}</dd>
+                </div>
+                <div>
+                  <dt>Montant remboursé</dt>
+                  <dd>{{ formatAmount(stats.paiements.montantRembourse) }}</dd>
+                </div>
+              </dl>
+            </article>
+          </div>
+        }
+      </section>
+
       <section class="info-section shortcuts-section">
         <h2>Accès rapides</h2>
 

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.spec.ts
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.spec.ts
@@ -1,0 +1,170 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AuthService } from '../../../core/auth/auth.service';
+import { MeProfile, MeStats } from '../../../core/me/me.models';
+import { MeService } from '../../../core/me/me.service';
+import { PaiementService } from '../../../core/payments/paiement.service';
+import { RegularisationsResponse } from '../../../core/regularisations/regularisation.models';
+import { RegularisationService } from '../../../core/regularisations/regularisation.service';
+import { EspacePrivePageComponent } from './espace-prive-page.component';
+
+describe('EspacePrivePageComponent integration', () => {
+  let fixture: ComponentFixture<EspacePrivePageComponent>;
+  let authService: {
+    isAdmin: ReturnType<typeof vi.fn>;
+    hasPlayerProfile: ReturnType<typeof vi.fn>;
+  };
+  let meService: {
+    getMe: ReturnType<typeof vi.fn>;
+    getMyStats: ReturnType<typeof vi.fn>;
+  };
+  let regularisationService: {
+    getMyRegularisations: ReturnType<typeof vi.fn>;
+    payLateCancellationRegularisation: ReturnType<typeof vi.fn>;
+  };
+  let paiementService: {
+    payerParticipation: ReturnType<typeof vi.fn>;
+  };
+
+  const profile: MeProfile = {
+    matricule: 'joueur.site.dev',
+    nom: 'Joueur Site',
+    type: 'SITE',
+    siteId: 1,
+    solde: 15,
+    penaliteJusqua: null
+  };
+  const regularisations: RegularisationsResponse = {
+    totalTracable: 0,
+    items: []
+  };
+  const stats: MeStats = {
+    prochainMatch: {
+      id: 12,
+      dateDebut: '2030-01-10T10:00:00',
+      siteNom: 'Site Nord',
+      terrainNom: 'Terrain 1',
+      roleJoueur: 'ORGANISATEUR'
+    },
+    matchsCommeOrganisateur: {
+      joues: 2,
+      aVenir: 1,
+      annules: 1
+    },
+    matchsCommeParticipant: {
+      joues: 6,
+      aVenir: 3,
+      annules: 0
+    },
+    paiements: {
+      participationsPayees: 7,
+      participationsAPayer: 2,
+      montantNetPaye: 105,
+      montantRembourse: 15
+    }
+  };
+
+  beforeEach(async () => {
+    authService = {
+      isAdmin: vi.fn(),
+      hasPlayerProfile: vi.fn()
+    };
+    meService = {
+      getMe: vi.fn(),
+      getMyStats: vi.fn()
+    };
+    regularisationService = {
+      getMyRegularisations: vi.fn(),
+      payLateCancellationRegularisation: vi.fn()
+    };
+    paiementService = {
+      payerParticipation: vi.fn()
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [EspacePrivePageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authService },
+        { provide: MeService, useValue: meService },
+        { provide: RegularisationService, useValue: regularisationService },
+        { provide: PaiementService, useValue: paiementService }
+      ]
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads and renders the current player statistics', () => {
+    arrangeSuccessfulPage();
+
+    createPage();
+
+    expect(meService.getMyStats).toHaveBeenCalled();
+    expect(pageText()).toContain('Mes statistiques');
+    expect(pageText()).toContain('Prochain match');
+    expect(pageText()).toContain('Site Nord');
+    expect(pageText()).toContain('Terrain 1');
+    expect(pageText()).toContain('Organisateur');
+    expect(pageText()).toContain('Matchs comme organisateur');
+    expect(pageText()).toContain('Matchs comme participant');
+    expect(pageText()).toContain('Paiements');
+    expect(pageText()).toContain('Participations payées');
+    expect(pageText()).toContain('Participations non payées');
+    expect(pageText()).toContain('Montant net payé');
+    expect(pageText()).toContain('105,00');
+    expect(pageText()).toContain('Montant remboursé');
+    expect(pageText()).toContain('15,00');
+  });
+
+  it('renders a local message when there is no next match', () => {
+    arrangeSuccessfulPage({
+      ...stats,
+      prochainMatch: null
+    });
+
+    createPage();
+
+    expect(pageText()).toContain('Aucun match à venir pour le moment.');
+  });
+
+  it('keeps the private space visible when statistics loading fails', () => {
+    authService.isAdmin.mockReturnValue(false);
+    authService.hasPlayerProfile.mockReturnValue(true);
+    meService.getMe.mockReturnValue(of(profile));
+    meService.getMyStats.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 }))
+    );
+    regularisationService.getMyRegularisations.mockReturnValue(of(regularisations));
+
+    createPage();
+
+    expect(pageText()).toContain('Informations personnelles');
+    expect(pageText()).toContain('Solde / dette');
+    expect(pageText()).toContain('Matchs à payer');
+    expect(pageText()).toContain('Accès rapides');
+    expect(pageText()).toContain('Les statistiques ne sont pas disponibles actuellement.');
+  });
+
+  function arrangeSuccessfulPage(statsResponse: MeStats = stats): void {
+    authService.isAdmin.mockReturnValue(false);
+    authService.hasPlayerProfile.mockReturnValue(true);
+    meService.getMe.mockReturnValue(of(profile));
+    meService.getMyStats.mockReturnValue(of(statsResponse));
+    regularisationService.getMyRegularisations.mockReturnValue(of(regularisations));
+  }
+
+  function createPage(): void {
+    fixture = TestBed.createComponent(EspacePrivePageComponent);
+    fixture.detectChanges();
+    fixture.detectChanges();
+  }
+
+  function pageText(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+});

--- a/frontend/src/app/features/player/espace-prive/espace-prive-page.component.ts
+++ b/frontend/src/app/features/player/espace-prive/espace-prive-page.component.ts
@@ -4,7 +4,7 @@ import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { finalize, forkJoin, Observable } from 'rxjs';
 import { AuthService } from '../../../core/auth/auth.service';
-import { MeProfile } from '../../../core/me/me.models';
+import { MeProfile, MeStats } from '../../../core/me/me.models';
 import { MeService } from '../../../core/me/me.service';
 import { PaiementService } from '../../../core/payments/paiement.service';
 import { Regularisation } from '../../../core/regularisations/regularisation.models';
@@ -30,8 +30,11 @@ export class EspacePrivePageComponent implements OnInit {
     totalTracable: 0,
     items: []
   });
+  protected readonly stats = signal<MeStats | null>(null);
   protected readonly isLoading = signal(true);
+  protected readonly isLoadingStats = signal(false);
   protected readonly errorMessage = signal('');
+  protected readonly statsErrorMessage = signal('');
   protected readonly paymentSuccessMessage = signal('');
   protected readonly paymentErrorMessage = signal('');
   protected readonly payingParticipationId = signal<number | null>(null);
@@ -96,6 +99,10 @@ export class EspacePrivePageComponent implements OnInit {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2
     }).format(amount) + ' €';
+  }
+
+  protected formatNumber(value: number): string {
+    return new Intl.NumberFormat('fr-BE').format(value);
   }
 
   protected isPaying(participationId: number): boolean {
@@ -180,14 +187,19 @@ export class EspacePrivePageComponent implements OnInit {
   private loadPageData(): void {
     if (this.authService.isAdmin() && !this.authService.hasPlayerProfile()) {
       this.isLoading.set(false);
+      this.stats.set(null);
+      this.isLoadingStats.set(false);
+      this.statsErrorMessage.set('');
       this.errorMessage.set('Cet espace est réservé aux joueurs.');
       return;
     }
 
     this.isLoading.set(true);
     this.errorMessage.set('');
+    this.statsErrorMessage.set('');
     this.paymentSuccessMessage.set('');
     this.paymentErrorMessage.set('');
+    this.loadStats();
 
     forkJoin({
       profile: this.meService.getMe(),
@@ -228,6 +240,24 @@ export class EspacePrivePageComponent implements OnInit {
         this.paymentErrorMessage.set('Le paiement a été enregistré, mais la mise à jour de l’espace a échoué.');
       }
     });
+    this.loadStats();
+  }
+
+  private loadStats(): void {
+    this.isLoadingStats.set(true);
+    this.statsErrorMessage.set('');
+
+    this.meService.getMyStats()
+      .pipe(finalize(() => this.isLoadingStats.set(false)))
+      .subscribe({
+        next: (stats) => {
+          this.stats.set(stats);
+        },
+        error: () => {
+          this.stats.set(null);
+          this.statsErrorMessage.set('Les statistiques ne sont pas disponibles actuellement.');
+        }
+      });
   }
 
   private getPaymentErrorMessage(error: HttpErrorResponse): string {


### PR DESCRIPTION
- ajout du bloc Mes statistiques dans l’espace privé joueur
- refonte du DTO /me/stats avec une structure imbriquée
- ajout du prochain match dans les statistiques personnelles
- chargement non bloquant des statistiques côté frontend
- adaptation des tests backend et frontend