### PR TITLE
Issue 198- fix(frontend): désactiver l’inlining des polices externes

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -32,6 +32,11 @@
           },
           "configurations": {
             "production": {
+              "optimization": {
+                "fonts": {
+                  "inline": false
+                }
+              },
               "budgets": [
                 {
                   "type": "initial",


### PR DESCRIPTION
Correction du build frontend en environnement sans accès Internet.

Angular tente par défaut d’optimiser et d’inliner les polices externes lors du build production, ce qui peut échouer si l’accès à Google Fonts est bloqué. L’inlining des polices a donc été désactivé dans la configuration production Angular.

Aucun impact sur la logique métier ni sur le backend.